### PR TITLE
Watchdog: progress-gated recovery and graceful restart

### DIFF
--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -117,6 +117,22 @@ systemctl --user enable --now openxlr-daemon.service
 journalctl --user -u openxlr-daemon.service -f   # watch it come up
 ```
 
+The supplied unit uses systemd notifications with a 60-second watchdog.
+Heartbeats require recent device and mixer progress, including completed steps
+inside graph operations. Failed polls still count as progress; a missing audio
+server leaves device control running rather than causing a restart loop.
+Startup timeout extensions are sent only while the workers make progress.
+
+On a watchdog timeout systemd sends SIGTERM, allowing normal graph teardown.
+Failed starts are limited to three attempts in five minutes. After fixing a
+persistent failure, use `systemctl --user reset-failed openxlr-daemon` followed
+by `systemctl --user start openxlr-daemon`. Manual launches without
+`NOTIFY_SOCKET` do not enable the watchdog.
+
+OpenXLR does not install a file-descriptor-limit override for pipewire-pulse.
+If its journal reports exhausted descriptors, inspect that service's limits
+and configure a user override explicitly for your environment.
+
 
 ## 7. OpenDeck plugin (optional)
 

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -50,6 +50,10 @@ in
       description = "OpenXLR audio daemon";
       after = [ "pipewire-pulse.service" "wireplumber.service" ];
       wantedBy = [ "default.target" ];
+      unitConfig = {
+        StartLimitIntervalSec = 300;
+        StartLimitBurst = 3;
+      };
       environment = {
         OPENXLR_BUILD_MIXER = "1";
         # Plugins load inside pw-cli, a child of the daemon, so this one
@@ -61,6 +65,11 @@ in
         LADSPA_PATH = "${pkgs.ladspaPlugins}/lib/ladspa";
       };
       serviceConfig = {
+        Type = "notify";
+        NotifyAccess = "main";
+        WatchdogSec = 60;
+        WatchdogSignal = "SIGTERM";
+        TimeoutStartSec = 120;
         ExecStart = "${cfg.package}/bin/openxlr-daemon";
         TimeoutStopSec = 45;
         Restart = "on-failure";

--- a/packaging/openxlr-daemon.service
+++ b/packaging/openxlr-daemon.service
@@ -1,8 +1,15 @@
 [Unit]
 Description=OpenXLR audio daemon
 After=pipewire-pulse.service wireplumber.service
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
+Type=notify
+NotifyAccess=main
+WatchdogSec=60
+WatchdogSignal=SIGTERM
+TimeoutStartSec=120
 # %h is your home directory; adjust the path to where you cloned the repo.
 ExecStart=%h/openxlr/src/OpenXLR.Daemon/bin/Release/net10.0/OpenXLR.Daemon
 Environment=OPENXLR_BUILD_MIXER=1

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -19,11 +19,15 @@ public sealed class PipeWireAdapter
     private const string ClipGuardPluginFile = "hard_limiter_1413.so";
 
     private readonly Func<DspFeatureAvailability>? _clipGuardAvailabilityOverride;
+    private readonly Action? _progress;
     private readonly List<uint> _modules = [];
     private readonly List<Process> _loopbacks = [];
     private readonly List<Process> _filters = [];
 
     public PipeWireAdapter() { }
+
+    /// <summary>Report completed helper operations, including failures, to the daemon's progress gate.</summary>
+    public PipeWireAdapter(Action progress) => _progress = progress;
 
     internal PipeWireAdapter(Func<DspFeatureAvailability> clipGuardAvailabilityOverride)
         => _clipGuardAvailabilityOverride = clipGuardAvailabilityOverride;
@@ -1090,7 +1094,7 @@ public sealed class PipeWireAdapter
 
     // Kept as UTF-8 bytes and parsed from them: the string form is twice
     // the size and was the bulk of the daemon's large-object garbage.
-    private static byte[] DumpJson()
+    private byte[] DumpJson()
     {
         lock (DumpGate)
         {
@@ -1101,7 +1105,13 @@ public sealed class PipeWireAdapter
         }
     }
 
-    private static byte[] RunBytes(string exe, params string[] args)
+    private byte[] RunBytes(string exe, params string[] args)
+    {
+        try { return RunBytesCore(exe, args); }
+        finally { _progress?.Invoke(); }
+    }
+
+    private static byte[] RunBytesCore(string exe, params string[] args)
     {
         var psi = new ProcessStartInfo(exe) { RedirectStandardOutput = true, RedirectStandardError = true };
         psi.Environment["LC_ALL"] = "C";
@@ -1121,7 +1131,13 @@ public sealed class PipeWireAdapter
         return stdout.ToArray();
     }
 
-    private static string Run(string exe, params string[] args)
+    internal string Run(string exe, params string[] args)
+    {
+        try { return RunCore(exe, args); }
+        finally { _progress?.Invoke(); }
+    }
+
+    private static string RunCore(string exe, params string[] args)
     {
         var psi = new ProcessStartInfo(exe) { RedirectStandardOutput = true, RedirectStandardError = true };
         // pactl's human-readable output is parsed ("Sink Input #", "Owner

--- a/src/OpenXLR.Daemon/DeviceManager.cs
+++ b/src/OpenXLR.Daemon/DeviceManager.cs
@@ -19,6 +19,7 @@ public sealed class DeviceManager : BackgroundService
     private DeviceState? _last;
     private IReadOnlyList<DeviceInfo> _detected = [];
     private ushort? _preferredPid;
+    internal ServiceProgress Progress { get; } = new();
 
     // Whether this run builds the submixer (same decision MixerService
     // makes). Only then does the card need the pro-audio profile; in
@@ -196,7 +197,9 @@ public sealed class DeviceManager : BackgroundService
             try
             {
                 EnsureConnected();
+                Progress.Mark();
                 PollOnce();
+                Progress.Mark();
                 TryParkCardProfile();
             }
             catch (UsbHungException ex)
@@ -208,6 +211,7 @@ public sealed class DeviceManager : BackgroundService
                 _log.LogWarning("device loop: {msg}", ex.Message);
                 Drop();
             }
+            Progress.Mark(); // a completed failed poll is responsive too
             await Task.Delay(100, stop).ContinueWith(_ => { }, TaskScheduler.Default);
         }
         Drop();

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -16,7 +16,10 @@ public sealed class MixerService : IHostedService, IDisposable
     private readonly ILogger<MixerService> _log;
     private readonly IConfiguration _config;
     private readonly DeviceManager _devices;
-    private readonly Mixer _mixer = new();
+    private readonly Mixer _mixer;
+    private readonly ServiceProgress _progress = new();
+    private volatile bool _checkingProgress;
+    internal bool IsResponsive(TimeSpan limit) => !_checkingProgress || _progress.IsRecent(limit);
     private Timer? _streamSweep;
     private Timer? _saveDebounce;
     private Timer? _meterPush;
@@ -36,6 +39,7 @@ public sealed class MixerService : IHostedService, IDisposable
         _log = log;
         _config = config;
         _devices = devices;
+        _mixer = new(new PipeWireAdapter(_progress.Mark));
     }
 
     /// <summary>
@@ -122,6 +126,8 @@ public sealed class MixerService : IHostedService, IDisposable
             return Task.CompletedTask;
         }
         OpenXLR.Core.Mixing.Lv2Catalog.Warm();   // plugin inserts: scan LV2 bundles off the startup path
+        _progress.Mark();
+        _checkingProgress = true;
 
         // Optional: the physical sink the monitor mix feeds. Without it the
         // monitor mix exists but isn't routed anywhere audible.
@@ -198,7 +204,11 @@ public sealed class MixerService : IHostedService, IDisposable
                     }
                     else _log.LogDebug("stream sweep: {msg}", ex.Message);
                 }
-                finally { Volatile.Write(ref _sweepRunning, 0); }
+                finally
+                {
+                    _progress.Mark();
+                    Volatile.Write(ref _sweepRunning, 0);
+                }
             }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
 
             // Meters refresh far more often than state; 15 Hz looks smooth
@@ -235,6 +245,8 @@ public sealed class MixerService : IHostedService, IDisposable
             // A partial graph is worse than none: half the sinks exist but no
             // routing, and a later rebuild would double up. Remove what was made.
             try { _mixer.TearDown(); } catch (Exception) { /* best effort */ }
+            // No audio server is a degraded operating mode, not a deadlock.
+            _checkingProgress = false;
         }
         return Task.CompletedTask;
     }

--- a/src/OpenXLR.Daemon/Program.cs
+++ b/src/OpenXLR.Daemon/Program.cs
@@ -7,6 +7,10 @@ const int ApiPort = 37890;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Start the notifier before graph construction so progressing startup work
+// can extend systemd's deadline. Readiness still waits for ApplicationStarted.
+builder.Services.AddHostedService<ServiceWatchdog>();
+
 // The DeviceManager is both a singleton (queried by the hub) and the hosted
 // background service that runs the poll/reconnect loop.
 builder.Services.AddSingleton<DeviceManager>();

--- a/src/OpenXLR.Daemon/ServiceWatchdog.cs
+++ b/src/OpenXLR.Daemon/ServiceWatchdog.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+using System.Net.Sockets;
+using System.Text;
+
+namespace OpenXLR.Daemon;
+
+/// <summary>A completed failed operation is alive; one that never returns is not.</summary>
+internal sealed class ServiceProgress(TimeProvider? clock = null)
+{
+    private readonly TimeProvider _clock = clock ?? TimeProvider.System;
+    private long _last = (clock ?? TimeProvider.System).GetTimestamp();
+
+    public void Mark() => Interlocked.Exchange(ref _last, _clock.GetTimestamp());
+    public bool IsRecent(TimeSpan limit) => _clock.GetElapsedTime(Interlocked.Read(ref _last)) < limit;
+}
+
+/// <summary>
+/// Reports readiness and progress without acquiring device or mixer locks.
+/// Only systemd-supervised launches with NOTIFY_SOCKET enable this service.
+/// </summary>
+internal sealed class ServiceWatchdog(
+    DeviceManager devices, MixerService mixer, IHostApplicationLifetime lifetime,
+    ILogger<ServiceWatchdog> log) : BackgroundService
+{
+    internal static TimeSpan? WatchdogInterval(string? usec, string? pid, int currentPid)
+    {
+        if (pid is not null && (!int.TryParse(pid, out int owner) || owner != currentPid)) return null;
+        return long.TryParse(usec, NumberStyles.None, CultureInfo.InvariantCulture, out long value)
+               && value >= 3_000 && value <= 86_400_000_000
+            ? TimeSpan.FromTicks(value * 10) : null;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stop)
+    {
+        string? address = Environment.GetEnvironmentVariable("NOTIFY_SOCKET");
+        if (!OperatingSystem.IsLinux() || string.IsNullOrEmpty(address)) return;
+        TimeSpan? interval = WatchdogInterval(Environment.GetEnvironmentVariable("WATCHDOG_USEC"),
+            Environment.GetEnvironmentVariable("WATCHDOG_PID"), Environment.ProcessId);
+        TimeSpan period = interval / 3 ?? TimeSpan.FromSeconds(20);
+        TimeSpan freshness = interval / 2 ?? TimeSpan.FromSeconds(30);
+        using var timer = new PeriodicTimer(period);
+        bool ready = false, stalled = false;
+        try
+        {
+            do
+            {
+                bool healthy = devices.Progress.IsRecent(freshness) && mixer.IsResponsive(freshness);
+                if (lifetime.ApplicationStarted.IsCancellationRequested)
+                {
+                    if (!ready)
+                    {
+                        ready = await NotifyAsync(address, "READY=1", stop);
+                        if (!ready) log.LogWarning("Could not report readiness to systemd");
+                    }
+                    if (interval is null && ready) return;
+                    if (healthy && interval is not null
+                        && !await NotifyAsync(address, "WATCHDOG=1", stop))
+                        log.LogWarning("Could not report progress to systemd");
+                }
+                else if (healthy)
+                {
+                    // StartAsync can build many nodes. Extend the startup
+                    // deadline only while real worker operations complete.
+                    await NotifyAsync(address, "EXTEND_TIMEOUT_USEC=60000000", stop);
+                }
+
+                if (!healthy && !stalled)
+                    log.LogWarning("Watchdog heartbeat withheld: device or mixer stopped making progress");
+                else if (healthy && stalled)
+                    log.LogInformation("Watchdog worker progress recovered");
+                stalled = !healthy;
+            } while (await timer.WaitForNextTickAsync(stop));
+        }
+        catch (OperationCanceledException) when (stop.IsCancellationRequested) { }
+    }
+
+    internal static async Task<bool> NotifyAsync(string address, string message, CancellationToken stop)
+    {
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(stop);
+            timeout.CancelAfter(TimeSpan.FromSeconds(2));
+            using var socket = new Socket(AddressFamily.Unix, SocketType.Dgram, ProtocolType.Unspecified);
+            var endpoint = new UnixDomainSocketEndPoint(address.StartsWith('@') ? "\0" + address[1..] : address);
+            await socket.SendToAsync(Encoding.UTF8.GetBytes(message), SocketFlags.None, endpoint, timeout.Token);
+            return true;
+        }
+        catch (Exception ex) when (ex is SocketException or ArgumentException or OperationCanceledException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/OpenXLR.Daemon/ServiceWatchdog.cs
+++ b/src/OpenXLR.Daemon/ServiceWatchdog.cs
@@ -39,18 +39,27 @@ internal sealed class ServiceWatchdog(
         TimeSpan period = interval / 3 ?? TimeSpan.FromSeconds(20);
         TimeSpan freshness = interval / 2 ?? TimeSpan.FromSeconds(30);
         using var timer = new PeriodicTimer(period);
+        // Hosted services start before the host fires ApplicationStarted. Keep
+        // readiness on that event path instead of waiting for the next watchdog
+        // tick (20 seconds with the packaged 60-second watchdog).
+        Task<bool> readyNotification = NotifyWhenStartedAsync(
+            lifetime.ApplicationStarted, address, stop);
         bool ready = false, stalled = false;
         try
         {
             do
             {
                 bool healthy = devices.Progress.IsRecent(freshness) && mixer.IsResponsive(freshness);
-                if (lifetime.ApplicationStarted.IsCancellationRequested)
+                if (readyNotification.IsCompleted)
                 {
                     if (!ready)
                     {
-                        ready = await NotifyAsync(address, "READY=1", stop);
-                        if (!ready) log.LogWarning("Could not report readiness to systemd");
+                        ready = await readyNotification;
+                        if (!ready)
+                        {
+                            log.LogWarning("Could not report readiness to systemd");
+                            readyNotification = NotifyAsync(address, "READY=1", stop);
+                        }
                     }
                     if (interval is null && ready) return;
                     if (healthy && interval is not null
@@ -72,6 +81,16 @@ internal sealed class ServiceWatchdog(
             } while (await timer.WaitForNextTickAsync(stop));
         }
         catch (OperationCanceledException) when (stop.IsCancellationRequested) { }
+    }
+
+    internal static async Task<bool> NotifyWhenStartedAsync(
+        CancellationToken applicationStarted, string address, CancellationToken stop)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = applicationStarted.Register(
+            static state => ((TaskCompletionSource)state!).TrySetResult(), started);
+        await started.Task.WaitAsync(stop);
+        return await NotifyAsync(address, "READY=1", stop);
     }
 
     internal static async Task<bool> NotifyAsync(string address, string message, CancellationToken stop)

--- a/src/OpenXLR.Tests/ServiceWatchdogTests.cs
+++ b/src/OpenXLR.Tests/ServiceWatchdogTests.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel;
+using System.Net.Sockets;
+using System.Text;
+using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+public sealed class ServiceWatchdogTests
+{
+    [Theory]
+    [InlineData("60000000", null, 42, 60)]
+    [InlineData("60000000", "42", 42, 60)]
+    [InlineData("60000000", "43", 42, 0)]
+    [InlineData("60000000", "bad", 42, 0)]
+    [InlineData(null, null, 42, 0)]
+    [InlineData("-1", null, 42, 0)]
+    [InlineData("0", null, 42, 0)]
+    [InlineData("9223372036854775807", null, 42, 0)]
+    public void IntervalHonoursSystemdProcessOwnership(string? interval, string? pid, int current, int seconds)
+        => Assert.Equal(seconds, ServiceWatchdog.WatchdogInterval(interval, pid, current)?.TotalSeconds ?? 0);
+
+    [Fact]
+    public void HungWorkerExpiresButCompletedWorkRenewsProgress()
+    {
+        var clock = new ManualClock();
+        var progress = new ServiceProgress(clock);
+        Assert.True(progress.IsRecent(TimeSpan.FromSeconds(30)));
+        clock.Now += TimeSpan.FromSeconds(30).Ticks;
+        Assert.False(progress.IsRecent(TimeSpan.FromSeconds(30)));
+        progress.Mark();
+        Assert.True(progress.IsRecent(TimeSpan.FromSeconds(30)));
+    }
+
+    [Fact]
+    public void LongOperationCanReportEachCompletedStep()
+    {
+        var clock = new ManualClock();
+        var progress = new ServiceProgress(clock);
+        for (int i = 0; i < 20; i++)
+        {
+            clock.Now += TimeSpan.FromSeconds(5).Ticks;
+            Assert.True(progress.IsRecent(TimeSpan.FromSeconds(30)));
+            progress.Mark();
+        }
+        Assert.Equal(TimeSpan.FromSeconds(100).Ticks, clock.Now);
+    }
+
+    [Fact]
+    public void HelperSuccessAndFailureBothReportCompletion()
+    {
+        int completed = 0;
+        var adapter = new PipeWireAdapter(() => completed++);
+        Assert.NotEmpty(adapter.Run("dotnet", "--version"));
+        Assert.Equal(1, completed);
+        Assert.Throws<Win32Exception>(() => adapter.Run("openxlr-no-such-helper-" + Guid.NewGuid().ToString("N")));
+        Assert.Equal(2, completed);
+    }
+
+    [Fact]
+    public async Task NotificationsReachARealUnixDatagramSocket()
+    {
+        string directory = Directory.CreateTempSubdirectory("ow-").FullName;
+        string address = Path.Combine(directory, "notify");
+        try
+        {
+            using var listener = new Socket(AddressFamily.Unix, SocketType.Dgram, ProtocolType.Unspecified);
+            listener.Bind(new UnixDomainSocketEndPoint(address));
+            using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            foreach (string message in new[] { "READY=1", "WATCHDOG=1", "EXTEND_TIMEOUT_USEC=60000000" })
+            {
+                Assert.True(await ServiceWatchdog.NotifyAsync(address, message, stop.Token));
+                byte[] buffer = new byte[128];
+                int received = await listener.ReceiveAsync(buffer, SocketFlags.None, stop.Token);
+                Assert.Equal(message, Encoding.UTF8.GetString(buffer, 0, received));
+            }
+        }
+        finally { Directory.Delete(directory, recursive: true); }
+    }
+
+    [Fact]
+    public async Task MissingNotifySocketDoesNotThrowOrHang()
+    {
+        string address = Path.Combine(Path.GetTempPath(), "ow-missing-" + Guid.NewGuid().ToString("N"));
+        Assert.False(await ServiceWatchdog.NotifyAsync(address, "READY=1", CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    private sealed class ManualClock : TimeProvider
+    {
+        public long Now { get; set; }
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override long GetTimestamp() => Now;
+    }
+}

--- a/src/OpenXLR.Tests/ServiceWatchdogTests.cs
+++ b/src/OpenXLR.Tests/ServiceWatchdogTests.cs
@@ -79,6 +79,31 @@ public sealed class ServiceWatchdogTests
     }
 
     [Fact]
+    public async Task ReadinessIsSentWhenApplicationStartedFires()
+    {
+        string directory = Directory.CreateTempSubdirectory("ow-").FullName;
+        string address = Path.Combine(directory, "notify");
+        try
+        {
+            using var listener = new Socket(AddressFamily.Unix, SocketType.Dgram, ProtocolType.Unspecified);
+            listener.Bind(new UnixDomainSocketEndPoint(address));
+            using var applicationStarted = new CancellationTokenSource();
+            using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            Task<bool> notification = ServiceWatchdog.NotifyWhenStartedAsync(
+                applicationStarted.Token, address, stop.Token);
+            Assert.False(notification.IsCompleted);
+
+            applicationStarted.Cancel();
+            Assert.True(await notification);
+            byte[] buffer = new byte[128];
+            int received = await listener.ReceiveAsync(buffer, SocketFlags.None, stop.Token);
+            Assert.Equal("READY=1", Encoding.UTF8.GetString(buffer, 0, received));
+        }
+        finally { Directory.Delete(directory, recursive: true); }
+    }
+
+    [Fact]
     public async Task MissingNotifySocketDoesNotThrowOrHang()
     {
         string address = Path.Combine(Path.GetTempPath(), "ow-missing-" + Guid.NewGuid().ToString("N"));

--- a/src/OpenXLR.UI/UiSettings.cs
+++ b/src/OpenXLR.UI/UiSettings.cs
@@ -224,8 +224,15 @@ public static class StartupIntegration
                     [Unit]
                     Description=OpenXLR audio daemon
                     After=pipewire-pulse.service wireplumber.service
+                    StartLimitIntervalSec=300
+                    StartLimitBurst=3
 
                     [Service]
+                    Type=notify
+                    NotifyAccess=main
+                    WatchdogSec=60
+                    WatchdogSignal=SIGTERM
+                    TimeoutStartSec=120
                     ExecStart={daemon}
                     Environment=OPENXLR_BUILD_MIXER=1
                     TimeoutStopSec=45


### PR DESCRIPTION
## Scope

Watchdog portion split from #10 and rebased onto current upstream main (0.1.20).
Kept as a draft because the remaining hardware/audio/package acceptance should
not be implied by the automated coverage.

- systemd notify with a 60-second watchdog and progress-gated heartbeats.
- `READY=1` is dispatched directly from the `ApplicationStarted` event path;
  it no longer waits for the first 20-second watchdog timer tick.
- Progress after completed PipeWire helper operations, including failures, and
  between device-loop stages. Long graph operations report intermediate progress.
- Startup timeout extensions only while workers make progress. The timer remains
  responsible for `WATCHDOG=1` and startup `EXTEND_TIMEOUT_USEC` notifications.
- Restart=on-failure, three starts in five minutes, WatchdogSignal=SIGTERM and
  the existing graceful shutdown timeout. Packaged, generated source-install
  and Nix unit definitions follow the same policy.
- A failed initial graph build disables the mixer progress requirement while
  device control continues. Audio-server absence is not itself a watchdog fault.
- No pipewire-pulse LimitNOFILE override, global service modification, native host,
  UI redesign, HTTP API, version bump or CI/Python tooling change.

## Verification

- Release solution build/test with warnings as errors: 96 tests passed, zero
  warnings/errors. This includes a real Unix datagram test proving that
  `READY=1` is sent as soon as the registered ApplicationStarted token fires.
- Real isolated transient systemd user-service test: withheld heartbeat caused
  SIGTERM, the test process handled SIGTERM and exited cleanly, restarts occurred,
  and systemd stopped retrying with start-limit-hit after the third attempt.
  This used shortened timeouts and a disposable test process, not the user's
  installed OpenXLR daemon. The temporary service failure state was cleared.
- systemd-analyze parsed the repository's source-install unit but reported the
  expected missing executable at its example %h/openxlr path.

## Remaining before ready

Exercise the new daemon itself through prolonged graph construction, startup
without PipeWire, audio-server loss, deliberate worker stalls and graceful
recovery on the target hardware. The transient-service test proves the chosen
systemd policy, not OpenXLR hardware teardown. Nix evaluation and packaged runtime
acceptance are also pending. Existing hardware-verified routing is not replaced.
