### PR TITLE
fix: harden DaemonClient lifecycle and queries

### DIFF
--- a/src/OpenXLR.Tests/DaemonClientTests.cs
+++ b/src/OpenXLR.Tests/DaemonClientTests.cs
@@ -1,0 +1,116 @@
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+public sealed class DaemonClientTests
+{
+    [Fact]
+    public async Task ConcurrentQueriesShareReplyEvenWhenOneCallerTimesOut()
+    {
+        int connections = 0, requests = 0;
+        var release = Completion();
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            Interlocked.Increment(ref connections);
+            while (!stop.IsCancellationRequested)
+            {
+                var command = await SocketTestServer.Receive(socket, stop);
+                if (command["cmd"]!.GetValue<string>() == "listPlugins")
+                {
+                    Interlocked.Increment(ref requests);
+                    await release.Task.WaitAsync(stop);
+                    await SocketTestServer.Send(socket, new { type = "plugins", plugins = new[] { new { name = "EQ" } } }, stop);
+                }
+                else
+                    await SocketTestServer.Send(socket, new { type = "diagnostics" }, stop);
+            }
+        });
+        await using var client = new DaemonClient(server.Url);
+        var connected = Completion();
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.Start();
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task<System.Text.Json.Nodes.JsonNode?> first = client.RequestPluginsAsync(TimeSpan.FromSeconds(5));
+        Assert.Null(await client.RequestPluginsAsync(TimeSpan.Zero));
+        var second = client.RequestPluginsAsync(TimeSpan.FromSeconds(5));
+        release.SetResult();
+        Assert.Equal("EQ", (await first)![0]!["name"]!.GetValue<string>());
+        Assert.Equal("EQ", (await second)![0]!["name"]!.GetValue<string>());
+        // This reply is a server-side barrier after any accidental duplicate requests.
+        Assert.NotNull(await client.RequestDiagnosticsAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(1, requests);
+        Assert.Equal(1, connections);
+    }
+
+    [Fact]
+    public async Task DisconnectReleasesQueryAndReconnectsWithoutReplayingIt()
+    {
+        int connections = 0, requests = 0;
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            if (Interlocked.Increment(ref connections) == 1)
+            {
+                await SocketTestServer.Receive(socket, stop);
+                Interlocked.Increment(ref requests);
+                socket.Abort();
+            }
+            else
+            {
+                await SocketTestServer.Send(socket, new { type = "state" }, stop);
+                await Task.Delay(Timeout.Infinite, stop);
+            }
+        });
+        await using var client = new DaemonClient(server.Url);
+        var connected = Completion();
+        var restored = Completion();
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.StateReceived += _ => restored.TrySetResult();
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Null(await client.RequestPluginsAsync(TimeSpan.FromMinutes(1)).WaitAsync(TimeSpan.FromSeconds(5)));
+        await restored.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(2, connections);
+        Assert.Equal(1, requests);
+    }
+
+    [Fact]
+    public async Task DisconnectedCommandsReportFailureAndDisposalIsIdempotent()
+    {
+        var client = new DaemonClient();
+        string? error = null;
+        client.ErrorReceived += message => error = message;
+        await client.SetLevelAsync("music", "monitor", 0.5);
+        Assert.Contains("disconnected", error);
+        Assert.Null(await client.RequestPluginsAsync(TimeSpan.FromSeconds(30)));
+        await Task.WhenAll(client.DisposeAsync().AsTask(), client.DisposeAsync().AsTask());
+        Assert.Throws<ObjectDisposedException>(client.Start);
+        await client.SetLevelAsync("music", "monitor", 0.5);
+        Assert.Null(await client.RequestDiagnosticsAsync(TimeSpan.FromSeconds(30)));
+    }
+
+    [Fact]
+    public async Task DisposalUnblocksPendingReceiveAndQuery()
+    {
+        var received = Completion();
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            await SocketTestServer.Receive(socket, stop);
+            received.TrySetResult();
+            await Task.Delay(Timeout.Infinite, stop);
+        });
+        await using var client = new DaemonClient(server.Url);
+        var connected = Completion();
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var query = client.RequestPluginsAsync(TimeSpan.FromMinutes(1));
+        await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await client.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Null(await query.WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    private static TaskCompletionSource Completion()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/OpenXLR.Tests/SocketTestServer.cs
+++ b/src/OpenXLR.Tests/SocketTestServer.cs
@@ -1,0 +1,57 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace OpenXLR.Tests;
+
+/// <summary>Real loopback WebSockets; no audio service, devices or user settings are touched.</summary>
+internal sealed class SocketTestServer(WebApplication app) : IAsyncDisposable
+{
+    public string Url => app.Urls.Single().Replace("http:", "ws:", StringComparison.Ordinal) + "/ws";
+
+    public static async Task<SocketTestServer> Start(Func<WebSocket, CancellationToken, Task> handler)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.UseWebSockets();
+        app.Map("/ws", async (HttpContext context) =>
+        {
+            using var socket = await context.WebSockets.AcceptWebSocketAsync();
+            try { await handler(socket, app.Lifetime.ApplicationStopping); }
+            catch (Exception ex) when (ex is OperationCanceledException or WebSocketException) { }
+        });
+        await app.StartAsync();
+        return new(app);
+    }
+
+    public static Task Send(WebSocket socket, object payload, CancellationToken stop)
+        => socket.SendAsync(JsonSerializer.SerializeToUtf8Bytes(payload), WebSocketMessageType.Text, true, stop);
+
+    public static async Task<JsonNode> Receive(WebSocket socket, CancellationToken stop)
+    {
+        var buffer = new byte[4096];
+        using var bytes = new MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await socket.ReceiveAsync(buffer, stop);
+            if (result.MessageType == WebSocketMessageType.Close) throw new OperationCanceledException();
+            bytes.Write(buffer, 0, result.Count);
+        } while (!result.EndOfMessage);
+        return JsonNode.Parse(Encoding.UTF8.GetString(bytes.ToArray()))!;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await app.StopAsync(timeout.Token);
+        await app.DisposeAsync();
+    }
+}

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -22,6 +22,18 @@ public sealed class DaemonClient : IAsyncDisposable
     private readonly CancellationTokenSource _cts = new();
     private ClientWebSocket? _socket;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly object _lifecycle = new();
