### PR TITLE
fix: verify stream moves before caching assignments

### DIFF
--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -1258,7 +1258,13 @@ public sealed class Mixer : IDisposable, ILayoutInfo
 
                 try
                 {
-                    _pw.MoveStreamToSink(s.Serial, ch.SinkName);
+                    if (!_pw.IsStreamOnSink(s.Serial, ch.SinkName))
+                    {
+                        _pw.MoveStreamToSink(s.Serial, ch.SinkName);
+                        // Leave it unplaced so the next sweep retries. No wait
+                        // or sleep under the mixer lock.
+                        if (!_pw.IsStreamOnSink(s.Serial, ch.SinkName)) continue;
+                    }
                     // The mixer owns muting (sends, masters) from here on; a
                     // per-stream mute remembered by stream-restore has no
                     // control anywhere in OpenXLR and just reads as silence.
@@ -1354,8 +1360,8 @@ public sealed class Mixer : IDisposable, ILayoutInfo
                 if (placed.Identity == identity)
                 {
                     try { _pw.MoveStreamToSink(placed.Serial, ch.SinkName); }
-                    catch (InvalidOperationException) { continue; }
-                    _streams[id] = placed with { ChannelId = channelId };
+                    catch (InvalidOperationException) { /* the sweep retries */ }
+                    _streams.Remove(id);
                 }
 
             if (_apps.TryGetValue(identity, out StreamAssignment? app))
@@ -1382,7 +1388,7 @@ public sealed class Mixer : IDisposable, ILayoutInfo
             {
                 _pw.MoveStreamToSink(existing.Serial, ch.SinkName);
                 Matcher.SetOverride(existing.Identity, channelId);
-                _streams[streamId] = existing with { ChannelId = channelId };
+                _streams.Remove(streamId); // the next sweep confirms the destination
                 return;
             }
             _pw.MoveStreamToSink(streamId, ch.SinkName);

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -604,6 +604,30 @@ public sealed class PipeWireAdapter
         => Run("pactl", "move-sink-input", streamSerial.ToString(), sinkName);
 
     /// <summary>
+    /// Confirm the published destination, not just pactl's acknowledgement.
+    /// A new stream can still be unbound when a successful move returns.
+    /// </summary>
+    public bool IsStreamOnSink(int streamSerial, string sinkName)
+        => IsStreamOnSink(
+            TryRun("pactl", "list", "sink-inputs", "short") ?? "",
+            TryRun("pactl", "list", "sinks", "short") ?? "",
+            streamSerial, sinkName);
+
+    internal static bool IsStreamOnSink(string sinkInputs, string sinks, int streamSerial, string sinkName)
+    {
+        string? sinkId = sinkInputs.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Split('\t'))
+            .Where(columns => columns.Length >= 2 && columns[0] == streamSerial.ToString())
+            .Select(columns => columns[1])
+            .FirstOrDefault();
+        if (sinkId is null || sinkId == uint.MaxValue.ToString()) return false;
+
+        return sinks.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Split('\t'))
+            .Any(columns => columns.Length >= 2 && columns[0] == sinkId && columns[1] == sinkName);
+    }
+
+    /// <summary>
     /// Connect two nodes with direct port links (FL to FL, FR to FR). Unlike a
     /// loopback there is no process and no clock bridging: the linked island is
     /// driven by the hardware sink's clock, which is what actually makes audio

--- a/src/OpenXLR.Tests/PipeWireRoutingTests.cs
+++ b/src/OpenXLR.Tests/PipeWireRoutingTests.cs
@@ -4,6 +4,17 @@ namespace OpenXLR.Tests;
 
 public sealed class PipeWireRoutingTests
 {
+    [Theory]
+    [InlineData("42\t101\t-\tPipeWire\n", "101\tOpenXLR_ch_music\tPipeWire\n", true)]
+    [InlineData("42\t101\t-\tPipeWire\n", "100\tOpenXLR_ch_music\tPipeWire\n", false)]
+    [InlineData("42\t101\t-\tPipeWire\n", "101\tOpenXLR_ch_game\tPipeWire\n", false)]
+    [InlineData("42\t4294967295\t-\tPipeWire\n", "101\tOpenXLR_ch_music\tPipeWire\n", false)]
+    [InlineData("43\t101\t-\tPipeWire\n", "101\tOpenXLR_ch_music\tPipeWire\n", false)]
+    [InlineData("", "", false)]
+    [InlineData("malformed\n42\n", "101\n", false)]
+    public void StreamTargetRequiresMatchingPublishedSink(string inputs, string sinks, bool expected)
+        => Assert.Equal(expected, PipeWireAdapter.IsStreamOnSink(inputs, sinks, 42, "OpenXLR_ch_music"));
+
     private static readonly string[] Ports = ["FL", "FR", "AUX0", "AUX1"];
 
     [Fact]


### PR DESCRIPTION
## Scope

A successful `pactl move-sink-input` acknowledgement can precede the stream's published destination. Check the Pulse sink-input/sink tables and cache an assignment only after the expected destination is visible. Unbound streams remain eligible for the next existing sweep. Manual app/stream reassignment invalidates the cached placement so that the next sweep verifies it. No sleeps under the mixer lock and no changes to hardware routing or module properties.

## Review context

One independent fix split from #10 as requested. Based directly on upstream main at 721802e (0.1.18), not on the previous fork main. No dependency on the other split branches. Versions, changelogs, README credits/fork links, CI matrix and Python tooling are untouched.

## Verification

Release solution build with `-warnaserror`: zero warnings/errors. 57 tests passed (7 new cases covering matching/mismatched destinations, unbound or missing streams and malformed listings). Real device acceptance remains to be done; the new tests validate published-table interpretation, not uninterrupted hardware playback.

The larger editable-layout, watchdog, native-LV2 and integration work is not part of this PR and will be ported separately against docs/roadmap.md.
