### PR TITLE
Native LV2 host: optional build and live plugin editors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
           python3 tools/check-openapi.py docs/openapi-v1.json
           node --test plugin/tests/*.test.mjs
 
+      - name: Optional native LV2 host compiles
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev
+          make -C native
+          test -x native/openxlr-lv2-host
+
       - name: Lint shell scripts
         run: shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh
 

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -21,7 +21,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential debhelper dotnet-sdk-10.0 lintian
+            build-essential debhelper dotnet-sdk-10.0 lintian \
+            pkg-config libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev
 
       - name: Versions agree everywhere
         run: tools/check-version.sh
@@ -48,6 +49,7 @@ jobs:
           for f in usr/lib/systemd/user/openxlr-daemon.service \
                    usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf \
                    usr/lib/udev/rules.d/70-openxlr.rules \
+                   usr/lib/openxlr/daemon/openxlr-lv2-host \
                    usr/bin/openxlr usr/bin/openxlr-daemon; do
             grep -q " ./$f\$" contents.txt || { echo "missing from the package: $f"; exit 1; }
           done

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Install build dependencies
         run: |
           dnf install -y --setopt=install_weak_deps=False \
-            rpm-build rpmlint git-core dotnet-sdk-10.0 systemd-rpm-macros
+            rpm-build rpmlint git-core dotnet-sdk-10.0 systemd-rpm-macros \
+            gcc make pkgconf-pkg-config pipewire-devel lilv-devel lv2-devel libX11-devel
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -54,6 +55,7 @@ jobs:
           rpm -q openxlr
           test -x /usr/bin/openxlr && test -x /usr/bin/openxlr-daemon
           test -x /usr/lib/openxlr/daemon/OpenXLR.Daemon
+          test -x /usr/lib/openxlr/daemon/openxlr-lv2-host
           test -f /usr/lib/udev/rules.d/70-openxlr.rules
           test -f /usr/share/wireplumber/wireplumber.conf.d/50-xlr-dock-capture-hold.conf
           test -f /usr/lib/systemd/user/openxlr-daemon.service

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ fork/
 # build output
 src/*/bin/
 src/*/obj/
+native/openxlr-lv2-host
 
 # Local working material, never shipped: personal Windows exports, USB capture
 # analysis, third-party clones, caches.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ fork/
 src/*/bin/
 src/*/obj/
 native/openxlr-lv2-host
+# nix build output symlink
+result
 
 # Local working material, never shipped: personal Windows exports, USB capture
 # analysis, third-party clones, caches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ tools/check-version.sh
 tools/check-locked-restore.sh
 tools/check-openapi.py docs/openapi-v1.json
 tools/check-spec.py packaging/rpm/openxlr.spec
+make -C native  # optional LV2 host; needs the PipeWire, lilv, LV2 and X11 headers
 ```
 
 CI runs exactly these; the build treats warnings as errors, so a build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ tools/check-version.sh                          # the five version locations agr
 tools/check-locked-restore.sh                   # every packaging path restores locked
 tools/check-openapi.py docs/openapi-v1.json     # the HTTP API document keeps its shape
 tools/check-spec.py packaging/rpm/openxlr.spec  # every installed file is in %files
+make -C native  # optional LV2 host; needs the PipeWire, lilv, LV2 and X11 headers
 ```
 
 If you add or change a NuGet package, regenerate the lock files with a

--- a/README.md
+++ b/README.md
@@ -259,9 +259,10 @@ Code:
   graph changes, the bounded send queue, diagnostics redaction, systemd
   sandboxing, the test project and CI), the progress-gated watchdog, the
   update notice, the versioned HTTP API, the OpenDeck choices generated
-  from daemon state, and the first pieces of the editable layout: its
-  saved format, live channel creation and the saved order. Her native LV2
-  plugin editors are in review.
+  from daemon state, the first pieces of the editable layout (its saved
+  format, live channel creation and the saved order), and the optional
+  native LV2 host that opens a plugin's own editor on the instance
+  processing your audio.
 - [Michael Brooks](https://github.com/Michael-Brooks): the stream-sweep
   starvation fix ([#7](https://github.com/emaspa/openxlr/pull/7)) and the
   diagnosis that led to it.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,9 @@ Source: openxlr
 Section: sound
 Priority: optional
 Maintainer: Emanuele Sparvoli <sparvoli@gmail.com>
-Build-Depends: debhelper-compat (= 13), dotnet-sdk-10.0
+Build-Depends: debhelper-compat (= 13), dotnet-sdk-10.0,
+ gcc, make, pkg-config,
+ libpipewire-0.3-dev, liblilv-dev, lv2-dev, libx11-dev
 Standards-Version: 4.7.0
 Homepage: https://github.com/emaspa/openxlr
 Vcs-Git: https://github.com/emaspa/openxlr.git

--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,8 @@ PKG = $(CURDIR)/debian/openxlr
 
 override_dh_auto_build:
 	dotnet publish src/OpenXLR.Daemon -c Release -r linux-x64 \
-		--self-contained false -p:RestoreLockedMode=true $(RESTORE_SOURCE) -o $(OUT)/daemon
+		--self-contained false -p:RestoreLockedMode=true -p:EnableNativeLv2Host=true \
+		$(RESTORE_SOURCE) -o $(OUT)/daemon
 	dotnet publish src/OpenXLR.UI -c Release -r linux-x64 \
 		--self-contained false -p:RestoreLockedMode=true $(RESTORE_SOURCE) -o $(OUT)/ui
 
@@ -36,6 +37,7 @@ override_dh_auto_install:
 	# dotnet publish marks assemblies executable; only the apphosts are.
 	find $(PKG)/usr/lib/openxlr -type f -exec chmod 644 {} +
 	chmod 755 $(PKG)/usr/lib/openxlr/daemon/OpenXLR.Daemon \
+		$(PKG)/usr/lib/openxlr/daemon/openxlr-lv2-host \
 		$(PKG)/usr/lib/openxlr/ui/OpenXLR.UI
 
 	install -dm755 $(PKG)/usr/bin

--- a/docs/api.md
+++ b/docs/api.md
@@ -96,6 +96,11 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `resetDevice` | none | write the firmware defaults back to a device without settings memory and forget its last settings (an error until the daemon has seen the device connect after a power cycle once); on the Wave XLR Pro, which keeps its own settings, write OpenXLR's baseline instead: gain 30 dB on both inputs, every processing stage and phantom off, headphones and aux level at half, the crossfade fully on PC, routing untouched, refused while the gain lock is on. The capabilities say `builtInDefaults` when a model has a baseline |
 | `getDiagnostics` | none | vendor block dump for bug reports |
 
+Insert definitions optionally carry `nativeHost: true` to select the native
+LV2 helper for that insert. Missing or false keeps PipeWire filter-chain, even
+when the helper is installed. Unsupported native selections are rejected.
+Changing this choice via `setInserts` rebuilds the chain and can interrupt audio.
+
 The OpenDeck plugin in `plugin/` is a client of this API; the command
 handler is `WebSocketHub.cs` and the message shapes are in
 `Protocol.cs`, both under `src/OpenXLR.Daemon/`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,6 +85,7 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setInserts` | `channel`, `inserts[]` | replace a chain; `channel` is `xlr1`, `xlr2` or `mix:<id>`, each insert is `{id, kind:"lv2", plugin:<uri>, label?, bypass?, params?}` |
 | `setInsertBypass` | `channel`, `insertId`, `value` | bypass one insert |
 | `setInsertParam` | `channel`, `insertId`, `symbol`, `value` | one plugin control, by its LV2 port symbol |
+| `showInsertUi` | `channel`, `insertId` | open an enabled insert's native editor when the optional host is installed |
 | `assignApp` | `identity`, `channel`, `label?` | route an app (creates a registry entry if unseen); `channel: "ignore"` stops managing it, its streams go back to the system default output and stay wherever the desktop routes them |
 | `assignStream` | `streamId`, `channel` | route one live stream by its PipeWire id; also remembered for the app; `ignore` works here too |
 | `forgetApp` | `identity` | drop an app and its remembered channel |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,11 @@ modules or custom drivers:
   inserts on inputs and mixes) are `filter-chain` nodes, each held by a
   long-lived `pw-cli -m` process for the life of the chain; their
   controls are set with `pw-cli set-param`.
+- An insert switched to the native host is not a filter-chain node but
+  an `openxlr-lv2-host` process, one per insert, holding that plugin and
+  its editor behind a PipeWire filter node of its own. The rest of the
+  chain stays filter-chain nodes, linked stage to stage, and the daemon
+  speaks to the helper over a pipe that carries control values only.
 - Direct port links (`pw-link`) wire hardware inputs, chains, mixes and
   outputs, so the output device clocks the chain. Hardware inputs are
   wired by capture-channel pair (XLR 1 = pair 0, XLR 2 = pair 1, Line

--- a/docs/features.md
+++ b/docs/features.md
@@ -120,12 +120,23 @@ with no extra process, and a chain adds latency only while it holds a
 plugin. Plugins are found in the standard LV2 directories
 (`/usr/lib/lv2`, `~/.lv2`, or wherever `LV2_PATH` points); the daemon
 reads them through lilv. `lsp-plugins-lv2` is the set used during
-development. Plugins that ship a custom GUI still load; the generated
-controls are shown instead of their window. A plugin that requires a
-host feature the chain does not provide (an editor needing instance
-access, for example) is left out of the picker and refused by the
-daemon rather than failing when the chain is built. VST and CLAP
-plugins are not supported; loading them would need a plugin host.
+development. A plugin that requires a host feature the chain does not
+provide is left out of the picker and refused by the daemon rather than
+failing when the chain is built. VST and CLAP plugins are not supported;
+loading them would need a plugin host.
+
+Plugins that ship their own editor still load, and the generated controls
+are shown for them. The editor itself can be opened through an optional
+native host, built from source and absent from the packages. Turning on
+"Native host" for one insert moves that insert out of the shared chain
+into a process of its own, which hosts the plugin and its editor
+together; the other inserts stay in the chain. The editor works on the
+audio that is playing and its changes are saved like any other control.
+The plugin keeps processing if the editor stops answering or the X
+display goes away, and a chain whose host keeps crashing is switched off
+once it has failed three times in five minutes, with the reason on the
+insert. The manual covers the
+setup in 3.12.
 
 The submixer can be switched off in Options. The daemon then controls
 the hardware only, restarts itself, and leaves the sound card in its

--- a/docs/features.md
+++ b/docs/features.md
@@ -126,11 +126,11 @@ failing when the chain is built. VST and CLAP plugins are not supported;
 loading them would need a plugin host.
 
 Plugins that ship their own editor still load, and the generated controls
-are shown for them. The editor itself can be opened through an optional
-native host, built from source and absent from the packages. Turning on
-"Native host" for one insert moves that insert out of the shared chain
-into a process of its own, which hosts the plugin and its editor
-together; the other inserts stay in the chain. The editor works on the
+are shown for them. The editor itself can be opened through a small host
+process, which every package installs. Turning on "Native host" for one
+insert moves that insert out of the shared chain into a process of its
+own, which hosts the plugin and its editor together; the other inserts
+stay in the chain and nothing moves unless you ask. The editor works on the
 audio that is playing and its changes are saved like any other control.
 The plugin keeps processing if the editor stops answering or the X
 display goes away, and a chain whose host keeps crashing is switched off

--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -66,6 +66,10 @@ Ubuntu). Without the flag nothing native is built and inserts use
 PipeWire's filter chain, which is also the default when the helper is
 present. The manual describes the feature in 3.12.
 
+Build with the flag every time once you rely on it. A later build without it
+removes the helper again, and inserts set to the native host then report that
+it is not installed.
+
 ## 3. Device access (udev rule, then replug the device):
 
 ```sh

--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -51,6 +51,21 @@ dotnet build -c Release
 Binaries land in `src/OpenXLR.Daemon/bin/Release/net10.0/` and
 `src/OpenXLR.UI/bin/Release/net10.0/`.
 
+To be able to open a plugin's own editor, build the optional native host
+as well:
+
+```sh
+dotnet build -c Release -p:EnableNativeLv2Host=true
+```
+
+That step compiles `native/lv2-host.c` and copies the helper next to the
+daemon. It needs a C compiler, make, pkg-config and the development files
+for PipeWire, lilv, LV2 and X11 (`base-devel`, `pipewire`, `lilv`, `lv2`
+and `libx11` on Arch; the `-dev` packages of the same on Debian and
+Ubuntu). Without the flag nothing native is built and inserts use
+PipeWire's filter chain, which is also the default when the helper is
+present. The manual describes the feature in 3.12.
+
 ## 3. Device access (udev rule, then replug the device):
 
 ```sh

--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -51,8 +51,8 @@ dotnet build -c Release
 Binaries land in `src/OpenXLR.Daemon/bin/Release/net10.0/` and
 `src/OpenXLR.UI/bin/Release/net10.0/`.
 
-To be able to open a plugin's own editor, build the optional native host
-as well:
+The packages install the small host process that opens a plugin's own
+editor. A source build leaves it out unless you ask:
 
 ```sh
 dotnet build -c Release -p:EnableNativeLv2Host=true

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -352,18 +352,12 @@ and Stream Deck keys survive a rename. The layout file is described in
 
 The controls window is generated from the plugin's parameters and works
 for every plugin. Some plugins also ship an editor of their own, with the
-meters and curves their authors drew. Opening one needs the optional
-native host, which the packages do not carry. Build it from source:
+meters and curves their authors drew. Opening one goes through a small
+host process that the packages install for you. If you build from source,
+add one flag to get it, as
+[install-from-source.md](install-from-source.md) describes.
 
-```sh
-dotnet build src/OpenXLR.slnx -c Release -p:EnableNativeLv2Host=true
-```
-
-It needs a C compiler, make, pkg-config and the development files for
-PipeWire, lilv, the LV2 headers and X11. See
-[install-from-source.md](install-from-source.md).
-
-With the host in place:
+To use it:
 
 1. Open a plugin's Controls window. A plugin whose editor OpenXLR can
    host shows a "Native host" button.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -206,9 +206,9 @@ channel, with its level and lock in the INPUTS card.
    (red light); the arrows reorder the chain; the cross removes it.
 4. Chains are saved with the mixer and with profiles.
 
-The plugin's own graphical interface, if it has one, is not shown; the
-generated controls cover every parameter the plugin exposes. VST and
-CLAP plugins cannot be loaded.
+The generated controls cover every parameter the plugin exposes. A
+plugin's own editor can be opened as well, with the optional native host
+described in 3.12. VST and CLAP plugins cannot be loaded.
 
 <a name="profiles"></a>
 ### 3.6 Save and recall a scene
@@ -346,6 +346,55 @@ three seconds: nothing is kept that the daemon could not set.
 Ids are generated from names and never change afterwards, so profiles
 and Stream Deck keys survive a rename. The layout file is described in
 [mixer-layout.md](mixer-layout.md).
+
+<a name="plugin-editors"></a>
+### 3.12 Open a plugin's own editor
+
+The controls window is generated from the plugin's parameters and works
+for every plugin. Some plugins also ship an editor of their own, with the
+meters and curves their authors drew. Opening one needs the optional
+native host, which the packages do not carry. Build it from source:
+
+```sh
+dotnet build src/OpenXLR.slnx -c Release -p:EnableNativeLv2Host=true
+```
+
+It needs a C compiler, make, pkg-config and the development files for
+PipeWire, lilv, the LV2 headers and X11. See
+[install-from-source.md](install-from-source.md).
+
+With the host in place:
+
+1. Open a plugin's Controls window. A plugin whose editor OpenXLR can
+   host shows a "Native host" button.
+2. Turn it on. That one insert moves out of the shared filter chain into
+   its own process, which rebuilds the chain and interrupts audio for a
+   moment. Every other plugin stays where it is.
+3. Press "Plugin UI". The editor opens on the plugin that is processing
+   your audio. What you change there appears in the controls window and
+   is saved with the mixer and with profiles.
+4. Turn "Native host" off to put the insert back in the shared chain.
+
+The editor draws on an X11 display, which means XWayland on a Wayland
+desktop, and the daemon has to know about it. A user service that started
+before the desktop published its display does not, and the fix is one
+import and a restart, from a terminal inside the graphical session:
+
+```sh
+systemctl --user import-environment DISPLAY XAUTHORITY
+systemctl --user restart openxlr-daemon.service
+```
+
+The restart interrupts audio briefly. Repeat it after a graphical login
+that assigns a new display.
+
+Trouble with an editor never costs you the sound. If the X server goes
+away while an editor is open, the editor closes and the plugin keeps
+processing; pressing "Plugin UI" again opens a fresh one. If an editor
+stops answering, the insert says its controls are frozen and its audio
+carries on. A plugin that keeps crashing has its chain switched off after
+it has failed three times in five minutes, with the reason on the insert;
+changing or bypassing that chain starts it over.
 
 <a name="stream-deck"></a>
 ## 4. Stream Deck (OpenDeck)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,10 +113,10 @@ host mechanism stable than two half-finished ones.
   existing chain never changes host on upgrade, and every insert without
   that choice stays in filter-chain. A failing editor costs the editor
   only: a lost X display, an editor that stops answering and a plugin that
-  crashes on start are each handled with the audio still playing. The .NET
-  build still needs no compiler; the helper is built with
-  `-p:EnableNativeLv2Host=true`. It is not in the packages yet, so it
-  remains a build-from-source feature.
+  crashes on start are each handled with the audio still playing. Every
+  package builds and installs the helper; an ordinary .NET build still
+  needs no compiler, and a source build opts in with
+  `-p:EnableNativeLv2Host=true`.
 - [ ] VST3 and CLAP, and Windows VST3 through yabridge, in the same host
   process model, one plugin per process, supervised and fail-open so a
   crashed plugin is bypassed and audio continues.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,17 +106,17 @@ plugin world, and it has to keep the audio path inside PipeWire. It waits
 for the mixer layout block above; the maintainer would rather have one
 host mechanism stable than two half-finished ones.
 
-- [ ] Native plugin editors: open an LV2 plugin's own window on the
-  instance that processes audio. This needs the instance out of
-  filter-chain and into a host process that exposes a PipeWire filter
-  node; the design has to keep filter-chain for inserts that have no
-  editor, and must not make the .NET build depend on a C toolchain. A
-  pull request (#19) meets those constraints with an optional C helper
-  and stays open until the layout work is done. Before it ships, native
-  hosting becomes a per-insert choice so an existing chain does not
-  change host on upgrade, and the helper is packaged on every channel
-  (its libraries already ship with the daemon; only build-time headers
-  and a compiler are new).
+- [x] Native plugin editors: an LV2 plugin's own window, open on the
+  instance that processes its audio. The instance moves out of
+  filter-chain into an optional C helper that carries one plugin and its
+  editor behind a PipeWire filter node. It is a per-insert choice, so an
+  existing chain never changes host on upgrade, and every insert without
+  that choice stays in filter-chain. A failing editor costs the editor
+  only: a lost X display, an editor that stops answering and a plugin that
+  crashes on start are each handled with the audio still playing. The .NET
+  build still needs no compiler; the helper is built with
+  `-p:EnableNativeLv2Host=true`. It is not in the packages yet, so it
+  remains a build-from-source feature.
 - [ ] VST3 and CLAP, and Windows VST3 through yabridge, in the same host
   process model, one plugin per process, supervised and fail-open so a
   crashed plugin is bypassed and audio continues.

--- a/native/Makefile
+++ b/native/Makefile
@@ -1,0 +1,11 @@
+PKGS = libpipewire-0.3 lilv-0 x11
+CPPFLAGS += $(shell pkg-config --cflags $(PKGS))
+CFLAGS += -std=c11 -O2 -g -Wall -Wextra -Werror -Wno-unused-parameter
+LDLIBS += $(shell pkg-config --libs $(PKGS)) -ldl -lm -pthread
+
+openxlr-lv2-host: lv2-host.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LDLIBS)
+
+.PHONY: clean
+clean:
+	rm -f openxlr-lv2-host

--- a/native/Makefile
+++ b/native/Makefile
@@ -1,4 +1,4 @@
-PKGS = libpipewire-0.3 lilv-0 x11
+PKGS = libpipewire-0.3 lilv-0 lv2 x11
 CPPFLAGS += $(shell pkg-config --cflags $(PKGS))
 CFLAGS += -std=c11 -O2 -g -Wall -Wextra -Werror -Wno-unused-parameter
 LDLIBS += $(shell pkg-config --libs $(PKGS)) -ldl -lm -pthread

--- a/native/README.md
+++ b/native/README.md
@@ -17,8 +17,11 @@ For a supported plugin exposing an X11 editor, the live instance runs in an
 isolated PipeWire filter process. Other plugins remain in filter-chain, also
 inside mixed chains. The existing generated controls window gains a Plugin UI
 button when the daemon advertises an available native editor. On Wayland the
-editor requires XWayland. Unsupported required DSP features are never silently
-accepted; the existing upstream catalog and API feature gate remain in place.
+editor requires XWayland. The catalog checks required features on both the DSP
+and the selected X11 UI before advertising the editor. The live insert status
+also reports whether its native host is running, so a failed or bypassed chain
+cannot offer an editor action that will only fail. Unsupported requirements are
+never silently accepted; the existing upstream API feature gate remains in place.
 
 Control edits return through the helper pipe and are saved by the normal
 daemon settings path. Plugin output-control meters are included in insert status.

--- a/native/README.md
+++ b/native/README.md
@@ -1,0 +1,35 @@
+# Optional LV2 editor host
+
+The default .NET build does not invoke make or require a C compiler.
+Plugins continue to use PipeWire filter-chain when the helper is absent.
+Build and copy the optional helper with:
+
+```sh
+dotnet build src/OpenXLR.slnx -c Release -p:EnableNativeLv2Host=true
+```
+
+Native build dependencies are a C11 compiler, make, pkg-config, PipeWire
+development headers, lilv development headers and X11 development headers.
+The helper can also be built with `make -C native` and installed beside
+the daemon separately. Distribution packages are not changed by this PR.
+
+For a supported plugin exposing an X11 editor, the live instance runs in an
+isolated PipeWire filter process. Other plugins remain in filter-chain, also
+inside mixed chains. The existing generated controls window gains a Plugin UI
+button when the daemon advertises an available native editor. On Wayland the
+editor requires XWayland. Unsupported required DSP features are never silently
+accepted; the existing upstream catalog and API feature gate remain in place.
+
+Control edits return through the helper pipe and are saved by the normal
+daemon settings path. Plugin output-control meters are included in insert status.
+Audio buffers never cross managed code or the command pipe.
+
+The helper observes the daemon-owned stdin pipe for EOF/HUP instead of using
+PDEATHSIG, whose Linux semantics tie it to the creating thread. A separate
+monitor thread reports audio progress; the UI loop reports UI progress.
+A stalled editor does not by itself make the DSP process unhealthy.
+
+The host currently implements URID map/unmap for DSP and the X11 editor
+features used by this implementation. Worker, state/preset, VST3 and CLAP
+support are separate work. Changing chains still uses the existing rebuild
+mechanism; seamless swapping is not claimed.

--- a/native/README.md
+++ b/native/README.md
@@ -33,6 +33,39 @@ Control edits return through the helper pipe and are saved by the normal
 daemon settings path. Plugin output-control meters are included in insert status.
 Audio buffers never cross managed code or the command pipe.
 
+## Desktop session environment with the packaged user service
+
+The user service can start before the desktop publishes its X11 environment.
+The helper inherits the daemon's environment; it does not search other sessions
+or guess a display/cookie. From a terminal **inside the active graphical session**,
+import its values before restarting the daemon:
+
+```sh
+systemctl --user import-environment DISPLAY XAUTHORITY
+systemctl --user restart openxlr-daemon.service
+```
+
+The restart briefly interrupts audio. Repeat the import at graphical login (or
+use the desktop's session-start integration), especially when XWayland assigns
+a new display. Check that DISPLAY is set and that XAUTHORITY, when set, points
+to a readable cookie file. GDM/SDDM often use a file under `/run/user/...`, not
+`~/.Xauthority`; use the session's value, not a copied or guessed cookie. Never
+use `xhost +` to bypass authentication.
+
+The packaged unit also enables `PrivateTmp`. For a filesystem X11 socket that
+is hidden by that setting, create a **user override** with
+`systemctl --user edit openxlr-daemon.service`:
+
+```ini
+[Service]
+PrivateTmp=false
+```
+
+Then run `systemctl --user daemon-reload` and restart after the import above.
+This optional override reduces temporary-directory isolation; the shipped unit
+is unchanged. Do not disable other hardening. On Wayland, XWayland must be
+running. These steps describe setup, not acceptance on GDM/SDDM hardware.
+
 The helper observes the daemon-owned stdin pipe for EOF/HUP instead of using
 PDEATHSIG, whose Linux semantics tie it to the creating thread. A separate
 monitor thread reports audio progress; the UI loop reports UI progress.

--- a/native/README.md
+++ b/native/README.md
@@ -6,19 +6,23 @@ editor on that live instance. It exists because a plugin's editor talks to its
 DSP instance directly (LV2 instance access), which a PipeWire filter chain
 cannot offer.
 
-Nothing here is built by default, and installing it changes nothing on its
-own: inserts use the filter chain until an insert is explicitly switched to
-the native host in its controls window.
+The distribution packages build and install it, and its presence changes
+nothing on its own: inserts use the filter chain until one is explicitly
+switched to the native host in its controls window.
 
 ## Build
+
+An ordinary .NET build does not invoke a C compiler. Opt in with:
 
 ```sh
 dotnet build src/OpenXLR.slnx -c Release -p:EnableNativeLv2Host=true
 ```
 
-The flag compiles this directory and copies the helper next to the daemon.
-`make -C native` builds it alone. It needs a C11 compiler, make, pkg-config
-and the development files for PipeWire, lilv, LV2 and X11.
+The flag compiles this directory and copies the helper next to the daemon,
+which is what the packaging recipes do. `make -C native` builds it alone.
+It needs a C11 compiler, make, pkg-config and the development files for
+PipeWire, lilv, LV2 and X11; the libraries it links are already runtime
+dependencies of every package.
 
 ## What it does
 

--- a/native/README.md
+++ b/native/README.md
@@ -1,7 +1,7 @@
 # Optional LV2 editor host
 
 The default .NET build does not invoke make or require a C compiler.
-Plugins continue to use PipeWire filter-chain when the helper is absent.
+Inserts use PipeWire filter-chain by default, even when the helper is installed.
 Build and copy the optional helper with:
 
 ```sh
@@ -13,8 +13,14 @@ development headers, lilv development headers and X11 development headers.
 The helper can also be built with `make -C native` and installed beside
 the daemon separately. Distribution packages are not changed by this PR.
 
-For a supported plugin exposing an X11 editor, the live instance runs in an
-isolated PipeWire filter process. Other plugins remain in filter-chain, also
+For a supported plugin exposing an X11 editor, enable **Native host** in its
+controls window to run that insert in an isolated PipeWire filter process.
+The choice is stored as `nativeHost: true` in the insert definition; old
+settings and profiles without the field keep filter-chain. An explicitly
+selected native host that is unavailable reports an error instead of silently
+changing hosts. Disable the choice to return to filter-chain. Switching hosts
+rebuilds the chain and can briefly interrupt audio.
+Other inserts remain in filter-chain, also
 inside mixed chains. The existing generated controls window gains a Plugin UI
 button when the daemon advertises an available native editor. On Wayland the
 editor requires XWayland. The catalog checks required features on both the DSP

--- a/native/README.md
+++ b/native/README.md
@@ -1,77 +1,76 @@
 # Optional LV2 editor host
 
-The default .NET build does not invoke make or require a C compiler.
-Inserts use PipeWire filter-chain by default, even when the helper is installed.
-Build and copy the optional helper with:
+`lv2-host.c` builds `openxlr-lv2-host`, a small process that loads one LV2
+plugin, gives it PipeWire ports and, on request, opens the plugin's own X11
+editor on that live instance. It exists because a plugin's editor talks to its
+DSP instance directly (LV2 instance access), which a PipeWire filter chain
+cannot offer.
+
+Nothing here is built by default, and installing it changes nothing on its
+own: inserts use the filter chain until an insert is explicitly switched to
+the native host in its controls window.
+
+## Build
 
 ```sh
 dotnet build src/OpenXLR.slnx -c Release -p:EnableNativeLv2Host=true
 ```
 
-Native build dependencies are a C11 compiler, make, pkg-config, PipeWire
-development headers, lilv development headers and X11 development headers.
-The helper can also be built with `make -C native` and installed beside
-the daemon separately. Distribution packages are not changed by this PR.
+The flag compiles this directory and copies the helper next to the daemon.
+`make -C native` builds it alone. It needs a C11 compiler, make, pkg-config
+and the development files for PipeWire, lilv, LV2 and X11.
 
-For a supported plugin exposing an X11 editor, enable **Native host** in its
-controls window to run that insert in an isolated PipeWire filter process.
-The choice is stored as `nativeHost: true` in the insert definition; old
-settings and profiles without the field keep filter-chain. An explicitly
-selected native host that is unavailable reports an error instead of silently
-changing hosts. Disable the choice to return to filter-chain. Switching hosts
-rebuilds the chain and can briefly interrupt audio.
-Other inserts remain in filter-chain, also
-inside mixed chains. The existing generated controls window gains a Plugin UI
-button when the daemon advertises an available native editor. On Wayland the
-editor requires XWayland. The catalog checks required features on both the DSP
-and the selected X11 UI before advertising the editor. The live insert status
-also reports whether its native host is running, so a failed or bypassed chain
-cannot offer an editor action that will only fail. Unsupported requirements are
-never silently accepted; the existing upstream API feature gate remains in place.
+## What it does
 
-Control edits return through the helper pipe and are saved by the normal
-daemon settings path. Plugin output-control meters are included in insert status.
-Audio buffers never cross managed code or the command pipe.
+- One process per insert, holding one plugin instance and its editor.
+- Audio stays in PipeWire: the process is a `pw_filter` with the plugin's
+  ports. Samples never cross the command pipe or managed code.
+- The pipe carries control values only, in both directions. What the editor
+  changes comes back and is saved with the mixer, like any other control.
+- The daemon owns the process. Closing its stdin ends the helper, which is
+  why it watches that pipe rather than using PDEATHSIG, whose Linux semantics
+  follow the thread that spawned it.
 
-## Desktop session environment with the packaged user service
+## What it will not do to your audio
 
-The user service can start before the desktop publishes its X11 environment.
-The helper inherits the daemon's environment; it does not search other sessions
-or guess a display/cookie. From a terminal **inside the active graphical session**,
-import its values before restarting the daemon:
+The whole point is that an editor cannot cost you the microphone.
+
+- A protocol error from the editor is logged and the plugin keeps running.
+  Xlib's default handler would have exited the process.
+- A lost X connection drops the editor and leaves the plugin processing.
+  Verified by asking the X server to close the helper's connection while an
+  editor was open: the process kept its heartbeat, kept its ports, and opened
+  a fresh editor on request. The same test on a build without the handlers
+  killed the process immediately.
+- An editor that stops answering freezes that insert's controls and says so.
+  Its audio continues, and the daemon does not rebuild the chain for it.
+- A chain that dies on its own is rebuilt, until it has failed three times
+  within five minutes; then it is left off with the reason on the insert,
+  because every rebuild of an input chain interrupts the microphone. Changing
+  or bypassing the chain starts it over.
+
+## Session environment
+
+The editor needs an X11 display, so XWayland on a Wayland desktop. The helper
+inherits the daemon's environment and does not go looking for a session. A
+user service that started before the desktop published its display has none,
+which shows up as an editor that will not open. From a terminal inside the
+graphical session:
 
 ```sh
 systemctl --user import-environment DISPLAY XAUTHORITY
 systemctl --user restart openxlr-daemon.service
 ```
 
-The restart briefly interrupts audio. Repeat the import at graphical login (or
-use the desktop's session-start integration), especially when XWayland assigns
-a new display. Check that DISPLAY is set and that XAUTHORITY, when set, points
-to a readable cookie file. GDM/SDDM often use a file under `/run/user/...`, not
-`~/.Xauthority`; use the session's value, not a copied or guessed cookie. Never
-use `xhost +` to bypass authentication.
+The restart interrupts audio for a moment. Repeat it after a graphical login
+that assigns a new display. `XAUTHORITY`, when set, has to point at a cookie
+file the daemon can read; display managers commonly put it under `/run/user`.
+Use the session's own value rather than a copy, and never `xhost +`.
 
-The packaged unit also enables `PrivateTmp`. For a filesystem X11 socket that
-is hidden by that setting, create a **user override** with
-`systemctl --user edit openxlr-daemon.service`:
+## Scope
 
-```ini
-[Service]
-PrivateTmp=false
-```
-
-Then run `systemctl --user daemon-reload` and restart after the import above.
-This optional override reduces temporary-directory isolation; the shipped unit
-is unchanged. Do not disable other hardening. On Wayland, XWayland must be
-running. These steps describe setup, not acceptance on GDM/SDDM hardware.
-
-The helper observes the daemon-owned stdin pipe for EOF/HUP instead of using
-PDEATHSIG, whose Linux semantics tie it to the creating thread. A separate
-monitor thread reports audio progress; the UI loop reports UI progress.
-A stalled editor does not by itself make the DSP process unhealthy.
-
-The host currently implements URID map/unmap for DSP and the X11 editor
-features used by this implementation. Worker, state/preset, VST3 and CLAP
-support are separate work. Changing chains still uses the existing rebuild
-mechanism; seamless swapping is not claimed.
+URID map and unmap for the plugin, and the X11 editor features this host
+implements: instance access, parent, resize and the idle interface. Worker
+threads, state and presets, and the VST and CLAP formats are separate work.
+Changing an insert's host rebuilds its chain; nothing here swaps a plugin
+without a gap.

--- a/native/lv2-host.c
+++ b/native/lv2-host.c
@@ -1,0 +1,649 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// One isolated LV2 instance, its PipeWire ports and its optional X11 UI.
+// The audio callback never allocates, logs, performs IPC, or calls the UI.
+#define _POSIX_C_SOURCE 200809L
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <lilv/lilv.h>
+#include <lv2/atom/atom.h>
+#include <lv2/atom/util.h>
+#include <lv2/instance-access/instance-access.h>
+#include <lv2/ui/ui.h>
+#include <lv2/urid/urid.h>
+#include <math.h>
+#include <pipewire/filter.h>
+#include <pipewire/pipewire.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <poll.h>
+#include <time.h>
+#include <unistd.h>
+
+enum {
+  MAX_PORTS = 2048,
+  MAX_FRAMES = 8192,
+  ATOM_CAPACITY = 65536,
+  MAX_URIS = 4096
+};
+typedef struct {
+  bool input, audio, control, atom;
+  const char *symbol;
+  float value, minimum, maximum, reported;
+  _Atomic float desired, observed;
+  void *pw_port;
+  float *samples;
+  float *dsp_buffer; // borrowed for one process callback; dequeue exactly once
+  LV2_Atom_Sequence *sequence;
+} Port;
+
+typedef struct {
+  LilvWorld *world;
+  const LilvPlugin *plugin;
+  LilvInstance *instance;
+  Port *ports;
+  uint32_t count, rate;
+  const char *node_name;
+  struct pw_main_loop *loop;
+  struct pw_filter *filter;
+  struct spa_source *timer;
+  _Atomic bool audio_error;
+  _Atomic uint64_t completed_cycles;
+  unsigned heartbeat_ticks;
+  _Atomic bool streaming, monitor_stop;
+  char *uris[MAX_URIS];
+  _Atomic uint32_t uri_count;
+  pthread_t main_thread;
+  LV2_URID_Map map;
+  LV2_URID_Unmap unmap;
+  LV2_URID sequence_type;
+  Display *display;
+  Window window;
+  Atom close_message;
+  void *ui_library;
+  const LV2UI_Descriptor *ui_descriptor;
+  const LV2UI_Idle_Interface *idle;
+  LV2UI_Handle ui;
+  LV2UI_Resize resize;
+  char input[16384];
+  size_t input_size;
+  int exit_code;
+} Host;
+
+// LV2 calls URI mapping during instantiation; these IDs remain stable until
+// instance destruction. UIs use instance-access, not a second DSP instance.
+static LV2_URID map_uri(LV2_URID_Map_Handle handle, const char *uri) {
+  Host *h = handle;
+  uint32_t count = atomic_load(&h->uri_count);
+  for (uint32_t i = 0; i < count; ++i)
+    if (!strcmp(h->uris[i], uri))
+      return i + 1;
+  if (count == MAX_URIS || !pthread_equal(pthread_self(), h->main_thread))
+    return 0;
+  char *copy = strdup(uri);
+  if (!copy)
+    return 0;
+  h->uris[count] = copy;
+  atomic_store(&h->uri_count, count + 1);
+  return count + 1;
+}
+
+static const char *unmap_uri(LV2_URID_Unmap_Handle handle, LV2_URID id) {
+  Host *h = handle;
+  return id && id <= h->uri_count ? h->uris[id - 1] : NULL;
+}
+
+static bool required_features_supported(const LilvNodes *required, bool ui) {
+  if (!required)
+    return true;
+  LILV_FOREACH(nodes, i, required) {
+    const char *uri = lilv_node_as_uri(lilv_nodes_get(required, i));
+    if (!uri)
+      return false;
+    if (!strcmp(uri, LV2_URID__map) || !strcmp(uri, LV2_URID__unmap))
+      continue;
+    if (ui && (!strcmp(uri, LV2_INSTANCE_ACCESS_URI) ||
+               !strcmp(uri, LV2_UI__parent) || !strcmp(uri, LV2_UI__resize) ||
+               !strcmp(uri, LV2_UI__idleInterface)))
+      continue;
+    fprintf(stderr, "unsupported required LV2 feature: %s\n", uri);
+    return false;
+  }
+  return true;
+}
+
+static void process_audio(void *data, struct spa_io_position *position) {
+  Host *h = data;
+  uint32_t frames = position->clock.duration;
+  if (frames > MAX_FRAMES || position->clock.rate.denom != h->rate) {
+    atomic_store(&h->audio_error, true);
+    for (uint32_t i = 0; i < h->count; ++i) {
+      Port *p = &h->ports[i];
+      if (p->audio && !p->input && p->pw_port) {
+        float *out = pw_filter_get_dsp_buffer(p->pw_port, frames);
+        if (out)
+          memset(out, 0, sizeof(float) * frames);
+      }
+    }
+    return;
+  }
+  for (uint32_t i = 0; i < h->count; ++i) {
+    Port *p = &h->ports[i];
+    if (p->audio) {
+      float *buffer =
+          p->pw_port ? pw_filter_get_dsp_buffer(p->pw_port, frames) : NULL;
+      p->dsp_buffer = buffer;
+      if (p->input) {
+        if (buffer)
+          memcpy(p->samples, buffer, frames * sizeof(float));
+        else
+          memset(p->samples, 0, frames * sizeof(float));
+      }
+    } else if (p->control && p->input)
+      p->value = atomic_load(&p->desired);
+    else if (p->atom) {
+      p->sequence->atom.type = h->sequence_type;
+      p->sequence->atom.size = p->input ? sizeof(LV2_Atom_Sequence_Body)
+                                        : ATOM_CAPACITY - sizeof(LV2_Atom);
+      p->sequence->body.unit = 0;
+      p->sequence->body.pad = 0;
+    }
+  }
+  lilv_instance_run(h->instance, frames);
+  for (uint32_t i = 0; i < h->count; ++i) {
+    Port *p = &h->ports[i];
+    if (p->audio && !p->input && p->pw_port) {
+      float *buffer = p->dsp_buffer;
+      if (buffer)
+        memcpy(buffer, p->samples, frames * sizeof(float));
+    } else if (p->control)
+      atomic_store(&p->observed, p->value);
+  }
+  atomic_fetch_add(&h->completed_cycles, 1);
+}
+
+static void state_changed(void *data, enum pw_filter_state old,
+                          enum pw_filter_state state, const char *error) {
+  Host *h = data;
+  h->streaming = state == PW_FILTER_STATE_STREAMING;
+  if (state == PW_FILTER_STATE_ERROR) {
+    fprintf(stderr, "PipeWire: %s\n", error ? error : "disconnected");
+    h->exit_code = 1;
+    pw_main_loop_quit(h->loop);
+  } else if (state == PW_FILTER_STATE_PAUSED)
+    puts("ready");
+}
+
+static const struct pw_filter_events filter_events = {
+    PW_VERSION_FILTER_EVENTS, .state_changed = state_changed,
+    .process = process_audio};
+
+static void close_ui(Host *h) {
+  if (h->ui)
+    h->ui_descriptor->cleanup(h->ui);
+  h->ui = NULL;
+  h->idle = NULL;
+  if (h->display) {
+    if (h->window)
+      XDestroyWindow(h->display, h->window);
+    XCloseDisplay(h->display);
+  }
+  h->display = NULL;
+  h->window = 0;
+  // Some plugin toolkits retain process-global resources: keep their library
+  // resident until process exit, as permitted by LV2 ui:makeSONameResident.
+}
+
+static void ui_write(LV2UI_Controller controller, uint32_t index, uint32_t size,
+                     uint32_t format, const void *buffer) {
+  Host *h = controller;
+  if (index >= h->count || format != 0 || size != sizeof(float))
+    return;
+  Port *p = &h->ports[index];
+  float value = *(const float *)buffer;
+  if (!p->input || !p->control || !isfinite(value))
+    return;
+  value = fminf(p->maximum, fmaxf(p->minimum, value));
+  atomic_store(&p->desired, value);
+  printf("control %s %.9g\n", p->symbol, value);
+}
+
+static int ui_resize(LV2UI_Feature_Handle handle, int width, int height) {
+  Host *h = handle;
+  if (!h->display || !h->window || width < 1 || height < 1 || width > 16384 ||
+      height > 16384)
+    return 1;
+  XResizeWindow(h->display, h->window, (unsigned)width, (unsigned)height);
+  return 0;
+}
+
+static bool open_ui(Host *h) {
+  if (h->ui) {
+    XMapRaised(h->display, h->window);
+    return true;
+  }
+  LilvUIs *uis = lilv_plugin_get_uis(h->plugin);
+  LilvNode *x11 = lilv_new_uri(h->world, LV2_UI__X11UI);
+  const LilvUI *selected = NULL;
+  LILV_FOREACH(uis, i, uis) {
+    const LilvUI *candidate = lilv_uis_get(uis, i);
+    if (lilv_ui_is_a(candidate, x11)) {
+      selected = candidate;
+      break;
+    }
+  }
+  lilv_node_free(x11);
+  if (!selected) {
+    lilv_uis_free(uis);
+    return false;
+  }
+  LilvNode *required_predicate =
+      lilv_new_uri(h->world, LV2_CORE__requiredFeature);
+  LilvNodes *required = lilv_world_find_nodes(
+      h->world, lilv_ui_get_uri(selected), required_predicate, NULL);
+  bool supported = required_features_supported(required, true);
+  lilv_nodes_free(required);
+  lilv_node_free(required_predicate);
+  if (!supported) {
+    lilv_uis_free(uis);
+    return false;
+  }
+  char *binary = lilv_file_uri_parse(
+      lilv_node_as_uri(lilv_ui_get_binary_uri(selected)), NULL);
+  char *bundle = lilv_file_uri_parse(
+      lilv_node_as_uri(lilv_ui_get_bundle_uri(selected)), NULL);
+  if (!h->ui_library)
+    h->ui_library = dlopen(binary, RTLD_NOW | RTLD_LOCAL);
+  const LV2UI_Descriptor *(*descriptor)(uint32_t) =
+      h->ui_library ? dlsym(h->ui_library, "lv2ui_descriptor") : NULL;
+  h->ui_descriptor = NULL;
+  if (descriptor)
+    for (uint32_t i = 0;; ++i) {
+      const LV2UI_Descriptor *d = descriptor(i);
+      if (!d)
+        break;
+      if (!strcmp(d->URI, lilv_node_as_uri(lilv_ui_get_uri(selected)))) {
+        h->ui_descriptor = d;
+        break;
+      }
+    }
+  h->display = h->ui_descriptor ? XOpenDisplay(NULL) : NULL;
+  if (h->display) {
+    h->window = XCreateSimpleWindow(h->display, DefaultRootWindow(h->display),
+                                    0, 0, 900, 600, 0, 0, 0x16181d);
+    XStoreName(h->display, h->window, "OpenXLR - Native LV2 controls");
+    XChangeProperty(h->display, h->window,
+                    XInternAtom(h->display, "_OPENXLR_NODE", False), XA_STRING,
+                    8, PropModeReplace, (const unsigned char *)h->node_name,
+                    (int)strlen(h->node_name));
+    h->close_message = XInternAtom(h->display, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(h->display, h->window, &h->close_message, 1);
+    h->resize = (LV2UI_Resize){h, ui_resize};
+    LV2_Feature parent = {LV2_UI__parent, (void *)(uintptr_t)h->window};
+    LV2_Feature map = {LV2_URID__map, &h->map},
+                unmap = {LV2_URID__unmap, &h->unmap};
+    LV2_Feature access = {LV2_INSTANCE_ACCESS_URI,
+                          lilv_instance_get_handle(h->instance)};
+    LV2_Feature size = {LV2_UI__resize, &h->resize};
+    LV2_Feature idle = {LV2_UI__idleInterface, NULL};
+    const LV2_Feature *features[] = {&parent, &map,  &unmap, &access,
+                                     &size,   &idle, NULL};
+    LV2UI_Widget widget = NULL;
+    h->ui = h->ui_descriptor->instantiate(
+        h->ui_descriptor, lilv_node_as_uri(lilv_plugin_get_uri(h->plugin)),
+        bundle, ui_write, h, &widget, features);
+    if (h->ui) {
+      h->idle = h->ui_descriptor->extension_data
+                    ? h->ui_descriptor->extension_data(LV2_UI__idleInterface)
+                    : NULL;
+      XMapRaised(h->display, h->window);
+      XFlush(h->display);
+    }
+  }
+  lilv_free(binary);
+  lilv_free(bundle);
+  lilv_uis_free(uis);
+  if (!h->ui)
+    close_ui(h);
+  return h->ui != NULL;
+}
+
+static bool set_control(Host *h, const char *symbol, float value) {
+  if (!isfinite(value))
+    return false;
+  for (uint32_t i = 0; i < h->count; ++i) {
+    Port *p = &h->ports[i];
+    if (p->input && p->control && !strcmp(p->symbol, symbol)) {
+      atomic_store(&p->desired, fminf(p->maximum, fmaxf(p->minimum, value)));
+      return true;
+    }
+  }
+  return false;
+}
+
+static void command(Host *h, char *line) {
+  char symbol[256], extra;
+  float value;
+  if (!strcmp(line, "show"))
+    puts(open_ui(h)
+             ? "ui opened"
+             : "ui unavailable: X11 LV2 UI or display could not be opened");
+  else if (!strcmp(line, "hide"))
+    close_ui(h);
+  else if (!strcmp(line, "quit"))
+    pw_main_loop_quit(h->loop);
+  else if (sscanf(line, "set %255s %f %c", symbol, &value, &extra) == 2) {
+    if (!set_control(h, symbol, value))
+      fprintf(stderr, "invalid control: %s\n", symbol);
+  }
+}
+
+static void read_commands(void *data, int fd, uint32_t mask) {
+  Host *h = data;
+  ssize_t count =
+      read(fd, h->input + h->input_size, sizeof(h->input) - h->input_size - 1);
+  if (count == 0 || (count < 0 && errno != EAGAIN)) {
+    pw_main_loop_quit(h->loop);
+    return;
+  }
+  if (count < 0)
+    return;
+  h->input_size += (size_t)count;
+  h->input[h->input_size] = 0;
+  char *start = h->input, *end;
+  while ((end = strchr(start, '\n'))) {
+    *end = 0;
+    command(h, start);
+    start = end + 1;
+  }
+  h->input_size -= (size_t)(start - h->input);
+  memmove(h->input, start, h->input_size);
+  if (h->input_size == sizeof(h->input) - 1) {
+    h->exit_code = 1;
+    pw_main_loop_quit(h->loop);
+  }
+}
+
+static void tick(void *data, uint64_t expirations) {
+  Host *h = data;
+  // Editor progress is separate from audio progress. A blocked editor must
+  // not cause the supervisor to tear down a working audio instance.
+  if (++h->heartbeat_ticks == 30) {
+    puts("ui-heartbeat");
+    h->heartbeat_ticks = 0;
+  }
+  if (atomic_load(&h->audio_error)) {
+    fputs(
+        "unsupported audio quantum or sample-rate change; restart the chain\n",
+        stderr);
+    h->exit_code = 1;
+    pw_main_loop_quit(h->loop);
+    return;
+  }
+  if (h->ui) {
+    while (XPending(h->display)) {
+      XEvent event;
+      XNextEvent(h->display, &event);
+      if (event.type == ClientMessage &&
+          (Atom)event.xclient.data.l[0] == h->close_message) {
+        close_ui(h);
+        break;
+      }
+    }
+  }
+  for (uint32_t i = 0; i < h->count; ++i) {
+    Port *p = &h->ports[i];
+    if (!p->control)
+      continue;
+    float value =
+        p->input ? atomic_load(&p->desired) : atomic_load(&p->observed);
+    if (h->ui && h->ui_descriptor->port_event)
+      h->ui_descriptor->port_event(h->ui, i, sizeof(float), 0, &value);
+    if (!p->input && isfinite(value) && value != p->reported) {
+      printf("meter %s %.9g\n", p->symbol, value);
+      p->reported = value;
+    }
+  }
+  if (h->ui && h->idle && h->idle->idle(h->ui))
+    close_ui(h);
+}
+
+static void stop(void *data, int signal) {
+  pw_main_loop_quit(((Host *)data)->loop);
+}
+
+static void *monitor_audio(void *data) {
+  Host *h = data;
+  uint64_t last_cycles = 0;
+  while (!atomic_load(&h->monitor_stop)) {
+    // The redirected input pipe belongs to the daemon process, unlike
+    // PDEATHSIG, which follows the short-lived .NET thread that spawned us.
+    // Observe HUP without consuming commands; also works with a stuck UI.
+    struct pollfd input = {STDIN_FILENO, POLLHUP | POLLERR, 0};
+    if (poll(&input, 1, 1000) > 0 && (input.revents & (POLLHUP | POLLERR)))
+      _exit(0);
+    uint64_t cycles = atomic_load(&h->completed_cycles);
+    if (!atomic_load(&h->streaming) || cycles != last_cycles)
+      puts("heartbeat");
+    last_cycles = cycles;
+  }
+  return NULL;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 5) {
+    fputs("usage: openxlr-lv2-host URI NODE CHANNELS RATE [SYMBOL=VALUE ...]\n",
+          stderr);
+    return 2;
+  }
+  int channels = atoi(argv[3]);
+  Host h = {.rate = (uint32_t)strtoul(argv[4], NULL, 10),
+            .node_name = argv[2],
+            .main_thread = pthread_self()};
+  if (channels < 1 || channels > 2 || h.rate < 8000 || h.rate > 384000)
+    return 2;
+  setvbuf(stdout, NULL, _IOLBF, 0);
+  h.world = lilv_world_new();
+  if (!h.world)
+    return 1;
+  lilv_world_load_all(h.world);
+  LilvNode *uri = lilv_new_uri(h.world, argv[1]);
+  h.plugin = lilv_plugins_get_by_uri(lilv_world_get_all_plugins(h.world), uri);
+  lilv_node_free(uri);
+  if (!h.plugin) {
+    fputs("plugin is not installed\n", stderr);
+    lilv_world_free(h.world);
+    return 1;
+  }
+  LilvNodes *required = lilv_plugin_get_required_features(h.plugin);
+  bool supported = required_features_supported(required, false);
+  lilv_nodes_free(required);
+  if (!supported) {
+    lilv_world_free(h.world);
+    return 1;
+  }
+  h.count = lilv_plugin_get_num_ports(h.plugin);
+  if (!h.count || h.count > MAX_PORTS) {
+    lilv_world_free(h.world);
+    return 1;
+  }
+  h.map = (LV2_URID_Map){&h, map_uri};
+  h.unmap = (LV2_URID_Unmap){&h, unmap_uri};
+  LV2_Feature map = {LV2_URID__map, &h.map},
+              unmap = {LV2_URID__unmap, &h.unmap};
+  const LV2_Feature *features[] = {&map, &unmap, NULL};
+  h.sequence_type = map_uri(&h, LV2_ATOM__Sequence);
+  h.instance = lilv_plugin_instantiate(h.plugin, h.rate, features);
+  if (!h.instance) {
+    fputs("LV2 instantiation failed\n", stderr);
+    h.exit_code = 1;
+    goto cleanup;
+  }
+  h.ports = calloc(h.count, sizeof(Port));
+  float *ranges = calloc(h.count * 3, sizeof(float));
+  if (!h.ports || !ranges) {
+    free(ranges);
+    h.exit_code = 1;
+    goto cleanup;
+  }
+  lilv_plugin_get_port_ranges_float(h.plugin, ranges, ranges + h.count,
+                                    ranges + 2 * h.count);
+  LilvNode *input = lilv_new_uri(h.world, LV2_CORE__InputPort),
+           *audio = lilv_new_uri(h.world, LV2_CORE__AudioPort);
+  LilvNode *control = lilv_new_uri(h.world, LV2_CORE__ControlPort),
+           *atom = lilv_new_uri(h.world, LV2_ATOM__AtomPort);
+  LilvNode *optional = lilv_new_uri(h.world, LV2_CORE__connectionOptional);
+  pw_init(NULL, NULL);
+  h.loop = pw_main_loop_new(NULL);
+  if (!h.loop) {
+    h.exit_code = 1;
+    goto ports_done;
+  }
+  char rate[32];
+  snprintf(rate, sizeof(rate), "1/%u", h.rate);
+  h.filter = pw_filter_new_simple(
+      pw_main_loop_get_loop(h.loop), argv[2],
+      pw_properties_new(PW_KEY_NODE_NAME, argv[2], PW_KEY_NODE_DESCRIPTION,
+                        "OpenXLR LV2", PW_KEY_MEDIA_TYPE, "Audio",
+                        PW_KEY_MEDIA_CATEGORY, "Filter", PW_KEY_MEDIA_ROLE,
+                        "DSP", PW_KEY_NODE_RATE, rate, "node.lock-rate", "true",
+                        "node.autoconnect", "false", NULL),
+      &filter_events, &h);
+  if (!h.filter) {
+    h.exit_code = 1;
+    goto ports_done;
+  }
+  unsigned ins = 0, outs = 0;
+  for (uint32_t i = 0; i < h.count; ++i) {
+    Port *p = &h.ports[i];
+    const LilvPort *port = lilv_plugin_get_port_by_index(h.plugin, i);
+    p->symbol = lilv_node_as_string(lilv_port_get_symbol(h.plugin, port));
+    p->input = lilv_port_is_a(h.plugin, port, input);
+    p->audio = lilv_port_is_a(h.plugin, port, audio);
+    p->control = lilv_port_is_a(h.plugin, port, control);
+    p->atom = lilv_port_is_a(h.plugin, port, atom);
+    if (p->audio) {
+      p->samples = calloc(MAX_FRAMES, sizeof(float));
+      if (!p->samples) {
+        h.exit_code = 1;
+        break;
+      }
+      lilv_instance_connect_port(h.instance, i, p->samples);
+      unsigned index = p->input ? ins++ : outs++;
+      if (index < (unsigned)channels) {
+        char name[32];
+        snprintf(name, sizeof(name), "%s_%u", p->input ? "playback" : "capture",
+                 index);
+        p->pw_port = pw_filter_add_port(
+            h.filter, p->input ? PW_DIRECTION_INPUT : PW_DIRECTION_OUTPUT,
+            PW_FILTER_PORT_FLAG_MAP_BUFFERS, 1,
+            pw_properties_new(PW_KEY_FORMAT_DSP, "32 bit float mono audio",
+                              PW_KEY_PORT_NAME, name, PW_KEY_AUDIO_CHANNEL,
+                              channels == 1 ? "MONO"
+                              : index == 0  ? "FL"
+                                            : "FR",
+                              NULL),
+            NULL, 0);
+        if (!p->pw_port) {
+          h.exit_code = 1;
+          break;
+        }
+      }
+    } else if (p->control) {
+      p->minimum = isfinite(ranges[i]) ? ranges[i] : -1e10f;
+      p->maximum = isfinite(ranges[i + h.count]) ? ranges[i + h.count] : 1e10f;
+      p->value =
+          isfinite(ranges[i + 2 * h.count]) ? ranges[i + 2 * h.count] : 0;
+      atomic_init(&p->desired, p->value);
+      atomic_init(&p->observed, p->value);
+      p->reported = NAN;
+      lilv_instance_connect_port(h.instance, i, &p->value);
+    } else if (p->atom) {
+      p->sequence = calloc(1, ATOM_CAPACITY);
+      if (!p->sequence) {
+        h.exit_code = 1;
+        break;
+      }
+      lilv_instance_connect_port(h.instance, i, p->sequence);
+    } else if (lilv_port_has_property(h.plugin, port, optional))
+      lilv_instance_connect_port(h.instance, i, NULL);
+    else {
+      fprintf(stderr, "unsupported required LV2 port: %s\n", p->symbol);
+      h.exit_code = 1;
+      break;
+    }
+  }
+ports_done:
+  lilv_node_free(input);
+  lilv_node_free(audio);
+  lilv_node_free(control);
+  lilv_node_free(atom);
+  lilv_node_free(optional);
+  free(ranges);
+  if (h.exit_code)
+    goto cleanup;
+  for (int i = 5; i < argc; ++i) {
+    char *equals = strchr(argv[i], '=');
+    if (!equals) {
+      h.exit_code = 2;
+      goto cleanup;
+    }
+    *equals = 0;
+    char *end;
+    float value = strtof(equals + 1, &end);
+    if (*end || !set_control(&h, argv[i], value)) {
+      h.exit_code = 2;
+      goto cleanup;
+    }
+  }
+  lilv_instance_activate(h.instance);
+  if (pw_filter_connect(h.filter, PW_FILTER_FLAG_RT_PROCESS, NULL, 0) < 0) {
+    h.exit_code = 1;
+    goto deactivate;
+  }
+  fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
+  struct pw_loop *loop = pw_main_loop_get_loop(h.loop);
+  pw_loop_add_io(loop, STDIN_FILENO, SPA_IO_IN | SPA_IO_HUP, false,
+                 read_commands, &h);
+  h.timer = pw_loop_add_timer(loop, tick, &h);
+  struct timespec interval = {0, 33333333};
+  pw_loop_update_timer(loop, h.timer, &interval, &interval, false);
+  pw_loop_add_signal(loop, SIGTERM, stop, &h);
+  pw_loop_add_signal(loop, SIGINT, stop, &h);
+  pthread_t monitor;
+  if (pthread_create(&monitor, NULL, monitor_audio, &h)) {
+    h.exit_code = 1;
+    goto deactivate;
+  }
+  pw_main_loop_run(h.loop);
+  atomic_store(&h.monitor_stop, true);
+  pthread_join(monitor, NULL);
+  pw_filter_disconnect(h.filter);
+deactivate:
+  lilv_instance_deactivate(h.instance);
+cleanup:
+  close_ui(&h);
+  if (h.filter)
+    pw_filter_destroy(h.filter);
+  if (h.loop)
+    pw_main_loop_destroy(h.loop);
+  if (h.instance)
+    lilv_instance_free(h.instance);
+  if (h.ports)
+    for (uint32_t i = 0; i < h.count; ++i) {
+      free(h.ports[i].samples);
+      free(h.ports[i].sequence);
+    }
+  free(h.ports);
+  for (uint32_t i = 0; i < h.uri_count; ++i)
+    free(h.uris[i]);
+  lilv_world_free(h.world);
+  return h.exit_code;
+}

--- a/native/lv2-host.c
+++ b/native/lv2-host.c
@@ -17,6 +17,7 @@
 #include <pipewire/filter.h>
 #include <pipewire/pipewire.h>
 #include <pthread.h>
+#include <setjmp.h>
 #include <signal.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -55,9 +56,8 @@ typedef struct {
   struct pw_filter *filter;
   struct spa_source *timer;
   _Atomic bool audio_error;
-  _Atomic uint64_t completed_cycles;
   unsigned heartbeat_ticks;
-  _Atomic bool streaming, monitor_stop;
+  _Atomic bool monitor_stop;
   char *uris[MAX_URIS];
   _Atomic uint32_t uri_count;
   pthread_t main_thread;
@@ -166,13 +166,11 @@ static void process_audio(void *data, struct spa_io_position *position) {
     } else if (p->control)
       atomic_store(&p->observed, p->value);
   }
-  atomic_fetch_add(&h->completed_cycles, 1);
 }
 
 static void state_changed(void *data, enum pw_filter_state old,
                           enum pw_filter_state state, const char *error) {
   Host *h = data;
-  h->streaming = state == PW_FILTER_STATE_STREAMING;
   if (state == PW_FILTER_STATE_ERROR) {
     fprintf(stderr, "PipeWire: %s\n", error ? error : "disconnected");
     h->exit_code = 1;
@@ -185,20 +183,60 @@ static const struct pw_filter_events filter_events = {
     PW_VERSION_FILTER_EVENTS, .state_changed = state_changed,
     .process = process_audio};
 
-static void close_ui(Host *h) {
-  if (h->ui)
-    h->ui_descriptor->cleanup(h->ui);
+// Xlib exits the process on both of its error paths: the default protocol
+// error handler calls exit, and so does a lost connection to the display.
+// Either would take an insert's audio down with its editor, which is the one
+// thing this host exists to prevent. A protocol error is logged and the
+// editor carries on. A lost connection cannot be resumed, so it jumps back to
+// whichever call armed the escape; that call drops the editor and returns,
+// leaving the plugin instance processing audio.
+static sigjmp_buf x_escape;
+static volatile sig_atomic_t x_escape_armed;
+
+static int report_x_error(Display *display, XErrorEvent *event) {
+  char text[256];
+  XGetErrorText(display, event->error_code, text, sizeof(text));
+  fprintf(stderr, "editor X11 error: %s (request %u)\n", text,
+          event->request_code);
+  return 0;
+}
+
+static int lost_x_connection(Display *display) {
+  if (x_escape_armed) {
+    x_escape_armed = 0;
+    siglongjmp(x_escape, 1);
+  }
+  // Xlib only calls this from inside one of its own functions, and every one
+  // this host calls is armed. Leave rather than return: Xlib exits either way.
+  _exit(1);
+}
+
+// Drop the editor without talking to X, for a connection that is already
+// gone. The plugin's UI instance cannot be cleaned up through a dead
+// connection, so it and its library stay until this process exits, which LV2
+// permits (ui:makeSONameResident).
+static void forget_ui(Host *h) {
   h->ui = NULL;
   h->idle = NULL;
-  if (h->display) {
+  h->display = NULL;
+  h->window = 0;
+}
+
+static void close_ui(Host *h) {
+  if (!h->display) {
+    forget_ui(h);
+    return;
+  }
+  if (sigsetjmp(x_escape, 0) == 0) {
+    x_escape_armed = 1;
+    if (h->ui)
+      h->ui_descriptor->cleanup(h->ui);
     if (h->window)
       XDestroyWindow(h->display, h->window);
     XCloseDisplay(h->display);
   }
-  h->display = NULL;
-  h->window = 0;
-  // Some plugin toolkits retain process-global resources: keep their library
-  // resident until process exit, as permitted by LV2 ui:makeSONameResident.
+  x_escape_armed = 0;
+  forget_ui(h);
 }
 
 static void ui_write(LV2UI_Controller controller, uint32_t index, uint32_t size,
@@ -224,11 +262,71 @@ static int ui_resize(LV2UI_Feature_Handle handle, int width, int height) {
   return 0;
 }
 
-static bool open_ui(Host *h) {
-  if (h->ui) {
-    XMapRaised(h->display, h->window);
-    return true;
+// Raise a window that is already up. A failure here is a lost connection.
+static bool raise_ui(Host *h) {
+  if (sigsetjmp(x_escape, 0)) {
+    x_escape_armed = 0;
+    forget_ui(h);
+    return false;
   }
+  x_escape_armed = 1;
+  XMapRaised(h->display, h->window);
+  XFlush(h->display);
+  x_escape_armed = 0;
+  return true;
+}
+
+/// Open the window and hand it to the plugin. Every X call of the editor's
+/// lifetime starts here or in the tick below, both of them guarded.
+/// Open the window and hand it to the plugin. Every X call of the editor's
+/// life happens here, in raise_ui or in the tick, and all three are guarded.
+static bool open_editor_window(Host *h, const char *bundle) {
+  if (sigsetjmp(x_escape, 0)) {
+    x_escape_armed = 0;
+    forget_ui(h);
+    return false;
+  }
+  x_escape_armed = 1;
+  h->display = XOpenDisplay(NULL);
+  if (h->display) {
+    h->window = XCreateSimpleWindow(h->display, DefaultRootWindow(h->display),
+                                    0, 0, 900, 600, 0, 0, 0x16181d);
+    XStoreName(h->display, h->window, "OpenXLR - Native LV2 controls");
+    XChangeProperty(h->display, h->window,
+                    XInternAtom(h->display, "_OPENXLR_NODE", False), XA_STRING,
+                    8, PropModeReplace, (const unsigned char *)h->node_name,
+                    (int)strlen(h->node_name));
+    h->close_message = XInternAtom(h->display, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(h->display, h->window, &h->close_message, 1);
+    h->resize = (LV2UI_Resize){h, ui_resize};
+    LV2_Feature parent = {LV2_UI__parent, (void *)(uintptr_t)h->window};
+    LV2_Feature map = {LV2_URID__map, &h->map},
+                unmap = {LV2_URID__unmap, &h->unmap};
+    LV2_Feature access = {LV2_INSTANCE_ACCESS_URI,
+                          lilv_instance_get_handle(h->instance)};
+    LV2_Feature size = {LV2_UI__resize, &h->resize};
+    LV2_Feature idle = {LV2_UI__idleInterface, NULL};
+    const LV2_Feature *features[] = {&parent, &map,  &unmap, &access,
+                                     &size,   &idle, NULL};
+    LV2UI_Widget widget = NULL;
+    h->ui = h->ui_descriptor->instantiate(
+        h->ui_descriptor, lilv_node_as_uri(lilv_plugin_get_uri(h->plugin)),
+        bundle, ui_write, h, &widget, features);
+    if (h->ui) {
+      h->idle = h->ui_descriptor->extension_data
+                    ? h->ui_descriptor->extension_data(LV2_UI__idleInterface)
+                    : NULL;
+      XMapRaised(h->display, h->window);
+      XFlush(h->display);
+    }
+  }
+  x_escape_armed = 0;
+  return h->ui != NULL;
+}
+
+static bool open_ui(Host *h) {
+  if (h->ui)
+    return raise_ui(h);
   LilvUIs *uis = lilv_plugin_get_uis(h->plugin);
   LilvNode *x11 = lilv_new_uri(h->world, LV2_UI__X11UI);
   const LilvUI *selected = NULL;
@@ -274,39 +372,8 @@ static bool open_ui(Host *h) {
         break;
       }
     }
-  h->display = h->ui_descriptor ? XOpenDisplay(NULL) : NULL;
-  if (h->display) {
-    h->window = XCreateSimpleWindow(h->display, DefaultRootWindow(h->display),
-                                    0, 0, 900, 600, 0, 0, 0x16181d);
-    XStoreName(h->display, h->window, "OpenXLR - Native LV2 controls");
-    XChangeProperty(h->display, h->window,
-                    XInternAtom(h->display, "_OPENXLR_NODE", False), XA_STRING,
-                    8, PropModeReplace, (const unsigned char *)h->node_name,
-                    (int)strlen(h->node_name));
-    h->close_message = XInternAtom(h->display, "WM_DELETE_WINDOW", False);
-    XSetWMProtocols(h->display, h->window, &h->close_message, 1);
-    h->resize = (LV2UI_Resize){h, ui_resize};
-    LV2_Feature parent = {LV2_UI__parent, (void *)(uintptr_t)h->window};
-    LV2_Feature map = {LV2_URID__map, &h->map},
-                unmap = {LV2_URID__unmap, &h->unmap};
-    LV2_Feature access = {LV2_INSTANCE_ACCESS_URI,
-                          lilv_instance_get_handle(h->instance)};
-    LV2_Feature size = {LV2_UI__resize, &h->resize};
-    LV2_Feature idle = {LV2_UI__idleInterface, NULL};
-    const LV2_Feature *features[] = {&parent, &map,  &unmap, &access,
-                                     &size,   &idle, NULL};
-    LV2UI_Widget widget = NULL;
-    h->ui = h->ui_descriptor->instantiate(
-        h->ui_descriptor, lilv_node_as_uri(lilv_plugin_get_uri(h->plugin)),
-        bundle, ui_write, h, &widget, features);
-    if (h->ui) {
-      h->idle = h->ui_descriptor->extension_data
-                    ? h->ui_descriptor->extension_data(LV2_UI__idleInterface)
-                    : NULL;
-      XMapRaised(h->display, h->window);
-      XFlush(h->display);
-    }
-  }
+  if (h->ui_descriptor)
+    open_editor_window(h, bundle);
   lilv_free(binary);
   lilv_free(bundle);
   lilv_uis_free(uis);
@@ -314,7 +381,6 @@ static bool open_ui(Host *h) {
     close_ui(h);
   return h->ui != NULL;
 }
-
 static bool set_control(Host *h, const char *symbol, float value) {
   if (!isfinite(value))
     return false;
@@ -371,6 +437,42 @@ static void read_commands(void *data, int fd, uint32_t mask) {
   }
 }
 
+// One pass of the editor: its events, the current control values, and the
+// toolkit's own idle work. Losing the display here costs the editor and
+// nothing else; the plugin keeps processing audio on the real-time thread.
+static void pump_editor(Host *h) {
+  if (sigsetjmp(x_escape, 0)) {
+    x_escape_armed = 0;
+    forget_ui(h);
+    fputs("editor X11 connection lost; audio continues without it\n", stderr);
+    return;
+  }
+  x_escape_armed = 1;
+  while (XPending(h->display)) {
+    XEvent event;
+    XNextEvent(h->display, &event);
+    if (event.type == ClientMessage &&
+        (Atom)event.xclient.data.l[0] == h->close_message) {
+      x_escape_armed = 0;
+      close_ui(h);
+      return;
+    }
+  }
+  if (h->ui_descriptor->port_event)
+    for (uint32_t i = 0; i < h->count; ++i) {
+      Port *p = &h->ports[i];
+      if (!p->control)
+        continue;
+      float value =
+          p->input ? atomic_load(&p->desired) : atomic_load(&p->observed);
+      h->ui_descriptor->port_event(h->ui, i, sizeof(float), 0, &value);
+    }
+  bool finished = h->idle && h->idle->idle(h->ui);
+  x_escape_armed = 0;
+  if (finished)
+    close_ui(h);
+}
+
 static void tick(void *data, uint64_t expirations) {
   Host *h = data;
   // Editor progress is separate from audio progress. A blocked editor must
@@ -387,32 +489,18 @@ static void tick(void *data, uint64_t expirations) {
     pw_main_loop_quit(h->loop);
     return;
   }
-  if (h->ui) {
-    while (XPending(h->display)) {
-      XEvent event;
-      XNextEvent(h->display, &event);
-      if (event.type == ClientMessage &&
-          (Atom)event.xclient.data.l[0] == h->close_message) {
-        close_ui(h);
-        break;
-      }
-    }
-  }
   for (uint32_t i = 0; i < h->count; ++i) {
     Port *p = &h->ports[i];
-    if (!p->control)
+    if (!p->control || p->input)
       continue;
-    float value =
-        p->input ? atomic_load(&p->desired) : atomic_load(&p->observed);
-    if (h->ui && h->ui_descriptor->port_event)
-      h->ui_descriptor->port_event(h->ui, i, sizeof(float), 0, &value);
-    if (!p->input && isfinite(value) && value != p->reported) {
+    float value = atomic_load(&p->observed);
+    if (isfinite(value) && value != p->reported) {
       printf("meter %s %.9g\n", p->symbol, value);
       p->reported = value;
     }
   }
-  if (h->ui && h->idle && h->idle->idle(h->ui))
-    close_ui(h);
+  if (h->ui)
+    pump_editor(h);
 }
 
 static void stop(void *data, int signal) {
@@ -421,7 +509,6 @@ static void stop(void *data, int signal) {
 
 static void *monitor_audio(void *data) {
   Host *h = data;
-  uint64_t last_cycles = 0;
   while (!atomic_load(&h->monitor_stop)) {
     // The redirected input pipe belongs to the daemon process, unlike
     // PDEATHSIG, which follows the short-lived .NET thread that spawned us.
@@ -429,10 +516,7 @@ static void *monitor_audio(void *data) {
     struct pollfd input = {STDIN_FILENO, POLLHUP | POLLERR, 0};
     if (poll(&input, 1, 1000) > 0 && (input.revents & (POLLHUP | POLLERR)))
       _exit(0);
-    uint64_t cycles = atomic_load(&h->completed_cycles);
-    if (!atomic_load(&h->streaming) || cycles != last_cycles)
-      puts("heartbeat");
-    last_cycles = cycles;
+    puts("heartbeat");
   }
   return NULL;
 }
@@ -450,6 +534,8 @@ int main(int argc, char **argv) {
   if (channels < 1 || channels > 2 || h.rate < 8000 || h.rate > 384000)
     return 2;
   setvbuf(stdout, NULL, _IOLBF, 0);
+  XSetErrorHandler(report_x_error);
+  XSetIOErrorHandler(lost_x_connection);
   h.world = lilv_world_new();
   if (!h.world)
     return 1;

--- a/native/lv2-host.c
+++ b/native/lv2-host.c
@@ -28,7 +28,7 @@
 #include <unistd.h>
 
 enum {
-  MAX_PORTS = 2048,
+  MAX_PORTS = 4096,
   MAX_FRAMES = 8192,
   ATOM_CAPACITY = 65536,
   MAX_URIS = 4096

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -1,11 +1,14 @@
 { lib
 , buildDotnetModule
 , dotnetCorePackages
+, gcc
+, pkg-config
 , fontconfig
 , icu
 , libpulseaudio
 , libusb1
 , lilv
+, lv2
 , pipewire
 , libx11
 , libice
@@ -36,6 +39,12 @@ buildDotnetModule {
   '';
   dotnetRestoreFlags = [ "-p:RestorePackagesWithLockFile=false" ];
   dotnetBuildFlags = [ "-p:RestorePackagesWithLockFile=false" ];
+
+  # The optional LV2 host, a small C program the daemon build compiles beside
+  # itself. Its libraries are already runtime dependencies below.
+  dotnetFlags = [ "-p:EnableNativeLv2Host=true" ];
+  nativeBuildInputs = [ gcc pkg-config ];
+  buildInputs = [ pipewire lilv lv2 libx11 ];
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
   dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;

--- a/packaging/rpm/openxlr.spec
+++ b/packaging/rpm/openxlr.spec
@@ -15,6 +15,15 @@ ExclusiveArch:  x86_64
 
 BuildRequires:  dotnet-sdk-10.0
 BuildRequires:  systemd-rpm-macros
+# The optional LV2 host is a small C program built beside the daemon. Its
+# libraries are already runtime dependencies below; only the headers are new.
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  pipewire-devel
+BuildRequires:  lilv-devel
+BuildRequires:  lv2-devel
+BuildRequires:  libX11-devel
 
 # Prebuilt .NET assemblies; dependencies are declared by hand, matching
 # the Debian and Arch packages.
@@ -58,7 +67,8 @@ interface once so the udev rule applies.
 export DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_NOLOGO=1 \
        DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 dotnet publish src/OpenXLR.Daemon -c Release -r linux-x64 \
-    --self-contained false -p:RestoreLockedMode=true -o out/daemon
+    --self-contained false -p:RestoreLockedMode=true \
+    -p:EnableNativeLv2Host=true -o out/daemon
 dotnet publish src/OpenXLR.UI -c Release -r linux-x64 \
     --self-contained false -p:RestoreLockedMode=true -o out/ui
 
@@ -69,6 +79,7 @@ cp -r out/ui %{buildroot}%{_prefix}/lib/openxlr/ui
 # dotnet publish marks assemblies executable; only the apphosts are.
 find %{buildroot}%{_prefix}/lib/openxlr -type f -exec chmod 644 {} +
 chmod 755 %{buildroot}%{_prefix}/lib/openxlr/daemon/OpenXLR.Daemon \
+    %{buildroot}%{_prefix}/lib/openxlr/daemon/openxlr-lv2-host \
     %{buildroot}%{_prefix}/lib/openxlr/ui/OpenXLR.UI
 
 install -dm755 %{buildroot}%{_bindir}

--- a/src/OpenXLR.Core/Mixing/Inserts.cs
+++ b/src/OpenXLR.Core/Mixing/Inserts.cs
@@ -28,7 +28,8 @@ public sealed record InsertDefinition
 }
 
 /// <summary>An insert as pushed to clients: its definition plus live status.</summary>
-public sealed record InsertStatus(InsertDefinition Insert, string? Error);
+public sealed record InsertStatus(InsertDefinition Insert, string? Error,
+    IReadOnlyDictionary<string, double>? Meters = null);
 
 /// <summary>A control port of a plugin, enough to build a sensible slider.</summary>
 public sealed record PluginParam(
@@ -59,4 +60,8 @@ public sealed record PluginInfo(
     public IReadOnlyList<string> UnsupportedFeatures { get; init; } = [];
 
     public bool Supported => UnsupportedFeatures.Count == 0;
+    public bool HasNativeUi { get; init; }
+    public bool NativeEditorAvailable => HasNativeUi
+        && System.IO.File.Exists(NativePluginHost.Executable)
+        && NativePluginHost.SupportsFeatures(RequiredFeatures);
 }

--- a/src/OpenXLR.Core/Mixing/Inserts.cs
+++ b/src/OpenXLR.Core/Mixing/Inserts.cs
@@ -29,7 +29,8 @@ public sealed record InsertDefinition
 
 /// <summary>An insert as pushed to clients: its definition plus live status.</summary>
 public sealed record InsertStatus(InsertDefinition Insert, string? Error,
-    IReadOnlyDictionary<string, double>? Meters = null);
+    IReadOnlyDictionary<string, double>? Meters = null,
+    bool NativeHostRunning = false);
 
 /// <summary>A control port of a plugin, enough to build a sensible slider.</summary>
 public sealed record PluginParam(
@@ -61,7 +62,10 @@ public sealed record PluginInfo(
 
     public bool Supported => UnsupportedFeatures.Count == 0;
     public bool HasNativeUi { get; init; }
+    /// <summary>Required features of the X11 UI selected by the native helper.</summary>
+    public IReadOnlyList<string> NativeUiRequiredFeatures { get; init; } = [];
     public bool NativeEditorAvailable => HasNativeUi
         && System.IO.File.Exists(NativePluginHost.Executable)
-        && NativePluginHost.SupportsFeatures(RequiredFeatures);
+        && NativePluginHost.SupportsFeatures(RequiredFeatures)
+        && NativePluginHost.SupportsUiFeatures(NativeUiRequiredFeatures);
 }

--- a/src/OpenXLR.Core/Mixing/Inserts.cs
+++ b/src/OpenXLR.Core/Mixing/Inserts.cs
@@ -23,6 +23,9 @@ public sealed record InsertDefinition
 
     public bool Bypass { get; init; }
 
+    /// <summary>Explicit opt-in; omitted in old settings and profiles means filter-chain.</summary>
+    public bool NativeHost { get; init; }
+
     /// <summary>Control values by port symbol; ports not listed keep defaults.</summary>
     public Dictionary<string, double> Params { get; init; } = [];
 }

--- a/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
+++ b/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
@@ -228,7 +228,22 @@ public static class Lv2Catalog
         return new PluginInfo("lv2", uri, name, category, audioIns, audioOuts, inSym, outSym, pars, features, inSyms, outSyms)
         {
             UnsupportedFeatures = UnsupportedFeatures(features),
+            HasNativeUi = HasX11Ui(world, plugin),
         };
+    }
+
+    private static bool HasX11Ui(IntPtr world, IntPtr plugin)
+    {
+        IntPtr uis = Lilv.lilv_plugin_get_uis(plugin);
+        if (uis == IntPtr.Zero) return false;
+        IntPtr type = Lilv.lilv_new_uri(world, "http://lv2plug.in/ns/extensions/ui#X11UI");
+        try
+        {
+            for (IntPtr it = Lilv.lilv_uis_begin(uis); !Lilv.lilv_uis_is_end(uis, it); it = Lilv.lilv_uis_next(uis, it))
+                if (Lilv.lilv_ui_is_a(Lilv.lilv_uis_get(uis, it), type)) return true;
+            return false;
+        }
+        finally { Lilv.lilv_node_free(type); Lilv.lilv_uis_free(uis); }
     }
 
     /// <summary>The slice of liblilv this catalog uses.</summary>
@@ -263,6 +278,13 @@ public static class Lv2Catalog
         [DllImport(Lib)] public static extern IntPtr lilv_plugin_get_port_by_index(IntPtr plugin, uint index);
         [DllImport(Lib)] public static extern void lilv_plugin_get_port_ranges_float(IntPtr plugin, float[] mins, float[] maxs, float[] defs);
         [DllImport(Lib)] public static extern IntPtr lilv_plugin_get_required_features(IntPtr plugin);
+        [DllImport(Lib)] public static extern IntPtr lilv_plugin_get_uis(IntPtr plugin);
+        [DllImport(Lib)] public static extern IntPtr lilv_uis_begin(IntPtr uis);
+        [DllImport(Lib)][return: MarshalAs(UnmanagedType.I1)] public static extern bool lilv_uis_is_end(IntPtr uis, IntPtr iterator);
+        [DllImport(Lib)] public static extern IntPtr lilv_uis_next(IntPtr uis, IntPtr iterator);
+        [DllImport(Lib)] public static extern IntPtr lilv_uis_get(IntPtr uis, IntPtr iterator);
+        [DllImport(Lib)][return: MarshalAs(UnmanagedType.I1)] public static extern bool lilv_ui_is_a(IntPtr ui, IntPtr type);
+        [DllImport(Lib)] public static extern void lilv_uis_free(IntPtr uis);
 
         [DllImport(Lib)] [return: MarshalAs(UnmanagedType.I1)] public static extern bool lilv_port_is_a(IntPtr plugin, IntPtr port, IntPtr cls);
         [DllImport(Lib)] [return: MarshalAs(UnmanagedType.I1)] public static extern bool lilv_port_has_property(IntPtr plugin, IntPtr port, IntPtr prop);

--- a/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
+++ b/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
@@ -225,25 +225,53 @@ public static class Lv2Catalog
             }
             Lilv.lilv_nodes_free(req);
         }
+        IReadOnlyList<string>? uiFeatures = X11UiRequiredFeatures(world, plugin);
         return new PluginInfo("lv2", uri, name, category, audioIns, audioOuts, inSym, outSym, pars, features, inSyms, outSyms)
         {
             UnsupportedFeatures = UnsupportedFeatures(features),
-            HasNativeUi = HasX11Ui(world, plugin),
+            HasNativeUi = uiFeatures is not null,
+            NativeUiRequiredFeatures = uiFeatures ?? [],
         };
     }
 
-    private static bool HasX11Ui(IntPtr world, IntPtr plugin)
+    /// <summary>
+    /// Required features of the X11 UI the native helper will select (the
+    /// first one in lilv's catalog order), or null when there is no X11 UI.
+    /// </summary>
+    private static IReadOnlyList<string>? X11UiRequiredFeatures(IntPtr world, IntPtr plugin)
     {
         IntPtr uis = Lilv.lilv_plugin_get_uis(plugin);
-        if (uis == IntPtr.Zero) return false;
+        if (uis == IntPtr.Zero) return null;
         IntPtr type = Lilv.lilv_new_uri(world, "http://lv2plug.in/ns/extensions/ui#X11UI");
+        IntPtr requiredFeature = Lilv.lilv_new_uri(world, "http://lv2plug.in/ns/lv2core#requiredFeature");
         try
         {
             for (IntPtr it = Lilv.lilv_uis_begin(uis); !Lilv.lilv_uis_is_end(uis, it); it = Lilv.lilv_uis_next(uis, it))
-                if (Lilv.lilv_ui_is_a(Lilv.lilv_uis_get(uis, it), type)) return true;
-            return false;
+            {
+                IntPtr ui = Lilv.lilv_uis_get(uis, it);
+                if (!Lilv.lilv_ui_is_a(ui, type)) continue;
+                var features = new List<string>();
+                IntPtr required = Lilv.lilv_world_find_nodes(
+                    world, Lilv.lilv_ui_get_uri(ui), requiredFeature, IntPtr.Zero);
+                if (required != IntPtr.Zero)
+                {
+                    for (IntPtr fit = Lilv.lilv_nodes_begin(required); !Lilv.lilv_nodes_is_end(required, fit); fit = Lilv.lilv_nodes_next(required, fit))
+                    {
+                        string? feature = Lilv.Str(Lilv.lilv_node_as_uri(Lilv.lilv_nodes_get(required, fit)));
+                        if (feature is not null) features.Add(feature);
+                    }
+                    Lilv.lilv_nodes_free(required);
+                }
+                return features;
+            }
+            return null;
         }
-        finally { Lilv.lilv_node_free(type); Lilv.lilv_uis_free(uis); }
+        finally
+        {
+            Lilv.lilv_node_free(requiredFeature);
+            Lilv.lilv_node_free(type);
+            Lilv.lilv_uis_free(uis);
+        }
     }
 
     /// <summary>The slice of liblilv this catalog uses.</summary>
@@ -255,6 +283,7 @@ public static class Lv2Catalog
         [DllImport(Lib)] public static extern void lilv_world_free(IntPtr world);
         [DllImport(Lib)] public static extern void lilv_world_load_all(IntPtr world);
         [DllImport(Lib)] public static extern IntPtr lilv_world_get_all_plugins(IntPtr world);
+        [DllImport(Lib)] public static extern IntPtr lilv_world_find_nodes(IntPtr world, IntPtr subject, IntPtr predicate, IntPtr obj);
         [DllImport(Lib)] public static extern IntPtr lilv_new_uri(IntPtr world, [MarshalAs(UnmanagedType.LPUTF8Str)] string uri);
         [DllImport(Lib)] public static extern IntPtr lilv_new_string(IntPtr world, [MarshalAs(UnmanagedType.LPUTF8Str)] string str);
         [DllImport(Lib)] public static extern void lilv_world_set_option(IntPtr world, [MarshalAs(UnmanagedType.LPUTF8Str)] string uri, IntPtr value);
@@ -283,6 +312,7 @@ public static class Lv2Catalog
         [DllImport(Lib)][return: MarshalAs(UnmanagedType.I1)] public static extern bool lilv_uis_is_end(IntPtr uis, IntPtr iterator);
         [DllImport(Lib)] public static extern IntPtr lilv_uis_next(IntPtr uis, IntPtr iterator);
         [DllImport(Lib)] public static extern IntPtr lilv_uis_get(IntPtr uis, IntPtr iterator);
+        [DllImport(Lib)] public static extern IntPtr lilv_ui_get_uri(IntPtr ui);
         [DllImport(Lib)][return: MarshalAs(UnmanagedType.I1)] public static extern bool lilv_ui_is_a(IntPtr ui, IntPtr type);
         [DllImport(Lib)] public static extern void lilv_uis_free(IntPtr uis);
 

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -243,9 +243,11 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
                 bool cg = ch.InputPair == 0 && _softClipGuard && _clipGuardApplicable;
                 List<InsertDefinition> inserts = IsInsertChannel(ch.Id) ? InsertsFor(ch.Id) : [];
                 bool anyInsert = inserts.Any(i => !i.Bypass && Lv2Catalog.Find(i.Plugin) is not null);
+                bool givenUp = anyInsert && _restarts.Blocked(ch.Id);
+                if (givenUp) { inserts = []; anyInsert = false; _insertErrors[ch.Id] = RestartPolicy.GivenUp; }
                 if (lc || cg || anyInsert)
                 {
-                    _insertErrors.Remove(ch.Id);
+                    if (!givenUp) _insertErrors.Remove(ch.Id);
                     FilterHandle chain;
                     string chainId = $"{ch.Id}_{generation}";
                     try
@@ -401,10 +403,13 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
                 string key = MixKey(mix);
                 if (_chains.TryGetValue(key, out FilterHandle? c) && !c.IsAlive)
                 {
-                    WireMixChainLocked(mix);
+                    _restarts.Failed(key);
+                    WireMixChainLocked(mix);   // leaves the chain off once it has failed enough
                     changed = true;
                 }
             }
+            foreach ((string key, FilterHandle chain) in _chains)
+                if (!key.StartsWith("mix:", StringComparison.Ordinal) && !chain.IsAlive) _restarts.Failed(key);
             bool inputBroken = _chains.Where(e => !e.Key.StartsWith("mix:", StringComparison.Ordinal)).Any(e => !e.Value.IsAlive)
                 || _chainOuts.Values.Any(l => _pw.EnsureLinks(l) == LinkHealth.Broken);
             if (inputBroken) { WireInputFeedsLocked(); changed = true; }
@@ -505,6 +510,7 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
     // running without its inserts.
     private readonly Dictionary<string, List<InsertDefinition>> _inserts = new();
     private readonly Dictionary<string, string> _insertErrors = new();
+    private readonly RestartPolicy _restarts = new(() => Environment.TickCount64);
 
     /// <summary>Insert keys: the mono XLR inputs (Aux In is stereo) and "mix:&lt;id&gt;" for every mix.</summary>
     private bool IsInsertChannel(string key) => key is "xlr1" or "xlr2" || MixForKey(key) is not null;
@@ -568,7 +574,8 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
 
         List<InsertDefinition> inserts = InsertsFor(key);
         bool anyInsert = inserts.Any(i => !i.Bypass && Lv2Catalog.Find(i.Plugin) is { } p && p.AudioIns >= 2 && p.AudioOuts >= 2);
-        if (anyInsert)
+        if (anyInsert && _restarts.Blocked(key)) _insertErrors[key] = RestartPolicy.GivenUp;
+        else if (anyInsert)
         {
             try
             {
@@ -714,6 +721,7 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
 
     private void RewireInsertKeyLocked(string key)
     {
+        _restarts.Forget(key);
         if (MixForKey(key) is MixDefinition mix) WireMixChainLocked(mix);
         else if (IsInsertChannel(key)) WireInputFeedsLocked();
     }
@@ -788,6 +796,7 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
                 return new InsertStatus(i,
                     Lv2Catalog.Find(i.Plugin) is null ? "plugin not installed"
                     : !i.Bypass && _insertErrors.TryGetValue(channel, out string? err) ? err
+                    : host?.EditorStalled == true ? "the plugin's editor stopped answering; its controls are frozen while audio keeps playing"
                     : null, host?.Meters, host?.IsRunning == true);
             })];
         }

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -718,20 +718,18 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         else if (IsInsertChannel(key)) WireInputFeedsLocked();
     }
 
-    /// <summary>
-    /// Set one control of an insert. Applied live to the running chain when
-    /// possible (no dropout); a chain that cannot take it is rebuilt.
-    /// </summary>
+    /// <summary>Capture the host under the mixer lock, then open its UI outside it.</summary>
     public void ShowInsertUi(string channel, string insertId)
     {
+        NativePluginHost? host;
         lock (_gate)
         {
-            NativePluginHost? host = _chains.GetValueOrDefault(channel)?.InsertStages
+            host = _chains.GetValueOrDefault(channel)?.InsertStages
                 .FirstOrDefault(stage => stage.Id == insertId).Stage?.NativeHost;
             if (host is null)
                 throw new InvalidOperationException("No native editor is running for this insert. Enable it and install the optional native host.");
-            host.ShowUi();
         }
+        host.ShowUi();
     }
 
     /// <summary>Collect editor changes on the same path used to persist ordinary controls.</summary>

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -399,13 +399,13 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
             foreach (MixDefinition mix in _config.Mixes)
             {
                 string key = MixKey(mix);
-                if (_chains.TryGetValue(key, out FilterHandle? c) && c.Process.HasExited)
+                if (_chains.TryGetValue(key, out FilterHandle? c) && !c.IsAlive)
                 {
                     WireMixChainLocked(mix);
                     changed = true;
                 }
             }
-            bool inputBroken = _chains.Where(e => !e.Key.StartsWith("mix:", StringComparison.Ordinal)).Any(e => e.Value.Process.HasExited)
+            bool inputBroken = _chains.Where(e => !e.Key.StartsWith("mix:", StringComparison.Ordinal)).Any(e => !e.Value.IsAlive)
                 || _chainOuts.Values.Any(l => _pw.EnsureLinks(l) == LinkHealth.Broken);
             if (inputBroken) { WireInputFeedsLocked(); changed = true; }
             return changed;
@@ -722,6 +722,41 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
     /// Set one control of an insert. Applied live to the running chain when
     /// possible (no dropout); a chain that cannot take it is rebuilt.
     /// </summary>
+    public void ShowInsertUi(string channel, string insertId)
+    {
+        lock (_gate)
+        {
+            NativePluginHost? host = _chains.GetValueOrDefault(channel)?.InsertStages
+                .FirstOrDefault(stage => stage.Id == insertId).Stage?.NativeHost;
+            if (host is null)
+                throw new InvalidOperationException("No native editor is running for this insert. Enable it and install the optional native host.");
+            host.ShowUi();
+        }
+    }
+
+    /// <summary>Collect editor changes on the same path used to persist ordinary controls.</summary>
+    public bool SyncPluginControls()
+    {
+        lock (_gate)
+        {
+            bool changed = false;
+            foreach ((string channel, FilterHandle chain) in _chains)
+                foreach ((string id, FilterHandle stage) in chain.InsertStages)
+                {
+                    if (stage.NativeHost is not { } host) continue;
+                    foreach ((string symbol, double value) in host.DrainChanges())
+                    {
+                        InsertDefinition? insert = InsertsFor(channel).FirstOrDefault(i => i.Id == id);
+                        PluginParam? parameter = insert is null ? null : Lv2Catalog.Find(insert.Plugin)?.Params.FirstOrDefault(p => p.Symbol == symbol);
+                        if (parameter is null || !double.IsFinite(value)) continue;
+                        insert!.Params[symbol] = Math.Clamp(value, parameter.Min, parameter.Max);
+                        changed = true;
+                    }
+                }
+            return changed;
+        }
+    }
+
     public void SetInsertParam(string channel, string insertId, string symbol, double value)
     {
         lock (_gate)
@@ -751,7 +786,8 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
             result[channel] = [.. list.Select(i => new InsertStatus(i,
                 Lv2Catalog.Find(i.Plugin) is null ? "plugin not installed"
                 : !i.Bypass && _insertErrors.TryGetValue(channel, out string? err) ? err
-                : null))];
+                : null, _chains.GetValueOrDefault(channel)?.InsertStages
+                    .FirstOrDefault(stage => stage.Id == i.Id).Stage?.NativeHost?.Meters))];
         }
         return result;
     }

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -783,11 +783,15 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         var result = new Dictionary<string, IReadOnlyList<InsertStatus>>();
         foreach ((string channel, List<InsertDefinition> list) in _inserts)
         {
-            result[channel] = [.. list.Select(i => new InsertStatus(i,
-                Lv2Catalog.Find(i.Plugin) is null ? "plugin not installed"
-                : !i.Bypass && _insertErrors.TryGetValue(channel, out string? err) ? err
-                : null, _chains.GetValueOrDefault(channel)?.InsertStages
-                    .FirstOrDefault(stage => stage.Id == i.Id).Stage?.NativeHost?.Meters))];
+            result[channel] = [.. list.Select(i =>
+            {
+                NativePluginHost? host = _chains.GetValueOrDefault(channel)?.InsertStages
+                    .FirstOrDefault(stage => stage.Id == i.Id).Stage?.NativeHost;
+                return new InsertStatus(i,
+                    Lv2Catalog.Find(i.Plugin) is null ? "plugin not installed"
+                    : !i.Bypass && _insertErrors.TryGetValue(channel, out string? err) ? err
+                    : null, host?.Meters, host?.IsRunning == true);
+            })];
         }
         return result;
     }

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -25,13 +25,29 @@ internal sealed class NativePluginHost : IDisposable
     private long _lastUiHeartbeat = Stopwatch.GetTimestamp();
 
     public Process Process { get; }
-    public bool IsHealthy => !Process.HasExited
+    public bool IsRunning
+    {
+        get
+        {
+            try { return !Process.HasExited; }
+            catch (InvalidOperationException) { return false; }
+        }
+    }
+    public bool IsHealthy => IsRunning
         && Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastHeartbeat)) < TimeSpan.FromSeconds(10);
     public IReadOnlyDictionary<string, double> Meters => new Dictionary<string, double>(_meters);
     public static string Executable => Path.Combine(AppContext.BaseDirectory, "openxlr-lv2-host");
     internal static bool SupportsFeatures(IEnumerable<string> required)
         => required.All(feature => feature is
             "http://lv2plug.in/ns/ext/urid#map" or "http://lv2plug.in/ns/ext/urid#unmap");
+    internal static bool SupportsUiFeatures(IEnumerable<string> required)
+        => required.All(feature => feature is
+            "http://lv2plug.in/ns/ext/urid#map"
+            or "http://lv2plug.in/ns/ext/urid#unmap"
+            or "http://lv2plug.in/ns/ext/instance-access"
+            or "http://lv2plug.in/ns/extensions/ui#parent"
+            or "http://lv2plug.in/ns/extensions/ui#resize"
+            or "http://lv2plug.in/ns/extensions/ui#idleInterface");
 
     public NativePluginHost(InsertDefinition insert, string node, int channels, int sampleRate)
     {

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -1,0 +1,150 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>
+/// Owns an isolated DSP/UI process. The small line protocol carries control
+/// values only; audio never crosses managed code or these pipes. Reader tasks
+/// coalesce native UI edits, which the mixer consumes under its own lock.
+/// </summary>
+internal sealed class NativePluginHost : IDisposable
+{
+    private readonly ConcurrentDictionary<string, double> _changes = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, double> _meters = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _writes = new(1, 1);
+    private readonly CancellationTokenSource _stop = new();
+    private readonly TaskCompletionSource _ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TaskCompletionSource<string?>? _uiReply;
+    private readonly Task _outputReader;
+    private readonly Task _errorReader;
+    private string _error = "";
+    private int _disposed;
+    private long _lastHeartbeat = Stopwatch.GetTimestamp();
+    private long _lastUiHeartbeat = Stopwatch.GetTimestamp();
+
+    public Process Process { get; }
+    public bool IsHealthy => !Process.HasExited
+        && Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastHeartbeat)) < TimeSpan.FromSeconds(10);
+    public IReadOnlyDictionary<string, double> Meters => new Dictionary<string, double>(_meters);
+    public static string Executable => Path.Combine(AppContext.BaseDirectory, "openxlr-lv2-host");
+    internal static bool SupportsFeatures(IEnumerable<string> required)
+        => required.All(feature => feature is
+            "http://lv2plug.in/ns/ext/urid#map" or "http://lv2plug.in/ns/ext/urid#unmap");
+
+    public NativePluginHost(InsertDefinition insert, string node, int channels, int sampleRate)
+    {
+        if (!File.Exists(Executable)) throw new InvalidOperationException("Native LV2 host is missing; rebuild/install the complete OpenXLR package.");
+        var start = new ProcessStartInfo(Executable)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        foreach (string argument in new[] { insert.Plugin, node, channels.ToString(CultureInfo.InvariantCulture), sampleRate.ToString(CultureInfo.InvariantCulture) })
+            start.ArgumentList.Add(argument);
+        foreach ((string symbol, double value) in insert.Params)
+            start.ArgumentList.Add($"{symbol}={value.ToString("R", CultureInfo.InvariantCulture)}");
+        Process = Process.Start(start) ?? throw new InvalidOperationException("Could not start the native LV2 host.");
+        _outputReader = ReadOutputAsync();
+        _errorReader = ReadErrorsAsync();
+        try { _ready.Task.WaitAsync(TimeSpan.FromSeconds(8)).GetAwaiter().GetResult(); }
+        catch (Exception ex)
+        {
+            Dispose();
+            throw new InvalidOperationException($"Native LV2 startup failed: {_error}", ex);
+        }
+    }
+
+    private async Task ReadOutputAsync()
+    {
+        try
+        {
+            while (await Process.StandardOutput.ReadLineAsync(_stop.Token).ConfigureAwait(false) is string line)
+            {
+                if (line == "ready") _ready.TrySetResult();
+                else if (line == "heartbeat") Interlocked.Exchange(ref _lastHeartbeat, Stopwatch.GetTimestamp());
+                else if (line == "ui-heartbeat") Interlocked.Exchange(ref _lastUiHeartbeat, Stopwatch.GetTimestamp());
+                else if (line.StartsWith("ui ", StringComparison.Ordinal))
+                    Volatile.Read(ref _uiReply)?.TrySetResult(line == "ui opened" ? null : line[3..]);
+                else
+                {
+                    string[] parts = line.Split(' ', 3);
+                    if (parts.Length == 3 && double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out double value) && double.IsFinite(value))
+                    {
+                        if (parts[0] == "control") _changes[parts[1]] = value;
+                        else if (parts[0] == "meter") _meters[parts[1]] = value;
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException) { }
+        finally
+        {
+            _ready.TrySetException(new InvalidOperationException("Native host exited before readiness."));
+            Volatile.Read(ref _uiReply)?.TrySetResult("Native plugin host disconnected.");
+        }
+    }
+
+    private async Task ReadErrorsAsync()
+    {
+        try
+        {
+            while (await Process.StandardError.ReadLineAsync(_stop.Token).ConfigureAwait(false) is string line)
+                _error = line.Length > 2048 ? line[..2048] : line;
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException) { }
+    }
+
+    private async Task SendAsync(string command)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_stop.Token);
+        timeout.CancelAfter(TimeSpan.FromSeconds(2));
+        await _writes.WaitAsync(timeout.Token).ConfigureAwait(false);
+        try
+        {
+            await Process.StandardInput.WriteLineAsync(command.AsMemory(), timeout.Token).ConfigureAwait(false);
+            await Process.StandardInput.FlushAsync(timeout.Token).ConfigureAwait(false);
+        }
+        finally { _writes.Release(); }
+    }
+
+    public void SetControl(string symbol, double value)
+        => SendAsync($"set {symbol} {value.ToString("R", CultureInfo.InvariantCulture)}").GetAwaiter().GetResult();
+
+    public void ShowUi()
+    {
+        if (Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastUiHeartbeat)) > TimeSpan.FromSeconds(10))
+            throw new InvalidOperationException("Plugin editor is unresponsive; audio is still running.");
+        var reply = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (Interlocked.CompareExchange(ref _uiReply, reply, null) is not null)
+            throw new InvalidOperationException("The plugin editor is already opening.");
+        try
+        {
+            SendAsync("show").GetAwaiter().GetResult();
+            string? error = reply.Task.WaitAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+            if (error is not null) throw new InvalidOperationException(error);
+        }
+        finally { Interlocked.Exchange(ref _uiReply, null); }
+    }
+
+    public IEnumerable<KeyValuePair<string, double>> DrainChanges()
+    {
+        foreach (string symbol in _changes.Keys)
+            if (_changes.TryRemove(symbol, out double value)) yield return new(symbol, value);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _stop.Cancel();
+        try { if (!Process.HasExited) { Process.Kill(entireProcessTree: true); Process.WaitForExit(2000); } }
+        catch (InvalidOperationException) { }
+        // Cancellation releases pipe readers; join before disposing their handles.
+        Task.WhenAll(_outputReader, _errorReader).GetAwaiter().GetResult();
+        Process.Dispose();
+        _stop.Dispose();
+        _writes.Dispose();
+    }
+}

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -69,7 +69,9 @@ internal sealed class NativePluginHost : IDisposable
         TimeSpan? patience = null)
     {
         if (patience is { } chosen) _patience = chosen;
-        if (!File.Exists(executable)) throw new InvalidOperationException("Native LV2 host is missing; rebuild/install the complete OpenXLR package.");
+        if (!File.Exists(executable))
+            throw new InvalidOperationException(
+                "The native LV2 host is not installed. Build it with -p:EnableNativeLv2Host=true, or switch this insert back to the filter chain.");
         var start = new ProcessStartInfo(executable)
         {
             RedirectStandardInput = true,

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -34,7 +34,19 @@ internal sealed class NativePluginHost : IDisposable
         }
     }
     public bool IsHealthy => IsRunning
-        && Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastHeartbeat)) < TimeSpan.FromSeconds(10);
+        && Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastHeartbeat)) < _patience;
+
+    /// <summary>
+    /// The editor loop has stopped answering while the DSP keeps running: a
+    /// plugin's own interface can block its thread, which freezes control
+    /// changes for that insert. Audio is unaffected, so this is reported
+    /// rather than treated as a death.
+    /// </summary>
+    public bool EditorStalled => IsRunning
+        && Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastUiHeartbeat)) > _patience;
+
+    /// <summary>How long either beat may go quiet before it means something.</summary>
+    private readonly TimeSpan _patience = TimeSpan.FromSeconds(10);
     public IReadOnlyDictionary<string, double> Meters => new Dictionary<string, double>(_meters);
     public static string Executable => Path.Combine(AppContext.BaseDirectory, "openxlr-lv2-host");
     internal static bool SupportsFeatures(IEnumerable<string> required)
@@ -53,8 +65,10 @@ internal sealed class NativePluginHost : IDisposable
         : this(insert, node, channels, sampleRate, Executable, []) { }
 
     internal NativePluginHost(InsertDefinition insert, string node, int channels, int sampleRate,
-        string executable, IReadOnlyList<string> prefixArguments, TimeSpan? startupTimeout = null)
+        string executable, IReadOnlyList<string> prefixArguments, TimeSpan? startupTimeout = null,
+        TimeSpan? patience = null)
     {
+        if (patience is { } chosen) _patience = chosen;
         if (!File.Exists(executable)) throw new InvalidOperationException("Native LV2 host is missing; rebuild/install the complete OpenXLR package.");
         var start = new ProcessStartInfo(executable)
         {
@@ -133,12 +147,19 @@ internal sealed class NativePluginHost : IDisposable
     {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_stop.Token);
         timeout.CancelAfter(TimeSpan.FromSeconds(1));
-        SendAsync($"set {symbol} {value.ToString("R", CultureInfo.InvariantCulture)}", timeout.Token).GetAwaiter().GetResult();
+        try
+        {
+            SendAsync($"set {symbol} {value.ToString("R", CultureInfo.InvariantCulture)}", timeout.Token).GetAwaiter().GetResult();
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException)
+        {
+            throw new InvalidOperationException("The plugin host did not take the change; audio is unaffected.", ex);
+        }
     }
 
     public void ShowUi()
     {
-        if (Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastUiHeartbeat)) > TimeSpan.FromSeconds(10))
+        if (EditorStalled)
             throw new InvalidOperationException("Plugin editor is unresponsive; audio is still running.");
         var reply = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
         if (Interlocked.CompareExchange(ref _uiReply, reply, null) is not null)
@@ -152,6 +173,12 @@ internal sealed class NativePluginHost : IDisposable
             SendAsync("show", timeout.Token).GetAwaiter().GetResult();
             string? error = reply.Task.WaitAsync(timeout.Token).GetAwaiter().GetResult();
             if (error is not null) throw new InvalidOperationException(error);
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException)
+        {
+            // Callers turn this into a client error message, so say what it
+            // means for the audio rather than reporting a cancelled task.
+            throw new InvalidOperationException("The plugin editor did not answer in time; audio is unaffected.", ex);
         }
         finally
         {

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -50,14 +50,19 @@ internal sealed class NativePluginHost : IDisposable
             or "http://lv2plug.in/ns/extensions/ui#idleInterface");
 
     public NativePluginHost(InsertDefinition insert, string node, int channels, int sampleRate)
+        : this(insert, node, channels, sampleRate, Executable, []) { }
+
+    internal NativePluginHost(InsertDefinition insert, string node, int channels, int sampleRate,
+        string executable, IReadOnlyList<string> prefixArguments, TimeSpan? startupTimeout = null)
     {
-        if (!File.Exists(Executable)) throw new InvalidOperationException("Native LV2 host is missing; rebuild/install the complete OpenXLR package.");
-        var start = new ProcessStartInfo(Executable)
+        if (!File.Exists(executable)) throw new InvalidOperationException("Native LV2 host is missing; rebuild/install the complete OpenXLR package.");
+        var start = new ProcessStartInfo(executable)
         {
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
+        foreach (string argument in prefixArguments) start.ArgumentList.Add(argument);
         foreach (string argument in new[] { insert.Plugin, node, channels.ToString(CultureInfo.InvariantCulture), sampleRate.ToString(CultureInfo.InvariantCulture) })
             start.ArgumentList.Add(argument);
         foreach ((string symbol, double value) in insert.Params)
@@ -65,7 +70,7 @@ internal sealed class NativePluginHost : IDisposable
         Process = Process.Start(start) ?? throw new InvalidOperationException("Could not start the native LV2 host.");
         _outputReader = ReadOutputAsync();
         _errorReader = ReadErrorsAsync();
-        try { _ready.Task.WaitAsync(TimeSpan.FromSeconds(8)).GetAwaiter().GetResult(); }
+        try { _ready.Task.WaitAsync(startupTimeout ?? TimeSpan.FromSeconds(8)).GetAwaiter().GetResult(); }
         catch (Exception ex)
         {
             Dispose();
@@ -113,21 +118,23 @@ internal sealed class NativePluginHost : IDisposable
         catch (Exception ex) when (ex is OperationCanceledException or IOException) { }
     }
 
-    private async Task SendAsync(string command)
+    private async Task SendAsync(string command, CancellationToken cancellation)
     {
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_stop.Token);
-        timeout.CancelAfter(TimeSpan.FromSeconds(2));
-        await _writes.WaitAsync(timeout.Token).ConfigureAwait(false);
+        await _writes.WaitAsync(cancellation).ConfigureAwait(false);
         try
         {
-            await Process.StandardInput.WriteLineAsync(command.AsMemory(), timeout.Token).ConfigureAwait(false);
-            await Process.StandardInput.FlushAsync(timeout.Token).ConfigureAwait(false);
+            await Process.StandardInput.WriteLineAsync(command.AsMemory(), cancellation).ConfigureAwait(false);
+            await Process.StandardInput.FlushAsync(cancellation).ConfigureAwait(false);
         }
         finally { _writes.Release(); }
     }
 
     public void SetControl(string symbol, double value)
-        => SendAsync($"set {symbol} {value.ToString("R", CultureInfo.InvariantCulture)}").GetAwaiter().GetResult();
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_stop.Token);
+        timeout.CancelAfter(TimeSpan.FromSeconds(1));
+        SendAsync($"set {symbol} {value.ToString("R", CultureInfo.InvariantCulture)}", timeout.Token).GetAwaiter().GetResult();
+    }
 
     public void ShowUi()
     {
@@ -138,11 +145,22 @@ internal sealed class NativePluginHost : IDisposable
             throw new InvalidOperationException("The plugin editor is already opening.");
         try
         {
-            SendAsync("show").GetAwaiter().GetResult();
-            string? error = reply.Task.WaitAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+            // One budget includes waiting for the writer, flushing and the reply.
+            // This path can be called under the mixer lock.
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_stop.Token);
+            timeout.CancelAfter(TimeSpan.FromSeconds(1));
+            SendAsync("show", timeout.Token).GetAwaiter().GetResult();
+            string? error = reply.Task.WaitAsync(timeout.Token).GetAwaiter().GetResult();
             if (error is not null) throw new InvalidOperationException(error);
         }
-        finally { Interlocked.Exchange(ref _uiReply, null); }
+        finally
+        {
+            // The protocol has no request IDs. Keep a timed-out request occupied
+            // until its late reply arrives, so it cannot acknowledge a new show.
+            if (reply.Task.IsCompleted) Interlocked.CompareExchange(ref _uiReply, null, reply);
+            else _ = reply.Task.ContinueWith(_ => Interlocked.CompareExchange(ref _uiReply, null, reply),
+                CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
     }
 
     public IEnumerable<KeyValuePair<string, double>> DrainChanges()

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -23,6 +23,7 @@ public sealed class PipeWireAdapter
     private readonly List<uint> _modules = [];
     private readonly List<Process> _loopbacks = [];
     private readonly List<Process> _filters = [];
+    private readonly HashSet<NativePluginHost> _nativeHosts = [];
 
     public PipeWireAdapter() { }
 
@@ -571,6 +572,8 @@ public sealed class PipeWireAdapter
     private FilterHandle CreateFilterChain(string sinkName, string srcName, string description, int channels,
         int lowCutHz, bool clipGuard, IReadOnlyList<InsertDefinition>? inserts)
     {
+        if (inserts?.Any(i => !i.Bypass && Lv2Catalog.Find(i.Plugin)?.NativeEditorAvailable == true) == true)
+            return CreateHostedChain(sinkName, srcName, description, channels, lowCutHz, clipGuard, inserts);
         if (clipGuard)
         {
             DspFeatureAvailability support = GetSoftwareClipGuardAvailability();
@@ -655,6 +658,67 @@ public sealed class PipeWireAdapter
         return handle;
     }
 
+    /// <summary>Splice native editors into the chain, retaining filter-chain for other plugins.</summary>
+    private FilterHandle CreateHostedChain(string sinkName, string sourceName, string description, int channels,
+        int lowCutHz, bool clipGuard, IReadOnlyList<InsertDefinition> inserts)
+    {
+        var stages = new List<FilterHandle>();
+        var insertStages = new List<(string Id, FilterHandle Stage)>();
+        try
+        {
+            if (lowCutHz > 0 || clipGuard)
+                stages.Add(CreateFilterChain(sinkName + "_safety", sourceName + "_safety", description,
+                    channels, lowCutHz, clipGuard, null));
+            int rate = ParseGraphSampleRate(Run("pw-metadata", "-n", "settings"));
+            foreach (InsertDefinition insert in inserts.Where(i => !i.Bypass))
+            {
+                PluginInfo? info = Lv2Catalog.Find(insert.Plugin);
+                if (info is null || !info.Supported)
+                    throw new InvalidOperationException("Plugin is unavailable or requires unsupported host features.");
+                string node = $"{sinkName}_stage_{insertStages.Count}";
+                FilterHandle stage;
+                if (info.NativeEditorAvailable)
+                {
+                    var host = new NativePluginHost(insert, node, channels, rate);
+                    _nativeHosts.Add(host);
+                    stage = new(node, node, node, host.Process) { NativeHost = host };
+                    stages.Add(stage);
+                    if (!WaitForPorts(node, "playback", false, TimeSpan.FromSeconds(3), host.Process)
+                        || !WaitForPorts(node, "capture", true, TimeSpan.FromSeconds(3), host.Process))
+                        throw new InvalidOperationException($"Native LV2 ports did not appear for {insert.Plugin}.");
+                }
+                else
+                {
+                    stage = CreateFilterChain(node + "_in", node + "_out", description, channels, 0, false, [insert]);
+                    stages.Add(stage);
+                }
+                insertStages.Add((insert.Id, stage));
+            }
+            for (int i = 1; i < stages.Count; i++)
+                if (LinkNodes(stages[i - 1].SourceName, "capture", stages[i].SinkName, "playback").Pairs.Count < channels)
+                    throw new InvalidOperationException("Could not link the plugin stages.");
+            return new(sinkName, stages[0].SinkName, stages[^1].SourceName, stages[0].Process)
+            { Stages = stages, InsertStages = insertStages };
+        }
+        catch
+        {
+            foreach (FilterHandle stage in stages) StopFilter(stage);
+            throw;
+        }
+    }
+
+    internal static int ParseGraphSampleRate(string metadata)
+    {
+        foreach (string key in new[] { "clock.force-rate", "clock.rate" })
+        {
+            var match = System.Text.RegularExpressions.Regex.Match(metadata,
+                $"key:'{System.Text.RegularExpressions.Regex.Escape(key)}' value:'(\\d+)'");
+            if (match.Success && int.TryParse(match.Groups[1].Value, out int rate) && rate is >= 8000 and <= 384000)
+                return rate;
+        }
+        throw new InvalidOperationException("PipeWire did not report a supported graph sample rate.");
+    }
+
     /// <summary>
     /// Change one control of a running filter-chain live: the chain exposes
     /// its plugins' controls as "node:symbol" entries of the Props param on
@@ -662,6 +726,18 @@ public sealed class PipeWireAdapter
     /// </summary>
     public void SetFilterControl(FilterHandle f, string control, double value)
     {
+        if (f.InsertStages.Count > 0)
+        {
+            int separator = control.IndexOf(':');
+            if (separator < 2 || control[0] != 'i'
+                || !int.TryParse(control.AsSpan(1, separator - 1), out int index)
+                || index < 0 || index >= f.InsertStages.Count)
+                throw new InvalidOperationException("Unknown plugin stage.");
+            FilterHandle stage = f.InsertStages[index].Stage;
+            if (stage.NativeHost is { } host) host.SetControl(control[(separator + 1)..], value);
+            else SetFilterControl(stage, "i0:" + control[(separator + 1)..], value);
+            return;
+        }
         int id = FindNodeId(f.SinkName) ?? throw new InvalidOperationException($"filter node {f.SinkName} not found");
         string v = value.ToString(System.Globalization.CultureInfo.InvariantCulture);
         Run("pw-cli", "set-param", id.ToString(), "Props", $"{{ params = [ \"{SpaString(control)}\" {v} ] }}");
@@ -670,6 +746,17 @@ public sealed class PipeWireAdapter
     /// <summary>Unload a filter by killing its holder process.</summary>
     public void StopFilter(FilterHandle f)
     {
+        if (f.Stages.Count > 0)
+        {
+            foreach (FilterHandle stage in f.Stages) StopFilter(stage);
+            return;
+        }
+        if (f.NativeHost is { } host)
+        {
+            _nativeHosts.Remove(host);
+            host.Dispose();
+            return;
+        }
         try { if (!f.Process.HasExited) { f.Process.Kill(entireProcessTree: true); f.Process.WaitForExit(2000); } }
         catch (Exception) { /* already gone */ }
         _filters.Remove(f.Process);