+    private Task? _runTask;
+    private Task? _disposeTask;
+    private bool _disposed;
+    private readonly Dictionary<string, PendingQuery> _queries = new();
+    private const int MaxMessageBytes = 8 * 1024 * 1024;
+
+    private sealed class PendingQuery
+    {
+        public readonly TaskCompletionSource<JsonNode?> Reply = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int Callers;
+    }
 
     public DaemonClient(string url = "ws://127.0.0.1:37890/ws") => _uri = new Uri(url);
 
@@ -31,30 +43,48 @@ public sealed class DaemonClient : IAsyncDisposable
     /// <summary>The raw JSON of the newest state push, for diagnostics.</summary>
     public string? LastStateJson { get; private set; }
 
-    private TaskCompletionSource<JsonNode>? _diagnosticsWaiter;
-
     /// <summary>Request the daemon's vendor-block dump; null on timeout.</summary>
-    public async Task<JsonNode?> RequestDiagnosticsAsync(TimeSpan timeout)
-    {
-        var tcs = new TaskCompletionSource<JsonNode>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _diagnosticsWaiter = tcs;
-        await SendAsync(new Dictionary<string, object> { ["cmd"] = "getDiagnostics" });
-        Task done = await Task.WhenAny(tcs.Task, Task.Delay(timeout));
-        _diagnosticsWaiter = null;
-        return done == tcs.Task ? tcs.Task.Result : null;
-    }
-
-    private TaskCompletionSource<JsonNode>? _pluginsWaiter;
+    public Task<JsonNode?> RequestDiagnosticsAsync(TimeSpan timeout)
+        => QueryAsync("diagnostics", "getDiagnostics", timeout);
 
     /// <summary>Request the daemon's plugin catalog (the "plugins" array); null on timeout.</summary>
