### PR TITLE
fix: parse pw-dump multi-batch snapshots

### DIFF
--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -797,7 +797,7 @@ public sealed class PipeWireAdapter
         var found = new List<AudioNode>();
         byte[] json = DumpJson();
         JsonDocument doc;
-        try { doc = JsonDocument.Parse(json); }
+        try { doc = PipeWireSnapshot.Parse(json); }
         catch (JsonException) { return found; }
         using (doc)
         {
@@ -911,7 +911,7 @@ public sealed class PipeWireAdapter
         var found = new List<AudioStream>();
         byte[] json = DumpJson();
         JsonDocument doc;
-        try { doc = JsonDocument.Parse(json); }
+        try { doc = PipeWireSnapshot.Parse(json); }
         catch (JsonException) { return found; }
         using (doc)
         {
@@ -953,7 +953,7 @@ public sealed class PipeWireAdapter
         var found = new List<AudioStream>();
         byte[] json = DumpJson();
         JsonDocument doc;
-        try { doc = JsonDocument.Parse(json); }
+        try { doc = PipeWireSnapshot.Parse(json); }
         catch (JsonException) { return found; }
         using (doc)
         {
@@ -1007,7 +1007,7 @@ public sealed class PipeWireAdapter
     {
         byte[] json = DumpJson();
         JsonDocument doc;
-        try { doc = JsonDocument.Parse(json); }
+        try { doc = PipeWireSnapshot.Parse(json); }
         catch (JsonException) { yield break; }
         using (doc)
         {

--- a/src/OpenXLR.Core/Mixing/PipeWireSnapshot.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireSnapshot.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>
+/// pw-dump may append change arrays while the graph is changing. Fold those
+/// batches by registry id, replacing full objects and removing tombstones.
+/// </summary>
+internal static class PipeWireSnapshot
+{
+    internal static JsonDocument Parse(ReadOnlySpan<byte> json)
+    {
+        var reader = new Utf8JsonReader(json,
+            new JsonReaderOptions { AllowMultipleValues = true });
+        JsonDocument first = JsonDocument.ParseValue(ref reader);
+        bool returnedFirst = false;
+        try
+        {
+            if (first.RootElement.ValueKind != JsonValueKind.Array)
+                throw new JsonException("Expected a PipeWire object array.");
+            // Most snapshots contain one array. Keep that document without
+            // cloning and serializing the entire graph on every sweep.
+            if (!reader.Read())
+            {
+                returnedFirst = true;
+                return first;
+            }
+
+            var objects = new Dictionary<uint, JsonElement>();
+            Apply(first.RootElement, objects);
+            do
+            {
+                using JsonDocument batch = JsonDocument.ParseValue(ref reader);
+                Apply(batch.RootElement, objects);
+            } while (reader.Read());
+            return JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(objects.Values));
+        }
+        finally
+        {
+            if (!returnedFirst) first.Dispose();
+        }
+    }
+
+    private static void Apply(JsonElement batch, Dictionary<uint, JsonElement> objects)
+    {
+        if (batch.ValueKind != JsonValueKind.Array)
+            throw new JsonException("Expected a PipeWire object array.");
+        foreach (JsonElement item in batch.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object || !item.TryGetProperty("id", out JsonElement key)
+                || key.ValueKind != JsonValueKind.Number || !key.TryGetUInt32(out uint id))
+                throw new JsonException("PipeWire update has no valid registry id.");
+            if (item.TryGetProperty("info", out JsonElement info) && info.ValueKind == JsonValueKind.Null
+                || item.TryGetProperty("props", out JsonElement props) && props.ValueKind == JsonValueKind.Null)
+                objects.Remove(id);
+            else
+                objects[id] = item.Clone();
+        }
+    }
+}

--- a/src/OpenXLR.Tests/PipeWireSnapshotTests.cs
+++ b/src/OpenXLR.Tests/PipeWireSnapshotTests.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using System.Text.Json;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class PipeWireSnapshotTests
+{
+    [Fact]
+    public void SingleArrayIsPreserved()
+    {
+        const string input = """[{"id":1,"info":{"props":{"node.name":"music"}}}]""";
+        using JsonDocument result = PipeWireSnapshot.Parse(Encoding.UTF8.GetBytes(input));
+        Assert.Equal(input, result.RootElement.GetRawText());
+    }
+
+    [Fact]
+    public void BatchesReplaceByIdAndRemoveBothTombstoneShapes()
+    {
+        using JsonDocument result = PipeWireSnapshot.Parse("""
+            [{"id":1,"info":{"state":"idle"}},{"id":2},{"id":3}]
+            [{"id":1,"info":{"state":"running"}},{"id":2,"info":null}]
+            [{"id":3,"props":null},{"id":4,"info":{"state":"idle"}}]
+            """u8);
+        JsonElement[] objects = result.RootElement.EnumerateArray().ToArray();
+        Assert.Equal([1, 4], objects.Select(o => o.GetProperty("id").GetInt32()));
+        Assert.Equal("running", objects[0].GetProperty("info").GetProperty("state").GetString());
+    }
+
+    [Fact]
+    public void RemovedIdCanBeReusedAndUnknownRemovalIsHarmless()
+    {
+        using JsonDocument result = PipeWireSnapshot.Parse("""
+            [{"id":1}] [{"id":1,"info":null},{"id":9,"info":null}] [{"id":1,"type":"new"}]
+            """u8);
+        Assert.Equal("new", Assert.Single(result.RootElement.EnumerateArray()).GetProperty("type").GetString());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("{}")]
+    [InlineData("[] {}")]
+    [InlineData("[] [")]
+    [InlineData("[] [null]")]
+    [InlineData("[] [{}]")]
+    [InlineData("[] [{\"id\":-1}]")]
+    [InlineData("[] [{\"id\":\"2\"}]")]
+    [InlineData("[] [{\"id\":4294967296}]")]
+    public void InvalidBatchesAreRejected(string input)
+        => Assert.ThrowsAny<JsonException>(() => PipeWireSnapshot.Parse(Encoding.UTF8.GetBytes(input)));
+
+    [Fact]
+    public void EmptyBatchesAreValid()
+    {
+        using JsonDocument result = PipeWireSnapshot.Parse("[] []"u8);
+        Assert.Empty(result.RootElement.EnumerateArray());
+    }
+}


### PR DESCRIPTION
## Scope

Accept consecutive `pw-dump` JSON arrays, replacing objects by registry id and removing `info:null` / `props:null` tombstones. All four backend dump consumers use the same parser. Preserve upstream's byte-oriented input and the single-array fast path without cloning/serializing the whole graph. Diagnostics remain raw upstream capture: no Python tools or new diagnostic UI are included. The object-replacement/tombstone behavior follows [pw-dump's implementation](https://github.com/PipeWire/pipewire/blob/master/src/tools/pw-dump.c).

## Review context

One independent fix split from #10 as requested. Based directly on upstream main at 721802e (0.1.18), not on the previous fork main. No dependency on the other split branches. Versions, changelogs, README credits/fork links, CI matrix and Python tooling are untouched.

## Verification

Release solution build with `-warnaserror`: zero warnings/errors. 63 tests passed (13 new cases including replacement, removal, id reuse, empty batches and malformed input).

The larger editable-layout, watchdog, native-LV2 and integration work is not part of this PR and will be ported separately against docs/roadmap.md.
