### PR TITLE
Fix lock starvation on Mixer._gate from overlapping stream-sweep ticks

### DIFF
--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -20,6 +20,15 @@ public sealed class MixerService : IHostedService, IDisposable
     private Timer? _streamSweep;
     private Timer? _saveDebounce;
     private Timer? _meterPush;
+    // System.Threading.Timer fires a new callback every period regardless of
+    // whether the previous one finished. If one tick runs long (a slow
+    // PipeWire round-trip, e.g. spawning a filter-chain module), overlapping
+    // ticks pile up, and since Mixer's internal lock gives no fairness
+    // guarantee, a steady stream of these freshly-arriving threads can starve
+    // out an unrelated waiter (e.g. a client's Snapshot() call, or
+    // EnsureInputFeeds() itself) indefinitely. Skip a tick outright rather
+    // than let it stack up.
+    private int _sweepRunning;
 
     public MixerService(ILogger<MixerService> log, IConfiguration config, DeviceManager devices)
     {
@@ -134,6 +143,7 @@ public sealed class MixerService : IHostedService, IDisposable
             // before a user notices, without polling the graph hard.
             _streamSweep = new Timer(_ =>
             {
+                if (Interlocked.CompareExchange(ref _sweepRunning, 1, 0) != 0) return;
                 try
                 {
                     // Channel feeds follow the actively driven interface; the
@@ -151,6 +161,7 @@ public sealed class MixerService : IHostedService, IDisposable
                     SyncOutputSelectors();
                 }
                 catch (Exception ex) { _log.LogDebug("stream sweep: {msg}", ex.Message); }
+                finally { Volatile.Write(ref _sweepRunning, 0); }
             }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
 
             // Meters refresh far more often than state; 15 Hz looks smooth


### PR DESCRIPTION
Follow-up to #6. The Run() stdout/stderr deadlock is already fixed on
main (thanks!), but while verifying that fix against my Wave XLR MK.1
I found a second, separate issue in the same area: the stream-sweep
Timer in MixerService.cs fires every second regardless of whether the
previous tick finished. If one tick runs long (e.g. spawning a
filter-chain module for the low-cut/ClipGuard path), the next tick's
callback still fires and immediately contends for Mixer._gate. Since
lock/Monitor gives no fairness guarantee, a steady stream of these
freshly-arriving sweep threads can win the lock ahead of an
already-waiting thread indefinitely.

Reproduced directly with build instrumentation: a client's
Snapshot() call (needed to report `connected: true` and device state)
was starved for over a minute straight while the sweep kept
re-acquiring the lock roughly once a second. From the UI's side this
looked like "device not found" — it kept receiving `meters`
broadcasts (a separate, lock-free path) but never once received the
`state` message that populates `DeviceConnected`. The same starvation
intermittently affected `EnsureInputFeeds()` itself, so the hardware
mic capture sometimes never linked into the mixer graph, or got
unlinked and never relinked, even though `EnsureInputFeeds()`'s own
port-matching logic is correct.

Fix: guard the timer with an Interlocked-based reentrancy flag so
overlapping ticks are skipped outright instead of piling up.

Verified end-to-end against the Wave XLR MK.1: the daemon now
reliably reports the device connected to the UI and self-heals the
mic capture link on a fresh start, including with the low-cut filter
chain active — the exact path that was getting starved before.

23/23 existing tests pass.