-    public async Task<JsonNode?> RequestPluginsAsync(TimeSpan timeout)
+    public Task<JsonNode?> RequestPluginsAsync(TimeSpan timeout)
+        => QueryAsync("plugins", "listPlugins", timeout);
+
+    private async Task<JsonNode?> QueryAsync(string type, string command, TimeSpan timeout)
     {
-        var tcs = new TaskCompletionSource<JsonNode>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _pluginsWaiter = tcs;
-        await SendAsync(new Dictionary<string, object> { ["cmd"] = "listPlugins" });
-        Task done = await Task.WhenAny(tcs.Task, Task.Delay(timeout));
-        _pluginsWaiter = null;
-        return done == tcs.Task ? tcs.Task.Result : null;
+        PendingQuery query;
+        bool send;
+        lock (_lifecycle)
+        {
+            if (_disposed) return null;
+            send = !_queries.TryGetValue(type, out query!);
+            if (send) _queries[type] = query = new();
+            query.Callers++;
+        }
+        try
+        {
+            if (send && !await SendAsync(new { cmd = command }, reportErrors: false))
+                query.Reply.TrySetResult(null);
+            return await query.Reply.Task.WaitAsync(timeout);
+        }
+        catch (TimeoutException) { return null; }
+        finally
+        {
+            lock (_lifecycle)
+            {
+                // One impatient caller must not remove the reply slot still
+                // used by other windows waiting for the same catalog.
+                if (--query.Callers == 0 && _queries.TryGetValue(type, out var current)
+                    && ReferenceEquals(current, query)) _queries.Remove(type);
+            }
+        }
+    }
+
+    private void CompleteQuery(string type, JsonNode? reply)
+    {
+        lock (_lifecycle)
+            if (_queries.TryGetValue(type, out var query)) query.Reply.TrySetResult(reply);
     }
 
     /// <summary>Raised when an error message arrives from the daemon.</summary>
@@ -66,7 +96,14 @@ public sealed class DaemonClient : IAsyncDisposable
     /// <summary>Raised when the connection comes up or goes down.</summary>
     public event Action<bool>? ConnectionChanged;
 
-    public void Start() => _ = RunAsync();
+    public void Start()
+    {
+        lock (_lifecycle)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _runTask ??= Task.Run(RunAsync);
+        }
+    }
 
     private async Task RunAsync()
     {
@@ -74,12 +111,17 @@ public sealed class DaemonClient : IAsyncDisposable
         {
             try
             {
-                _socket = new ClientWebSocket();
-                await _socket.ConnectAsync(_uri, _cts.Token);
+                var socket = new ClientWebSocket();
+                _socket = socket;
+                socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(20);
+                socket.Options.KeepAliveTimeout = TimeSpan.FromSeconds(10);
+                using var connect = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+                connect.CancelAfter(TimeSpan.FromSeconds(5));
+                await socket.ConnectAsync(_uri, connect.Token);
                 ConnectionChanged?.Invoke(true);
-                await ReceiveLoop(_socket);
+                await ReceiveLoop(socket);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
             {
                 return;
             }
@@ -88,9 +130,17 @@ public sealed class DaemonClient : IAsyncDisposable
                 // daemon not up yet, or the link dropped, so fall through and retry
             }
 
-            ConnectionChanged?.Invoke(false);
-            _socket?.Dispose();
-            _socket = null;
+            finally
+            {
+                _socket?.Dispose();
+                _socket = null;
+                lock (_lifecycle)
+                {
+                    foreach (var query in _queries.Values) query.Reply.TrySetResult(null);
+                    _queries.Clear();
+                }
+                ConnectionChanged?.Invoke(false);
+            }
             try { await Task.Delay(1000, _cts.Token); }
             catch (OperationCanceledException) { return; }
         }
@@ -107,6 +157,8 @@ public sealed class DaemonClient : IAsyncDisposable
             {
                 res = await socket.ReceiveAsync(buf, _cts.Token);
                 if (res.MessageType == WebSocketMessageType.Close) return;
+                if (res.MessageType != WebSocketMessageType.Text || ms.Length + res.Count > MaxMessageBytes)
+                    throw new WebSocketException("Invalid or oversized daemon message.");
                 ms.Write(buf, 0, res.Count);
             } while (!res.EndOfMessage);
 
@@ -114,13 +166,13 @@ public sealed class DaemonClient : IAsyncDisposable
             JsonNode? node;
             try { node = JsonNode.Parse(text); }
             catch (JsonException) { continue; }
-            if (node is null) continue;
+            if (node is not JsonObject) continue;
 
             string? type = node["type"]?.GetValue<string>();
             if (type == "error") ErrorReceived?.Invoke(node["message"]?.GetValue<string>() ?? "unknown error");
             else if (type == "state") { LastStateJson = text; StateReceived?.Invoke(node); }
-            else if (type == "diagnostics") _diagnosticsWaiter?.TrySetResult(node);
-            else if (type == "plugins" && node["plugins"] is JsonNode plugins) _pluginsWaiter?.TrySetResult(plugins);
+            else if (type == "diagnostics") CompleteQuery(type, node);
+            else if (type == "plugins") CompleteQuery(type, node["plugins"]);
             else if (type == "meters" && node["levels"] is JsonNode levels) MetersReceived?.Invoke(levels);
         }
     }
