### PR TITLE
fix: add a nonblocking daemon restart button

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -317,6 +317,12 @@ other devices this would be new information: collect diagnostics
 
 ### 5.7 The daemon froze, or a control hung the window
 
+The header's **Restart daemon** button restarts the systemd user service.
+Audio is interrupted during the restart. The window stays responsive, and
+the button is disabled until the service command finishes. If it fails,
+check `journalctl --user -u openxlr-daemon`. A daemon started by hand must
+be restarted by hand.
+
 Since 0.1.11 a USB transfer that never returns fails after a few
 seconds instead of stalling the daemon; the device is dropped and
 reconnected after 10 seconds, and the fault is recorded. Collect

--- a/src/OpenXLR.Tests/DaemonRestartTests.cs
+++ b/src/OpenXLR.Tests/DaemonRestartTests.cs
@@ -1,0 +1,46 @@
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+public sealed class DaemonRestartTests
+{
+    [Fact]
+    public async Task RestartIsAwaitedWithoutBlockingAndRepeatedClicksAreIgnored()
+    {
+        var finish = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        int calls = 0;
+        var model = new DaemonRestartViewModel(() => { calls++; return finish.Task; });
+        var changes = new List<string?>();
+        model.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
+
+        Task restart = model.RestartAsync();
+        Assert.False(restart.IsCompleted);
+        Assert.False(model.CanRestart);
+        Assert.Contains("Restarting", model.Status);
+        await model.RestartAsync();
+        Assert.Equal(1, calls);
+        finish.SetResult(true);
+        await restart;
+        Assert.True(model.CanRestart);
+        Assert.Contains("Service restarted", model.Status);
+        Assert.Equal(2, changes.Count(name => name == nameof(model.CanRestart)));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailureReenablesButtonAndAllowsRetry(bool throws)
+    {
+        int calls = 0;
+        var model = new DaemonRestartViewModel(() =>
+        {
+            calls++;
+            return throws ? Task.FromException<bool>(new IOException("unavailable")) : Task.FromResult(false);
+        });
+        await model.RestartAsync();
+        Assert.True(model.CanRestart);
+        Assert.Contains("Restart failed", model.Status);
+        await model.RestartAsync();
+        Assert.Equal(2, calls);
+    }
+}

--- a/src/OpenXLR.UI/DaemonRestartViewModel.cs
+++ b/src/OpenXLR.UI/DaemonRestartViewModel.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+
+namespace OpenXLR.UI;
+
+/// <summary>Shared restart state for the header and upgrade banner buttons.</summary>
+public sealed class DaemonRestartViewModel : ViewModelBase
+{
+    private readonly Func<Task<bool>> _restart;
+    private bool _busy;
+    private string? _status;
+
+    public DaemonRestartViewModel()
+        : this(() => Task.Run(StartupIntegration.RestartDaemon)) { }
+
+    internal DaemonRestartViewModel(Func<Task<bool>> restart) => _restart = restart;
+
+    public bool CanRestart => !_busy;
+    public string? Status { get => _status; private set => Set(ref _status, value); }
+
+    /// <summary>
+    /// Run systemctl off the UI thread. Only one restart runs at a time, and a
+    /// failed request leaves the buttons usable for another attempt.
+    /// </summary>
+    public async Task RestartAsync()
+    {
+        if (_busy) return;
+        _busy = true;
+        Raise(nameof(CanRestart));
+        Status = "Restarting daemon...";
+        try
+        {
+            Status = await _restart()
+                ? "Service restarted. Waiting for the daemon connection."
+                : "Restart failed. Check the user service logs; a manually started daemon must be restarted by hand.";
+        }
+        catch (Exception)
+        {
+            Status = "Restart failed. Check the user service logs.";
+        }
+        finally
+        {
+            _busy = false;
+            Raise(nameof(CanRestart));
+        }
+    }
+}

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -195,6 +195,9 @@
           </DropDownButton>
           <Button Content="Flow" Padding="10,3" FontSize="12" Background="Transparent"
                   Click="OnFlow" ToolTip.Tip="Show the live audio routing graph"/>
+          <Button Content="Restart daemon" Padding="10,3" FontSize="12" Background="Transparent"
+                  IsEnabled="{Binding DaemonRestart.CanRestart}" Click="OnRestartDaemon"
+                  ToolTip.Tip="Restart the OpenXLR user service. Audio will be interrupted briefly."/>
           <TextBlock Name="HeaderVersion" Text="v0.0.0" Classes="h" VerticalAlignment="Center"/>
           <Button Content="About" Padding="10,3" FontSize="12" Background="Transparent"
                   Click="OnAbout"/>
@@ -202,10 +205,14 @@
       </Grid>
     </Border>
 
+    <TextBlock Text="{Binding DaemonRestart.Status}" Classes="h" TextWrapping="Wrap"
+               Margin="0,0,0,8"/>
+
     <!-- a daemon left running across an upgrade offers the old version's controls -->
     <Border Classes="card" Margin="0,0,0,8" IsVisible="{Binding DaemonVersionMismatch}">
       <DockPanel>
         <Button DockPanel.Dock="Right" Content="Restart daemon" Padding="10,3" FontSize="12"
+                IsEnabled="{Binding DaemonRestart.CanRestart}"
                 VerticalAlignment="Center" Click="OnRestartDaemon"
                 ToolTip.Tip="systemctl --user restart openxlr-daemon"/>
         <TextBlock Text="{Binding DaemonVersionNote}" Classes="h" TextWrapping="Wrap"

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -212,13 +212,8 @@ public partial class MainWindow : Window
         _flow.Show(this);
     }
 
-    private void OnRestartDaemon(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
-    {
-        // Managed by systemd on packaged installs; a hand-started daemon has
-        // to be restarted by hand, and the banner stays until it is.
-        if (sender is Avalonia.Controls.Button b)
-            b.Content = StartupIntegration.RestartDaemon() ? "Restarting…" : "Not managed by systemd: restart it by hand";
-    }
+    private async void OnRestartDaemon(object? sender, RoutedEventArgs e)
+        => await _vm.DaemonRestart.RestartAsync();
 
     // ---- collapsed tiles, remembered in ui.json ----
     private static readonly string[] SectionTiles =

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -32,6 +32,8 @@ public abstract class ViewModelBase : INotifyPropertyChanged
 /// </summary>
 public sealed class MainViewModel : ViewModelBase
 {
+    public DaemonRestartViewModel DaemonRestart { get; } = new();
+
     private readonly DaemonClient _client;
     private bool _applying;
 


### PR DESCRIPTION
## Scope

Expose Restart daemon in the header even without a version mismatch. The existing upgrade-banner button shares its restart state. Run the existing bounded `systemctl --user restart openxlr-daemon.service` helper off the UI thread; disable both buttons while pending and show completion/failure feedback. Document the audio interruption and manually launched daemon limitation. No watchdog, service policy, version, theme, knob window or automatic update check is included.

## Review context

One independent fix split from #10 as requested. Based directly on upstream main at 721802e (0.1.18), not on the previous fork main. No dependency on the other split branches. Versions, changelogs, README credits/fork links, CI matrix and Python tooling are untouched.

## Verification

Release solution build with `-warnaserror`: zero warnings/errors. 53 tests passed (3 new controlled ViewModel cases for pending restart, duplicate clicks, failure and retry). Avalonia XAML compiles. These tests do not restart the user's service or constitute visual/hardware acceptance.

The larger editable-layout, watchdog, native-LV2 and integration work is not part of this PR and will be ported separately against docs/roadmap.md.
