### PR TITLE
fix: coalesce hub state broadcasts outside device callbacks

### DIFF
--- a/src/OpenXLR.Daemon/StateBroadcastQueue.cs
+++ b/src/OpenXLR.Daemon/StateBroadcastQueue.cs
@@ -1,0 +1,34 @@
+using System.Threading.Channels;
+
+namespace OpenXLR.Daemon;
+
+/// <summary>
+/// Carries a dirty flag, not a snapshot: bursts retain at most one pending
+/// update and event producers never acquire the device or mixer locks.
+/// </summary>
+internal sealed class StateBroadcastQueue(Action broadcast, ILogger log)
+{
+    private readonly Channel<bool> _changes = Channel.CreateBounded<bool>(
+        new BoundedChannelOptions(1)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            AllowSynchronousContinuations = false,
+        });
+
+    internal void Signal() => _changes.Writer.TryWrite(true);
+
+    internal async Task RunAsync(CancellationToken stop)
+    {
+        try
+        {
+            await foreach (bool ignored in _changes.Reader.ReadAllAsync(stop))
+            {
+                if (stop.IsCancellationRequested) break;
+                try { broadcast(); }
+                catch (Exception ex) { log.LogWarning(ex, "State broadcast failed"); }
+            }
+        }
+        catch (OperationCanceledException) when (stop.IsCancellationRequested) { }
+    }
+}

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -29,6 +29,7 @@ public sealed class WebSocketHub
     // enough for systemd to SIGKILL the daemon before the other services
     // ever get to tear down.
     private readonly CancellationToken _stopping;
+    private readonly StateBroadcastQueue _stateBroadcasts;
 
     public WebSocketHub(DeviceManager devices, MixerService mixer, ILogger<WebSocketHub> log,
         IHostApplicationLifetime lifetime)
@@ -39,8 +40,13 @@ public sealed class WebSocketHub
         _stopping = lifetime.ApplicationStopping;
         // Either half changing pushes the combined state, so clients always see
         // device and mixer consistently in one message.
-        _devices.StateChanged += ignored => Broadcast(Snapshot());
-        _mixer.Changed += () => Broadcast(Snapshot());
+        _stateBroadcasts = new(() =>
+        {
+            if (!_clients.IsEmpty) Broadcast(Snapshot());
+        }, _log);
+        _devices.StateChanged += ignored => _stateBroadcasts.Signal();
+        _mixer.Changed += _stateBroadcasts.Signal;
+        _ = _stateBroadcasts.RunAsync(_stopping);
         _mixer.MetersUpdated += () =>
         {
             if (_clients.IsEmpty) return;                    // nobody watching

--- a/src/OpenXLR.Tests/StateBroadcastQueueTests.cs
+++ b/src/OpenXLR.Tests/StateBroadcastQueueTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+public sealed class StateBroadcastQueueTests
+{
+    [Fact]
+    public async Task SlowSnapshotNeverBlocksProducersAndBurstsBecomeOnePendingSnapshot()
+    {
+        using var stop = new CancellationTokenSource();
+        using var release = new ManualResetEventSlim();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var second = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int calls = 0;
+        var queue = new StateBroadcastQueue(() =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                entered.SetResult();
+                Assert.True(release.Wait(TimeSpan.FromSeconds(5)));
+            }
+            else second.TrySetResult();
+        }, NullLogger.Instance);
+        Task pump = queue.RunAsync(stop.Token);
+        try
+        {
+            queue.Signal();
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Run(() =>
+            {
+                for (int i = 0; i < 1000; i++) queue.Signal();
+            }).WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(1, Volatile.Read(ref calls));
+            release.Set();
+            await second.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            release.Set();
+            stop.Cancel();
+            await pump.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task FailedSnapshotDoesNotStopLaterUpdates()
+    {
+        using var stop = new CancellationTokenSource();
+        var first = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var next = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int calls = 0;
+        var queue = new StateBroadcastQueue(() =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                first.SetResult();
+                throw new InvalidOperationException("simulated snapshot failure");
+            }
+            next.SetResult();
+        }, NullLogger.Instance);
+        Task pump = queue.RunAsync(stop.Token);
+        try
+        {
+            queue.Signal();
+            await first.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            queue.Signal();
+            await next.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            stop.Cancel();
+            await pump.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
+    public async Task IdlePumpStopsWithoutAnotherSignal()
+    {
+        using var stop = new CancellationTokenSource();
+        var queue = new StateBroadcastQueue(() => throw new Exception("unexpected"), NullLogger.Instance);
+        Task pump = queue.RunAsync(stop.Token);
+        stop.Cancel();
+        await pump.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+}


### PR DESCRIPTION
## Scope

Device callbacks can run while holding device locks. They now signal a bounded one-slot queue rather than synchronously taking a mixer snapshot. A single consumer captures current state and broadcasts outside the producer callback. Bursts retain at most one pending dirty flag, no-clients updates skip snapshots, snapshot failures are logged without killing later updates, and shutdown cancels the idle consumer. Upstream's command validation, rate/connection limits and socket handling are retained.

## Review context

One independent fix split from #10 as requested. Based directly on upstream main at 721802e (0.1.18), not on the previous fork main. No dependency on the other split branches. Versions, changelogs, README credits/fork links, CI matrix and Python tooling are untouched.

## Verification

Release solution build with `-warnaserror`: zero warnings/errors. 53 tests passed (3 new cases for nonblocking producers and coalescing under a held snapshot, recovery after snapshot failure, and shutdown while idle).

The larger editable-layout, watchdog, native-LV2 and integration work is not part of this PR and will be ported separately against docs/roadmap.md.