@@ -209,22 +261,54 @@ public sealed class DaemonClient : IAsyncDisposable
         => SendAsync(new Dictionary<string, object>
         { ["cmd"] = "assignStream", ["streamId"] = streamId, ["channel"] = channel });
 
-    private async Task SendAsync(object payload)
+    private async Task<bool> SendAsync(object payload, bool reportErrors = true)
     {
-        ClientWebSocket? s = _socket;
-        if (s is null || s.State != WebSocketState.Open) return;
+        ClientWebSocket? s;
+        CancellationToken stop;
+        lock (_lifecycle)
+        {
+            s = _disposed ? null : _socket;
+            stop = _disposed ? new CancellationToken(true) : _cts.Token;
+        }
+        if (s is null || s.State != WebSocketState.Open)
+        {
+            if (reportErrors) ErrorReceived?.Invoke("Daemon disconnected; no change was sent.");
+            return false;
+        }
         byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(payload, Json);
-        await _sendLock.WaitAsync();
-        try { await s.SendAsync(bytes, WebSocketMessageType.Text, true, _cts.Token); }
-        catch (Exception) { /* dropped; the reconnect loop handles it */ }
-        finally { _sendLock.Release(); }
+        bool acquired = false;
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(stop);
+            timeout.CancelAfter(TimeSpan.FromSeconds(5));
+            await _sendLock.WaitAsync(timeout.Token);
+            acquired = true;
+            await s.SendAsync(bytes, WebSocketMessageType.Text, true, timeout.Token);
+            return true;
+        }
+        catch (Exception ex) when (ex is WebSocketException or OperationCanceledException or ObjectDisposedException)
+        {
+            if (reportErrors) ErrorReceived?.Invoke("Connection lost; the change could not be confirmed.");
+            return false;
+        }
+        finally { if (acquired) _sendLock.Release(); }
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
+    {
+        lock (_lifecycle)
+        {
+            _disposed = true;
+            return new(_disposeTask ??= Task.Run(DisposeCoreAsync));
+        }
+    }
+
+    private async Task DisposeCoreAsync()
     {
         await _cts.CancelAsync();
-        _socket?.Dispose();
-        _sendLock.Dispose();
+        if (_runTask is not null) await _runTask;
+        // Sends may still be releasing the semaphore. It has no native handle;
+        // let it be collected instead of disposing under those continuations.
         _cts.Dispose();
     }
 }


### PR DESCRIPTION
## Scope

Make Start and disposal idempotent, serialize sends with cancellation and a five-second bound, bound connection establishment, and enable WebSocket keepalive timeouts. Disconnect completes pending queries without replaying mutations. Concurrent plugin/diagnostic requests share a reply slot; one caller timing out no longer removes a slot used by another. Bound incoming messages to 8 MiB and refuse binary frames. Disconnected edits report failure rather than disappearing silently. No command acknowledgements, editable-layout methods, HTTP endpoints or native-plugin commands are introduced.

## Review context

One independent fix split from #10 as requested. Based directly on upstream main at 721802e (0.1.18), not on the previous fork main. No dependency on the other split branches. Versions, changelogs, README credits/fork links, CI matrix and Python tooling are untouched.

## Verification

Release solution build with `-warnaserror`: zero warnings/errors. 54 tests passed, including 4 new real loopback-WebSocket/lifecycle tests. Tests cover duplicate Start, mixed-timeout catalog callers, disconnect/reconnect, pending-query cancellation, disconnected commands and repeated disposal. No user daemon, audio graph or hardware is accessed.

The larger editable-layout, watchdog, native-LV2 and integration work is not part of this PR and will be ported separately against docs/roadmap.md.