@@ -1250,6 +1337,8 @@ public sealed class PipeWireAdapter
     /// <summary>Remove everything this adapter created, in reverse order.</summary>
     public void TearDown()
     {
+        foreach (NativePluginHost host in _nativeHosts) host.Dispose();
+        _nativeHosts.Clear();
         foreach (Process p in _loopbacks.Concat(_filters))
         {
             try { if (!p.HasExited) { p.Kill(entireProcessTree: true); p.WaitForExit(2000); } }
@@ -1337,7 +1426,14 @@ public sealed record LoopbackHandle(string Id, string CaptureNodeName, string Pl
 
 /// <summary>A loaded filter-chain: sink half (input), source half (output),
 /// and the pw-cli process whose lifetime is the module's.</summary>
-public sealed record FilterHandle(string Id, string SinkName, string SourceName, Process Process);
+public sealed record FilterHandle(string Id, string SinkName, string SourceName, Process Process)
+{
+    internal NativePluginHost? NativeHost { get; init; }
+    internal IReadOnlyList<FilterHandle> Stages { get; init; } = [];
+    internal IReadOnlyList<(string Id, FilterHandle Stage)> InsertStages { get; init; } = [];
+    internal bool IsAlive => Stages.Count > 0 ? Stages.All(stage => stage.IsAlive)
+        : NativeHost?.IsHealthy ?? !Process.HasExited;
+}
 
 /// <summary>Whether an optional host-side DSP feature can be loaded safely.</summary>
 public sealed record DspFeatureAvailability(bool Available, string? Error);

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -572,7 +572,7 @@ public sealed class PipeWireAdapter
     private FilterHandle CreateFilterChain(string sinkName, string srcName, string description, int channels,
         int lowCutHz, bool clipGuard, IReadOnlyList<InsertDefinition>? inserts)
     {
-        if (inserts?.Any(i => !i.Bypass && Lv2Catalog.Find(i.Plugin)?.NativeEditorAvailable == true) == true)
+        if (inserts?.Any(i => !i.Bypass && i.NativeHost) == true)
             return CreateHostedChain(sinkName, srcName, description, channels, lowCutHz, clipGuard, inserts);
         if (clipGuard)
         {
@@ -677,8 +677,10 @@ public sealed class PipeWireAdapter
                     throw new InvalidOperationException("Plugin is unavailable or requires unsupported host features.");
                 string node = $"{sinkName}_stage_{insertStages.Count}";
                 FilterHandle stage;
-                if (info.NativeEditorAvailable)
+                if (insert.NativeHost)
                 {
+                    if (!info.NativeEditorAvailable)
+                        throw new InvalidOperationException($"Native hosting is unavailable for {insert.Plugin}; install the optional helper or select filter-chain.");
                     var host = new NativePluginHost(insert, node, channels, rate);
                     _nativeHosts.Add(host);
                     stage = new(node, node, node, host.Process) { NativeHost = host };

--- a/src/OpenXLR.Core/Mixing/RestartPolicy.cs
+++ b/src/OpenXLR.Core/Mixing/RestartPolicy.cs
@@ -1,0 +1,34 @@
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>
+/// How often one insert chain may be rebuilt for dying on its own. A plugin
+/// that crashes the moment it starts would otherwise be started again on
+/// every sweep, and rebuilding an input chain interrupts the microphone, so a
+/// chain that keeps failing is left off with an error until it is changed or
+/// the window passes.
+/// </summary>
+internal sealed class RestartPolicy(Func<long> clock, int limit = 3, long windowMs = 300_000)
+{
+    /// <summary>What a client sees for a chain that has been given up on.</summary>
+    internal const string GivenUp = "this chain kept failing and is off; change or bypass its plugins to try again";
+
+    private readonly Dictionary<string, (int Count, long Since)> _failures = new(StringComparer.Ordinal);
+
+    /// <summary>Record that a chain died on its own, not by anyone's request.</summary>
+    public void Failed(string key)
+    {
+        long now = clock();
+        if (!_failures.TryGetValue(key, out (int Count, long Since) seen) || now - seen.Since > windowMs)
+            _failures[key] = (1, now);
+        else if (seen.Count < limit)
+            _failures[key] = (seen.Count + 1, seen.Since);
+    }
+
+    /// <summary>Whether a chain has failed too often to be worth building again.</summary>
+    public bool Blocked(string key)
+        => _failures.TryGetValue(key, out (int Count, long Since) seen)
+            && seen.Count >= limit && clock() - seen.Since <= windowMs;
+
+    /// <summary>Forget a chain's history: the user changed it, so it is new again.</summary>
+    public void Forget(string key) => _failures.Remove(key);
+}

--- a/src/OpenXLR.Core/OpenXLR.Core.csproj
+++ b/src/OpenXLR.Core/OpenXLR.Core.csproj
@@ -4,10 +4,18 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableNativeLv2Host Condition="'$(EnableNativeLv2Host)' == ''">false</EnableNativeLv2Host>
   </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="OpenXLR.Tests" />
+    <None Include="../../native/openxlr-lv2-host" Link="openxlr-lv2-host"
+          CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest"
+          Condition="'$(EnableNativeLv2Host)' == 'true' And $([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>
 
+  <Target Name="BuildNativeLv2Host" BeforeTargets="BeforeBuild"
+          Condition="'$(EnableNativeLv2Host)' == 'true' And $([MSBuild]::IsOSPlatform('Linux'))">
+    <Exec Command="make -C &quot;$(MSBuildProjectDirectory)/../../native&quot;" />
+  </Target>
 </Project>

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -115,8 +115,9 @@ public static class CommandValidation
                 }
                 return null;
             case "setInsertBypass":
-                if (cmd.Channel is not null && !layout.IsInsertKey(cmd.Channel)) return $"setInsertBypass: '{Short(cmd.Channel)}' has no insert chain";
-                return TooLong(cmd.InsertId, MaxInsertId) ? "setInsertBypass: insert id too long" : null;
+            case "showInsertUi":
+                if (cmd.Channel is not null && !layout.IsInsertKey(cmd.Channel)) return $"{cmd.Cmd}: '{Short(cmd.Channel)}' has no insert chain";
+                return TooLong(cmd.InsertId, MaxInsertId) ? $"{cmd.Cmd}: insert id too long" : null;
             case "setInsertParam":
                 if (cmd.Channel is not null && !layout.IsInsertKey(cmd.Channel)) return $"setInsertParam: '{Short(cmd.Channel)}' has no insert chain";
                 if (TooLong(cmd.InsertId, MaxInsertId) || TooLong(cmd.Symbol, MaxText)) return "setInsertParam: id or symbol too long";

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -103,6 +103,8 @@ public static class CommandValidation
                         if (i.Plugin.Length > MaxUri) return "setInserts: plugin URI too long";
                         PluginInfo? plugin = findPlugin(i.Plugin);
                         if (plugin is null) return $"setInserts: plugin '{Short(i.Plugin)}' is not installed";
+                        if (i.NativeHost && !plugin.NativeEditorAvailable)
+                            return $"setInserts: native hosting is unavailable for '{plugin.Name}'";
                         if (!plugin.Supported)
                             return $"setInserts: '{plugin.Name}' needs {string.Join(", ", plugin.UnsupportedFeatures.Select(Tail))}, which the PipeWire chain does not provide";
                         if (i.Params.Count > MaxParamsPerInsert) return "setInserts: too many parameters";

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -226,6 +226,11 @@ public sealed class MixerService : IHostedService, IDisposable
                         | _mixer.EnsureInputFeeds() | _mixer.EnsureAuxRoute()
                         | _mixer.EnsureFilterRoutes()
                         | _mixer.EnsureMonitorRoutes()) Changed?.Invoke();
+                    if (_mixer.SyncPluginControls())
+                    {
+                        ScheduleSave();
+                        Changed?.Invoke();
+                    }
                     SyncOutputSelectors();
                     // Once a minute: is the PulseAudio server close to its
                     // open-file limit? Cheap (one /proc directory listing).
@@ -437,6 +442,10 @@ public sealed class MixerService : IHostedService, IDisposable
                         return "setInsertParam: need 'channel', 'insertId', and 'symbol'";
                     _mixer.SetInsertParam(cmd.Channel, cmd.InsertId, cmd.Symbol, cmd.Value.GetDouble());
                     break;
+                case "showInsertUi":
+                    if (cmd.Channel is null || cmd.InsertId is null) return "showInsertUi: need 'channel' and 'insertId'";
+                    _mixer.ShowInsertUi(cmd.Channel, cmd.InsertId);
+                    return null;
                 default:
                     return $"unknown mixer command '{cmd.Cmd}'";
             }

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -222,15 +222,18 @@ public sealed class MixerService : IHostedService, IDisposable
                     if (restoredSinks.Count > 0)
                         _log.LogWarning("put {n} OpenXLR sink(s) back to full volume, unmuted ({names}); something outside OpenXLR had changed them",
                             restoredSinks.Count, string.Join(", ", restoredSinks));
-                    if (_mixer.SyncStreams() | _mixer.SyncDeviceVolumes() | _mixer.EnforceDefaults()
-                        | _mixer.EnsureInputFeeds() | _mixer.EnsureAuxRoute()
-                        | _mixer.EnsureFilterRoutes()
-                        | _mixer.EnsureMonitorRoutes()) Changed?.Invoke();
+                    // Collect what the plugins' own editors changed before the
+                    // healing pass below, so a chain that is about to be rebuilt
+                    // comes back with the values its editor last showed.
                     if (_mixer.SyncPluginControls())
                     {
                         ScheduleSave();
                         Changed?.Invoke();
                     }
+                    if (_mixer.SyncStreams() | _mixer.SyncDeviceVolumes() | _mixer.EnforceDefaults()
+                        | _mixer.EnsureInputFeeds() | _mixer.EnsureAuxRoute()
+                        | _mixer.EnsureFilterRoutes()
+                        | _mixer.EnsureMonitorRoutes()) Changed?.Invoke();
                     SyncOutputSelectors();
                     // Once a minute: is the PulseAudio server close to its
                     // open-file limit? Cheap (one /proc directory listing).

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -225,6 +225,7 @@ public sealed class WebSocketHub
             case "setInserts":
             case "setInsertBypass":
             case "setInsertParam":
+            case "showInsertUi":
                 error = _mixer.Apply(cmd);                     // broadcasts on success
                 stateOnError = true;
                 break;

--- a/src/OpenXLR.Tests/NativeHostProtocolTests.cs
+++ b/src/OpenXLR.Tests/NativeHostProtocolTests.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class NativeHostProtocolTests
+{
+    private static NativePluginHost Start(string script, TimeSpan? startupTimeout = null)
+        => new(new InsertDefinition { Id = "test", Kind = "lv2", Plugin = "urn:test" },
+            "test", 2, 48000, "/usr/bin/python3", ["-u", "-c", script], startupTimeout);
+
+    [Fact]
+    public void FakeHelperCoversReadyControlMeterAndUiReplies()
+    {
+        using var host = Start("""
+            import sys
+            print('ready')
+            for line in sys.stdin:
+                if line.startswith('set '):
+                    _, symbol, value = line.split()
+                    print('control', symbol, value)
+                    print('meter peak 0.25')
+                elif line.strip() == 'show':
+                    print('heartbeat')
+                    print('ui-heartbeat')
+                    print('ui opened')
+            """);
+        host.SetControl("gain", 0.37);
+        host.ShowUi(); // output before the reply has been consumed by the same reader
+        Assert.True(host.IsHealthy);
+        Assert.Equal(0.25, host.Meters["peak"]);
+        Assert.Equal(0.37, host.DrainChanges().Single().Value);
+        Assert.Empty(host.DrainChanges());
+    }
+
+    [Fact]
+    public void UnresponsiveEditorHasOneSecondBudgetAndCannotQueueMoreShows()
+    {
+        using var host = Start("""
+            import sys
+            print('ready')
+            for line in sys.stdin:
+                if line.strip() == 'show':
+                    print('heartbeat')
+            """);
+        var elapsed = Stopwatch.StartNew();
+        Assert.ThrowsAny<OperationCanceledException>(() => host.ShowUi());
+        Assert.InRange(elapsed.Elapsed.TotalSeconds, 0.8, 2.5);
+        Assert.Contains("already opening", Assert.Throws<InvalidOperationException>(() => host.ShowUi()).Message);
+        Assert.True(host.IsHealthy); // editor timeout must not kill working DSP
+    }
+
+    [Fact]
+    public void MissingReadyFailsWithinStartupDeadline()
+    {
+        var elapsed = Stopwatch.StartNew();
+        Assert.Throws<InvalidOperationException>(() => Start("import time; time.sleep(60)", TimeSpan.FromMilliseconds(150)));
+        Assert.InRange(elapsed.Elapsed.TotalSeconds, 0.1, 3);
+    }
+}

--- a/src/OpenXLR.Tests/NativeHostProtocolTests.cs
+++ b/src/OpenXLR.Tests/NativeHostProtocolTests.cs
@@ -5,9 +5,10 @@ namespace OpenXLR.Tests;
 
 public sealed class NativeHostProtocolTests
 {
-    private static NativePluginHost Start(string script, TimeSpan? startupTimeout = null)
+    private static NativePluginHost Start(string script, TimeSpan? startupTimeout = null,
+        TimeSpan? patience = null)
         => new(new InsertDefinition { Id = "test", Kind = "lv2", Plugin = "urn:test" },
-            "test", 2, 48000, "/usr/bin/python3", ["-u", "-c", script], startupTimeout);
+            "test", 2, 48000, "/usr/bin/python3", ["-u", "-c", script], startupTimeout, patience);
 
     [Fact]
     public void FakeHelperCoversReadyControlMeterAndUiReplies()
@@ -44,7 +45,8 @@ public sealed class NativeHostProtocolTests
                     print('heartbeat')
             """);
         var elapsed = Stopwatch.StartNew();
-        Assert.ThrowsAny<OperationCanceledException>(() => host.ShowUi());
+        Assert.Contains("did not answer in time",
+            Assert.Throws<InvalidOperationException>(() => host.ShowUi()).Message);
         Assert.InRange(elapsed.Elapsed.TotalSeconds, 0.8, 2.5);
         Assert.Contains("already opening", Assert.Throws<InvalidOperationException>(() => host.ShowUi()).Message);
         Assert.True(host.IsHealthy); // editor timeout must not kill working DSP
@@ -56,5 +58,40 @@ public sealed class NativeHostProtocolTests
         var elapsed = Stopwatch.StartNew();
         Assert.Throws<InvalidOperationException>(() => Start("import time; time.sleep(60)", TimeSpan.FromMilliseconds(150)));
         Assert.InRange(elapsed.Elapsed.TotalSeconds, 0.1, 3);
+    }
+
+    [Fact]
+    public async Task AFrozenEditorLoopIsReportedWithoutCondemningTheAudio()
+    {
+        // The helper's two beats mean different things: one says the process
+        // lives, the other that its editor loop is still turning. A plugin's
+        // interface can block the second without touching the first.
+        // One lock around stdout: unbuffered print writes the text and the
+        // newline separately, so two threads can otherwise split a line.
+        using var host = Start("""
+            import sys, threading, time
+            lock = threading.Lock()
+            def say(line):
+                with lock:
+                    sys.stdout.write(line + '\n')
+                    sys.stdout.flush()
+            say('ready')
+            def beat():
+                while True:
+                    say('heartbeat')
+                    time.sleep(0.1)
+            threading.Thread(target=beat, daemon=True).start()
+            for line in sys.stdin:
+                pass
+            """, patience: TimeSpan.FromSeconds(1));
+
+        bool bothTrue = false;
+        for (int attempt = 0; attempt < 60 && !bothTrue; attempt++)
+        {
+            bothTrue = host.IsHealthy && host.EditorStalled;
+            if (!bothTrue) await Task.Delay(100);
+        }
+        Assert.True(bothTrue, "a beating process whose editor loop is frozen should read as both");
+        Assert.Contains("unresponsive", Assert.Throws<InvalidOperationException>(() => host.ShowUi()).Message);
     }
 }

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using OpenXLR.Core.Mixing;
 using OpenXLR.Daemon;
+using OpenXLR.UI;
 
 namespace OpenXLR.Tests;
 
@@ -14,6 +16,16 @@ public sealed class NativeLv2HostTests
     [InlineData("urn:unknown", false)]
     public void NativeHostDoesNotClaimFeaturesItDoesNotImplement(string feature, bool supported)
         => Assert.Equal(supported, NativePluginHost.SupportsFeatures([feature]));
+
+    [Theory]
+    [InlineData("http://lv2plug.in/ns/ext/urid#map", true)]
+    [InlineData("http://lv2plug.in/ns/ext/instance-access", true)]
+    [InlineData("http://lv2plug.in/ns/extensions/ui#parent", true)]
+    [InlineData("http://lv2plug.in/ns/extensions/ui#resize", true)]
+    [InlineData("http://lv2plug.in/ns/extensions/ui#idleInterface", true)]
+    [InlineData("urn:unsupported-ui-feature", false)]
+    public void NativeEditorOnlyClaimsUiFeaturesTheHelperProvides(string feature, bool supported)
+        => Assert.Equal(supported, NativePluginHost.SupportsUiFeatures([feature]));
 
     [Fact]
     public void ForcedGraphRateTakesPrecedenceOverDefaultRate()
@@ -44,8 +56,33 @@ public sealed class NativeLv2HostTests
     public void LiveOutputControlsHaveAnAdditiveStatusField()
     {
         var status = new InsertStatus(new InsertDefinition { Id = "comp", Kind = "lv2", Plugin = "urn:test" },
-            null, new Dictionary<string, double> { ["gain_reduction"] = 3 });
+            null, new Dictionary<string, double> { ["gain_reduction"] = 3 }, NativeHostRunning: true);
         string json = JsonSerializer.Serialize(status, new JsonSerializerOptions(JsonSerializerDefaults.Web));
         Assert.Contains("\"gain_reduction\":3", json);
+        Assert.Contains("\"nativeHostRunning\":true", json);
+    }
+
+    [Fact]
+    public async Task EditorButtonRequiresAHealthyLiveInsert()
+    {
+        await using var client = new DaemonClient();
+        var owner = new InsertsViewModel(client, "xlr1");
+        owner.PluginChoices.Add(new PluginChoice("urn:test", "Test", "", new JsonArray(), NativeEditorAvailable: true));
+        var insert = new InsertViewModel(owner, "comp", "urn:test", "Test");
+        JsonNode definition = JsonNode.Parse("""{"id":"comp","kind":"lv2","plugin":"urn:test","bypass":false,"params":{}}""")!;
+
+        insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: false);
+        Assert.True(insert.NativeEditorSupported);
+        Assert.False(insert.NativeEditorAvailable);
+
+        insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: true);
+        Assert.True(insert.NativeEditorAvailable);
+
+        insert.ApplyFromDaemon(definition, error: "chain build failed", nativeHostRunning: true);
+        Assert.False(insert.NativeEditorAvailable);
+
+        definition["bypass"] = true;
+        insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: true);
+        Assert.False(insert.NativeEditorAvailable);
     }
 }

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+public sealed class NativeLv2HostTests
+{
+    [Theory]
+    [InlineData("http://lv2plug.in/ns/ext/urid#map", true)]
+    [InlineData("http://lv2plug.in/ns/ext/urid#unmap", true)]
+    [InlineData("http://lv2plug.in/ns/ext/worker#schedule", false)]
+    [InlineData("http://lv2plug.in/ns/ext/options#options", false)]
+    [InlineData("urn:unknown", false)]
+    public void NativeHostDoesNotClaimFeaturesItDoesNotImplement(string feature, bool supported)
+        => Assert.Equal(supported, NativePluginHost.SupportsFeatures([feature]));
+
+    [Fact]
+    public void ForcedGraphRateTakesPrecedenceOverDefaultRate()
+        => Assert.Equal(96000, PipeWireAdapter.ParseGraphSampleRate(
+            "key:'clock.rate' value:'48000'\nkey:'clock.force-rate' value:'96000'"));
+
+    [Fact]
+    public void DisabledForcedRateFallsBackToGraphRate()
+        => Assert.Equal(48000, PipeWireAdapter.ParseGraphSampleRate(
+            "key:'clock.force-rate' value:'0'\nkey:'clock.rate' value:'48000'"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("key:'clock.rate' value:'4000'")]
+    public void InvalidRateIsRejectedBeforeOpeningPlugin(string metadata)
+        => Assert.Throws<InvalidOperationException>(() => PipeWireAdapter.ParseGraphSampleRate(metadata));
+
+    [Fact]
+    public void EditorCommandRequiresARealInsertTarget()
+    {
+        using var mixer = new Mixer();
+        var command = new Command { Cmd = "showInsertUi", Channel = "not-a-channel", InsertId = "eq" };
+        Assert.Contains("showInsertUi", CommandValidation.Check(command, mixer, _ => null));
+        Assert.Throws<InvalidOperationException>(() => mixer.ShowInsertUi("xlr1", "missing"));
+    }
+
+    [Fact]
+    public void LiveOutputControlsHaveAnAdditiveStatusField()
+    {
+        var status = new InsertStatus(new InsertDefinition { Id = "comp", Kind = "lv2", Plugin = "urn:test" },
+            null, new Dictionary<string, double> { ["gain_reduction"] = 3 });
+        string json = JsonSerializer.Serialize(status, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.Contains("\"gain_reduction\":3", json);
+    }
+}

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -76,6 +76,9 @@ public sealed class NativeLv2HostTests
         Assert.False(insert.NativeEditorAvailable);
 
         insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: true);
+        Assert.False(insert.NativeEditorAvailable); // A live-process flag does not opt an old insert in.
+        definition["nativeHost"] = true;
+        insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: true);
         Assert.True(insert.NativeEditorAvailable);
 
         insert.ApplyFromDaemon(definition, error: "chain build failed", nativeHostRunning: true);
@@ -84,5 +87,48 @@ public sealed class NativeLv2HostTests
         definition["bypass"] = true;
         insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: true);
         Assert.False(insert.NativeEditorAvailable);
+    }
+
+    [Fact]
+    public void OldInsertJsonKeepsFilterChainAndExplicitChoiceRoundTrips()
+    {
+        var json = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        var old = JsonSerializer.Deserialize<InsertDefinition>("""{"id":"x","kind":"lv2","plugin":"urn:test"}""", json)!;
+        Assert.False(old.NativeHost);
+        var selected = old with { NativeHost = true };
+        Assert.True(JsonSerializer.Deserialize<InsertDefinition>(JsonSerializer.Serialize(selected, json), json)!.NativeHost);
+    }
+
+    [Fact]
+    public void SettingsPreservePerInsertHostChoice()
+    {
+        string dir = Directory.CreateTempSubdirectory("openxlr-host-choice-").FullName;
+        try
+        {
+            var legacy = new InsertDefinition { Id = "old", Kind = "lv2", Plugin = "urn:test" };
+            var settings = new MixerSettings { Inserts = new() { ["mix:stream"] = [legacy, legacy with { Id = "new", NativeHost = true }] } };
+            string path = Path.Combine(dir, "mixer.json");
+            Assert.Null(settings.Save(path));
+            var loaded = MixerSettings.Load(path)!.Inserts["mix:stream"];
+            Assert.False(loaded[0].NativeHost);
+            Assert.True(loaded[1].NativeHost);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task UiPreservesExplicitChoiceAndCanDisableItWhenHelperIsUnavailable()
+    {
+        await using var client = new DaemonClient();
+        var owner = new InsertsViewModel(client, "xlr1");
+        owner.Apply(JsonNode.Parse("""[{"insert":{"id":"x","kind":"lv2","plugin":"urn:test","nativeHost":true},"error":"helper unavailable"}]"""));
+        var insert = Assert.Single(owner.Items);
+        Assert.True(insert.NativeHost);
+        Assert.True(insert.CanChooseNativeHost);
+        Assert.False(insert.NativeEditorAvailable);
+        Assert.Contains("\"nativeHost\":true", JsonSerializer.Serialize(insert.ToPayload()));
+        owner.Apply(JsonNode.Parse("""[{"insert":{"id":"x","kind":"lv2","plugin":"urn:test"}}]"""));
+        Assert.False(insert.NativeHost);
+        Assert.Contains("\"nativeHost\":false", JsonSerializer.Serialize(insert.ToPayload()));
     }
 }

--- a/src/OpenXLR.Tests/RestartPolicyTests.cs
+++ b/src/OpenXLR.Tests/RestartPolicyTests.cs
@@ -1,0 +1,44 @@
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class RestartPolicyTests
+{
+    [Fact]
+    public void AChainThatKeepsDyingIsLeftOffUntilTheWindowPasses()
+    {
+        long now = 0;
+        var policy = new RestartPolicy(() => now, limit: 3, windowMs: 300_000);
+        Assert.False(policy.Blocked("xlr1"));
+
+        // Three deaths are three rebuilds; the fourth leaves the chain off.
+        for (int death = 1; death <= 3; death++)
+        {
+            now += 1_000;
+            policy.Failed("xlr1");
+            Assert.Equal(death == 3, policy.Blocked("xlr1"));
+        }
+
+        // Another chain's history is its own.
+        policy.Failed("mix:stream");
+        Assert.False(policy.Blocked("mix:stream"));
+
+        // The window runs from the first death, so a chain that has been quiet
+        // for long enough gets its chances back.
+        now += 300_001;
+        Assert.False(policy.Blocked("xlr1"));
+    }
+
+    [Fact]
+    public void ChangingAChainMakesItNewAgain()
+    {
+        long now = 0;
+        var policy = new RestartPolicy(() => now, limit: 2, windowMs: 300_000);
+        policy.Failed("xlr1");
+        policy.Failed("xlr1");
+        Assert.True(policy.Blocked("xlr1"));
+
+        policy.Forget("xlr1");
+        Assert.False(policy.Blocked("xlr1"));
+    }
+}

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -347,6 +347,10 @@ public sealed class DaemonClient : IAsyncDisposable
         => SendAsync(new Dictionary<string, object>
         { ["cmd"] = "setInsertBypass", ["channel"] = channel, ["insertId"] = insertId, ["value"] = bypass });
 
+    public Task ShowInsertUiAsync(string channel, string insertId)
+        => SendAsync(new Dictionary<string, object>
+        { ["cmd"] = "showInsertUi", ["channel"] = channel, ["insertId"] = insertId });
+
     public Task SetInsertParamAsync(string channel, string insertId, string symbol, double value)
         => SendAsync(new Dictionary<string, object>
         { ["cmd"] = "setInsertParam", ["channel"] = channel, ["insertId"] = insertId, ["symbol"] = symbol, ["value"] = value });

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml
@@ -50,6 +50,9 @@
         <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
       </StackPanel>
       <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Top">
+        <Button Content="Plugin UI" Padding="12,4" Click="OnNativeEditor"
+                IsVisible="{Binding NativeEditorAvailable}"
+                ToolTip.Tip="Open this plugin's own editor on the live audio instance"/>
         <Button Content="Defaults" Padding="12,4" Click="OnDefaults"
                 ToolTip.Tip="Put every control back to the plugin's own defaults"/>
         <ToggleButton Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}" Padding="12,4"/>

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml
@@ -51,7 +51,8 @@
       </StackPanel>
       <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Top">
         <Button Content="Plugin UI" Padding="12,4" Click="OnNativeEditor"
-                IsVisible="{Binding NativeEditorAvailable}"
+                IsVisible="{Binding NativeEditorSupported}"
+                IsEnabled="{Binding NativeEditorAvailable}"
                 ToolTip.Tip="Open this plugin's own editor on the live audio instance"/>
         <Button Content="Defaults" Padding="12,4" Click="OnDefaults"
                 ToolTip.Tip="Put every control back to the plugin's own defaults"/>

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml
@@ -48,6 +48,9 @@
         </StackPanel>
         <TextBlock Text="{Binding Plugin}" Classes="h" FontSize="11"/>
         <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
+        <ToggleButton Content="Native host" IsChecked="{Binding NativeHost, Mode=TwoWay}"
+                      IsVisible="{Binding CanChooseNativeHost}" Padding="12,4" HorizontalAlignment="Left"
+                      ToolTip.Tip="Use the optional native host for this insert. Switching rebuilds its chain and may briefly interrupt audio."/>
       </StackPanel>
       <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Top">
         <Button Content="Plugin UI" Padding="12,4" Click="OnNativeEditor"

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml
@@ -48,9 +48,13 @@
         </StackPanel>
         <TextBlock Text="{Binding Plugin}" Classes="h" FontSize="11"/>
         <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
-        <ToggleButton Content="Native host" IsChecked="{Binding NativeHost, Mode=TwoWay}"
-                      IsVisible="{Binding CanChooseNativeHost}" Padding="12,4" HorizontalAlignment="Left"
-                      ToolTip.Tip="Use the optional native host for this insert. Switching rebuilds its chain and may briefly interrupt audio."/>
+        <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Left"
+                    IsVisible="{Binding CanChooseNativeHost}">
+          <ToggleButton Content="Native host" IsChecked="{Binding NativeHost, Mode=TwoWay}" Padding="12,4"
+                        ToolTip.Tip="Run this insert in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
+          <Button Content="Manual" Padding="10,4" Click="OnEditorManual" VerticalAlignment="Center"
+                  ToolTip.Tip="Open the manual section on plugin editors"/>
+        </StackPanel>
       </StackPanel>
       <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Top">
         <Button Content="Plugin UI" Padding="12,4" Click="OnNativeEditor"

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml.cs
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml.cs
@@ -17,5 +17,10 @@ public partial class InsertControlsWindow : Window
 
     private void OnDefaults(object? sender, RoutedEventArgs e) => (DataContext as InsertViewModel)?.ResetToDefaults();
 
+    private async void OnNativeEditor(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is InsertViewModel insert) await insert.Owner.ShowNativeEditorAsync(insert);
+    }
+
     private void OnClose(object? sender, RoutedEventArgs e) => Close();
 }

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml.cs
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml.cs
@@ -22,5 +22,10 @@ public partial class InsertControlsWindow : Window
         if (DataContext is InsertViewModel insert) await insert.Owner.ShowNativeEditorAsync(insert);
     }
 
+    private const string EditorManual =
+        "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#plugin-editors";
+
+    private void OnEditorManual(object? sender, RoutedEventArgs e) => ExternalLink.Open(EditorManual);
+
     private void OnClose(object? sender, RoutedEventArgs e) => Close();
 }

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -9,7 +9,7 @@ using Avalonia.Threading;
 namespace OpenXLR.UI;
 
 /// <summary>A plugin the picker offers (mono in / mono out only for the mic path).</summary>
-public sealed record PluginChoice(string Uri, string Name, string Category, JsonNode Params)
+public sealed record PluginChoice(string Uri, string Name, string Category, JsonNode Params, bool NativeEditorAvailable = false)
 {
     public override string ToString() => Category.Length > 0 ? $"{Name}  ({Category})" : Name;
 }
@@ -39,6 +39,9 @@ public sealed class InsertsViewModel : ViewModelBase
 
     /// <summary>What the chain belongs to, for window titles ("XLR 1", "Stream mix").</summary>
     public string Title { get; }
+
+    public Task ShowNativeEditorAsync(InsertViewModel insert)
+        => _client.ShowInsertUiAsync(_channel, insert.Id);
 
     /// <summary>Picker header: which plugins fit this chain.</summary>
     public string PickerHint => _channels == 1
@@ -106,7 +109,8 @@ public sealed class InsertsViewModel : ViewModelBase
                     p["plugin"]!.GetValue<string>(),
                     p["name"]?.GetValue<string>() ?? p["plugin"]!.GetValue<string>(),
                     p["category"]?.GetValue<string>() ?? "",
-                    p["params"] ?? new JsonArray()));
+                    p["params"] ?? new JsonArray(),
+                    p["nativeEditorAvailable"]?.GetValue<bool>() == true));
             }
             string width = _channels == 1 ? "mono" : "stereo";
             Note = PluginChoices.Count == 0
@@ -226,6 +230,7 @@ public sealed class InsertViewModel : ViewModelBase
 
     /// <summary>The channel chain this insert belongs to (row buttons route through it).</summary>
     public InsertsViewModel Owner => _owner;
+    public bool NativeEditorAvailable => !Bypass && _owner.PluginChoices.Any(p => p.Uri == Plugin && p.NativeEditorAvailable);
 
     private readonly Dictionary<string, double> _params = [];
 
@@ -233,7 +238,7 @@ public sealed class InsertViewModel : ViewModelBase
     public bool Bypass
     {
         get => _bypass;
-        set { if (Set(ref _bypass, value)) { Raise(nameof(StateText)); Raise(nameof(IsActive)); _owner.SendBypass(this, value); } }
+        set { if (Set(ref _bypass, value)) { Raise(nameof(StateText)); Raise(nameof(IsActive)); Raise(nameof(NativeEditorAvailable)); _owner.SendBypass(this, value); } }
     }
 
     private string? _error;
@@ -347,6 +352,7 @@ public sealed class InsertViewModel : ViewModelBase
 
     private void BuildParams()
     {
+        Raise(nameof(NativeEditorAvailable));
         if (_owner.ParamsFor(Plugin) is not JsonArray arr) return;
         foreach (JsonNode? p in arr)
         {

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -142,7 +142,8 @@ public sealed class InsertsViewModel : ViewModelBase
                 string id = ins["id"]!.GetValue<string>();
                 if (!byId.TryGetValue(id, out InsertViewModel? vm))
                     vm = new InsertViewModel(this, id, ins["plugin"]!.GetValue<string>(), ins["label"]?.GetValue<string>() ?? id);
-                vm.ApplyFromDaemon(ins, entry?["error"]?.GetValue<string>());
+                vm.ApplyFromDaemon(ins, entry?["error"]?.GetValue<string>(),
+                    entry?["nativeHostRunning"]?.GetValue<bool>() == true);
                 next.Add(vm);
             }
             if (!next.SequenceEqual(Items))
@@ -230,7 +231,8 @@ public sealed class InsertViewModel : ViewModelBase
 
     /// <summary>The channel chain this insert belongs to (row buttons route through it).</summary>
     public InsertsViewModel Owner => _owner;
-    public bool NativeEditorAvailable => !Bypass && _owner.PluginChoices.Any(p => p.Uri == Plugin && p.NativeEditorAvailable);
+    public bool NativeEditorSupported => _owner.PluginChoices.Any(p => p.Uri == Plugin && p.NativeEditorAvailable);
+    public bool NativeEditorAvailable => NativeEditorSupported && !Bypass && !HasError && NativeHostRunning;
 
     private readonly Dictionary<string, double> _params = [];
 
@@ -245,9 +247,16 @@ public sealed class InsertViewModel : ViewModelBase
     public string? Error
     {
         get => _error;
-        private set { if (Set(ref _error, value)) { Raise(nameof(HasError)); Raise(nameof(StateText)); Raise(nameof(IsActive)); } }
+        private set { if (Set(ref _error, value)) { Raise(nameof(HasError)); Raise(nameof(StateText)); Raise(nameof(IsActive)); Raise(nameof(NativeEditorAvailable)); } }
     }
     public bool HasError => _error is not null;
+
+    private bool _nativeHostRunning;
+    public bool NativeHostRunning
+    {
+        get => _nativeHostRunning;
+        private set { if (Set(ref _nativeHostRunning, value)) Raise(nameof(NativeEditorAvailable)); }
+    }
 
     public string StateText => HasError ? "problem" : Bypass ? "bypassed" : "active";
 
@@ -322,13 +331,15 @@ public sealed class InsertViewModel : ViewModelBase
                 Groups.Add(new InsertParamGroup(g, true, l));
     }
 
-    public void ApplyFromDaemon(JsonNode ins, string? error)
+    public void ApplyFromDaemon(JsonNode ins, string? error, bool nativeHostRunning)
     {
         _bypass = ins["bypass"]?.GetValue<bool>() ?? false;
         Raise(nameof(Bypass));
         Raise(nameof(StateText));
         Raise(nameof(IsActive));
+        Raise(nameof(NativeEditorAvailable));
         Error = error;
+        NativeHostRunning = nativeHostRunning;
         _params.Clear();
         if (ins["params"] is JsonObject po)
             foreach ((string k, JsonNode? v) in po)
@@ -352,6 +363,7 @@ public sealed class InsertViewModel : ViewModelBase
 
     private void BuildParams()
     {
+        Raise(nameof(NativeEditorSupported));
         Raise(nameof(NativeEditorAvailable));
         if (_owner.ParamsFor(Plugin) is not JsonArray arr) return;
         foreach (JsonNode? p in arr)

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -205,6 +205,11 @@ public sealed class InsertsViewModel : ViewModelBase
 
     internal bool Applying => _applying;
 
+    internal void SendHostChoice()
+    {
+        if (!_applying) _ = _client.SetInsertsAsync(_channel, Snapshot());
+    }
+
     /// <summary>The current chain as the daemon wants it, minus an optional id.</summary>
     private List<object> Snapshot(IEnumerable<InsertViewModel>? order = null, string? skip = null)
         => [.. (order ?? Items).Where(i => i.Id != skip).Select(i => (object)i.ToPayload())];
@@ -232,7 +237,23 @@ public sealed class InsertViewModel : ViewModelBase
     /// <summary>The channel chain this insert belongs to (row buttons route through it).</summary>
     public InsertsViewModel Owner => _owner;
     public bool NativeEditorSupported => _owner.PluginChoices.Any(p => p.Uri == Plugin && p.NativeEditorAvailable);
-    public bool NativeEditorAvailable => NativeEditorSupported && !Bypass && !HasError && NativeHostRunning;
+    public bool NativeEditorAvailable => NativeEditorSupported && NativeHost && !Bypass && !HasError && NativeHostRunning;
+
+    private bool _nativeHost;
+    public bool NativeHost
+    {
+        get => _nativeHost;
+        set
+        {
+            if (Set(ref _nativeHost, value))
+            {
+                Raise(nameof(NativeEditorAvailable));
+                Raise(nameof(CanChooseNativeHost));
+                _owner.SendHostChoice();
+            }
+        }
+    }
+    public bool CanChooseNativeHost => NativeEditorSupported || NativeHost;
 
     private readonly Dictionary<string, double> _params = [];
 
@@ -334,6 +355,9 @@ public sealed class InsertViewModel : ViewModelBase
     public void ApplyFromDaemon(JsonNode ins, string? error, bool nativeHostRunning)
     {
         _bypass = ins["bypass"]?.GetValue<bool>() ?? false;
+        _nativeHost = ins["nativeHost"]?.GetValue<bool>() ?? false;
+        Raise(nameof(NativeHost));
+        Raise(nameof(CanChooseNativeHost));
         Raise(nameof(Bypass));
         Raise(nameof(StateText));
         Raise(nameof(IsActive));
@@ -364,6 +388,7 @@ public sealed class InsertViewModel : ViewModelBase
     private void BuildParams()
     {
         Raise(nameof(NativeEditorSupported));
+        Raise(nameof(CanChooseNativeHost));
         Raise(nameof(NativeEditorAvailable));
         if (_owner.ParamsFor(Plugin) is not JsonArray arr) return;
         foreach (JsonNode? p in arr)
@@ -394,6 +419,7 @@ public sealed class InsertViewModel : ViewModelBase
         ["plugin"] = Plugin,
         ["label"] = Label,
         ["bypass"] = _bypass,
+        ["nativeHost"] = _nativeHost,
         ["params"] = new Dictionary<string, double>(_params),
     };
 }


### PR DESCRIPTION
## Scope

Optional native LV2 host, split from #10 and based on main `9f60f5b` after the live channel creation and order PRs. No layout editor, VST3, themes, release changes or CI tooling.

- The ordinary .NET build does not invoke a C compiler. Opt in at build time with `EnableNativeLv2Host=true`.
- Native hosting is also an explicit **per-insert** choice: `nativeHost` defaults to false. Installing the helper does not switch existing settings/profiles away from PipeWire filter-chain. The control window offers a Native host toggle; disabling it returns to filter-chain. Changing the choice rebuilds the chain and may briefly interrupt audio.
- Explicit native selections without a usable helper/editor report an error, not a silent host substitution. The UI preserves the choice and allows it to be disabled if the helper becomes unavailable.
- The catalog checks the required features of both DSP and the exact selected X11 UI. Editor availability also requires an opted-in, non-bypassed, error-free insert and a live native process.
- Native editors control the same instance that processes audio. Controls return through normal settings persistence. Mixed chains retain filter-chain for all non-opted-in stages.
- Parent-owned pipe EOF/HUP controls helper lifetime. Separate audio/UI progress avoids treating a stalled editor alone as stalled DSP.

## Verification

- 217 Release tests pass, including old insert JSON defaulting to filter-chain, persisted host choices, UI payload preservation/recovery, feature gating and editor liveness. The existing upstream Lv2BundleTests xUnit2013 warning is not suppressed.
- Explicit native-enabled build and C11 helper compilation with C warnings as errors pass.
- Private PipeWire/Pulse/WirePlumber acceptance with Xvfb: an installed helper leaves a legacy insert in filter-chain; two instances of the same plugin in one chain honor different explicit host choices.
- The helper survives its creating managed Thread exiting. Mixed native/filter-chain build, dead-stage detection, cleanup and rebuild pass. The actual Mixer path passes real editor gesture, saved control values and reconstruction after its native process is killed.
- Earlier isolated runs verified continuing audio during a deliberately stalled UI thread, bounded parent-pipe cleanup, and the published optional helper. Those measurements are documented in the earlier comments, not claimed as freshly repeated for every code change.

Acceptance tools remain outside the PR. No seamless swapping is claimed.

## Maintainer sequencing

The per-insert opt-in prerequisite from the roadmap is implemented. The explicit hold until the remaining editable-layout work settles is still respected. Distribution-specific helper packaging is also still outstanding before shipping; this PR does not claim to complete it. Worker/state support, VST3/CLAP, presets and latency compensation remain separate work.
