### PR TITLE
docs: fix the API command discriminator field

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,7 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `plugins` | in answer to `listPlugins` | the installed LV2 plugins with their controls; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `error` | when a command is rejected | `message` |
 
-Commands are single JSON objects with a `type` field:
+Commands are single JSON objects with a `cmd` field:
 
 | Command | Fields | Purpose |
 |---|---|---|


### PR DESCRIPTION
## Scope

Commands are dispatched through `Command.Cmd` (`[JsonPropertyName("cmd")]`), whereas daemon messages use `type`. Correct the sentence introducing the command table; no runtime behavior changes.

## Review context

One independent fix split from #10 as requested. Based directly on upstream main at 721802e (0.1.18), not on the previous fork main. No dependency on the other split branches. Versions, changelogs, README credits/fork links, CI matrix and Python tooling are untouched.

## Verification

Checked against `Protocol.cs`; `git diff --check` passes.

The larger editable-layout, watchdog, native-LV2 and integration work is not part of this PR and will be ported separately against docs/roadmap.md.
