### PR TITLE
Add opt-in throttled update notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Collect diagnostics).
   and source once a second, and serves a WebSocket API on
   127.0.0.1:37890. The UI has a routing graph view, a tray icon and a
   diagnostics archive exporter.
+- **Optional update notice**: the UI can check the upstream GitHub release
+  feed for a newer stable release. Startup checks are off by default and,
+  when enabled, run at most once per day. Nothing is installed automatically.
 
 The full feature list, area by area: [docs/features.md](docs/features.md).
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -41,6 +41,12 @@ If you only want hardware control and no mixer, turn the submixer off
 in Options (section 3.8). The daemon restarts in hardware-control mode
 and the `OpenXLR …` devices disappear.
 
+Update checks are also controlled in Options. They are off by default. You can
+make one explicit check with **Check now**, or opt into a background check at
+startup; opted-in checks run at most once per 24 hours. A notice contains the
+upstream stable release notes as plain text and a link to GitHub. OpenXLR never
+downloads or installs an update.
+
 ## 2. Concepts
 
 **Channels** are where audio enters the mixer. Three carry the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,7 @@ plugin world, and it has to keep the audio path inside PipeWire.
   with a start limit, a Restart button in the window, and a graceful
   signal so teardown always runs. Never a restart loop when the audio
   server is down; the daemon degrades to device control instead.
-- [ ] Update notice: an opt-in, throttled check against the project's
+- [x] Update notice: an opt-in, throttled check against the project's
   releases, presented once, never automatic installation.
 - [ ] A documented, versioned local API for third parties, once client
   authentication exists on top of the origin check; today the WebSocket

--- a/src/OpenXLR.Tests/UpdateCheckerTests.cs
+++ b/src/OpenXLR.Tests/UpdateCheckerTests.cs
@@ -63,6 +63,41 @@ public sealed class UpdateCheckerTests
     }
 
     [Fact]
+    public async Task DeadlineCancelsAStalledBodyAfterHeadersArrive()
+    {
+        using var stream = new StalledStream();
+        using var handler = new StreamHandler(stream);
+        using var http = new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
+        var checker = new UpdateChecker(http, TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => checker.CheckAsync("0.1.20").WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(stream.ReadStarted);
+    }
+
+    private sealed class StreamHandler(Stream stream) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(stream),
+            });
+    }
+
+    private sealed class StalledStream : MemoryStream
+    {
+        public bool ReadStarted { get; private set; }
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            ReadStarted = true;
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+    }
+
+    [Fact]
     public void AutomaticChecksAreOptInAndDaily()
     {
         var now = new DateTimeOffset(2026, 9, 5, 8, 0, 0, TimeSpan.Zero);

--- a/src/OpenXLR.Tests/UpdateCheckerTests.cs
+++ b/src/OpenXLR.Tests/UpdateCheckerTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Text.Json;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+/// <summary>Offline contracts: these tests never contact GitHub or install anything.</summary>
+public sealed class UpdateCheckerTests
+{
+    [Theory]
+    [InlineData("v1.10.0", "1.9.9", true)]
+    [InlineData("1.2.0", "1.2", false)]
+    [InlineData("1.2.0", "1.2.0+abc", false)]
+    [InlineData("1.2.0-rc1", "1.1.0", false)]
+    [InlineData("v0.1.19", "0.1.20", false)]
+    [InlineData("latest", "0.1.20", false)]
+    public void VersionsCompareNumerically(string remote, string local, bool expected)
+        => Assert.Equal(expected, UpdateChecker.Newer(remote, local));
+
+    [Fact]
+    public async Task ReleaseUsesConstructedUpstreamUrlAndBoundedPlainNotes()
+    {
+        using var handler = new ResponseHandler(JsonSerializer.Serialize(new
+        {
+            tag_name = "v0.2.0",
+            body = new string('a', 15000),
+            html_url = "https://evil.example/run",
+        }));
+        using var http = new HttpClient(handler);
+
+        UpdateResult result = await new UpdateChecker(http).CheckAsync("0.1.20");
+
+        Assert.True(result.Available);
+        Assert.Equal("https://github.com/emaspa/openxlr/releases/tag/v0.2.0", result.Url);
+        Assert.InRange(result.Details.Length, 12000, 12100);
+        Assert.Equal("api.github.com", handler.RequestUri!.Host);
+        Assert.Null(handler.Authorization);
+    }
+
+    [Theory]
+    [InlineData("{\"tag_name\":\"v99.0.0\",\"prerelease\":true}")]
+    [InlineData("{\"tag_name\":\"v99.0.0\",\"draft\":true}")]
+    [InlineData("{\"tag_name\":null}")]
+    public async Task DraftPrereleaseAndMissingTagsAreNotAdvertised(string response)
+    {
+        using var handler = new ResponseHandler(response);
+        using var http = new HttpClient(handler);
+
+        UpdateResult result = await new UpdateChecker(http).CheckAsync("0.1.20");
+
+        Assert.False(result.Available);
+        Assert.Null(result.Url);
+    }
+
+    [Fact]
+    public async Task OversizedResponseIsRejected()
+    {
+        using var handler = new ResponseHandler(new string('x', 512 * 1024 + 1));
+        using var http = new HttpClient(handler);
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => new UpdateChecker(http).CheckAsync("0.1.20"));
+    }
+
+    [Fact]
+    public void AutomaticChecksAreOptInAndDaily()
+    {
+        var now = new DateTimeOffset(2026, 9, 5, 8, 0, 0, TimeSpan.Zero);
+        Assert.False(UpdatesViewModel.AutomaticCheckDue(new UiSettings(), now));
+        Assert.True(UpdatesViewModel.AutomaticCheckDue(
+            new UiSettings { CheckForUpdates = true }, now));
+        Assert.False(UpdatesViewModel.AutomaticCheckDue(new UiSettings
+        {
+            CheckForUpdates = true,
+            LastUpdateCheckUtc = now.AddHours(-23),
+        }, now));
+        Assert.True(UpdatesViewModel.AutomaticCheckDue(new UiSettings
+        {
+            CheckForUpdates = true,
+            LastUpdateCheckUtc = now.AddHours(-24),
+        }, now));
+    }
+
+    private sealed class ResponseHandler(string response) : HttpMessageHandler
+    {
+        public Uri? RequestUri { get; private set; }
+        public System.Net.Http.Headers.AuthenticationHeaderValue? Authorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RequestUri = request.RequestUri;
+            Authorization = request.Headers.Authorization;
+            Assert.NotEmpty(request.Headers.UserAgent);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(response),
+            });
+        }
+    }
+}

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -215,6 +215,15 @@
     <TextBlock Text="{Binding DaemonRestart.Status}" Classes="h" TextWrapping="Wrap"
                Margin="0,0,0,8" IsVisible="{Binding DaemonRestart.Status, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
+    <Border Classes="card" Margin="0,0,0,8" IsVisible="{Binding Updates.BannerVisible}">
+      <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+        <TextBlock Text="{Binding Updates.Title}" Foreground="#5ba8f5"
+                   TextWrapping="Wrap" VerticalAlignment="Center"/>
+        <Button Grid.Column="1" Content="View changes" Click="OnUpdates"/>
+        <Button Grid.Column="2" Content="Dismiss" Click="OnDismissUpdate" Background="Transparent"/>
+      </Grid>
+    </Border>
+
     <!-- a daemon left running across an upgrade offers the old version's controls -->
     <Border Classes="card" Margin="0,0,0,8" IsVisible="{Binding DaemonVersionMismatch}">
       <DockPanel>

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -15,6 +16,8 @@ public partial class MainWindow : Window
     private readonly MainViewModel _vm;
     private TrayIcon? _tray;
     private bool _reallyExit;
+    private readonly CancellationTokenSource _lifetime = new();
+    private bool _automaticUpdateCheckStarted;
 
     public MainWindow()
     {
@@ -25,6 +28,12 @@ public partial class MainWindow : Window
         HeaderVersion.Text = $"v{AppVersion.Current}";
         SetupTray();
         RestoreSectionState();
+        Opened += async (_, _) =>
+        {
+            if (_automaticUpdateCheckStarted) return;
+            _automaticUpdateCheckStarted = true;
+            await _vm.Updates.CheckAsync(manual: false, cancellation: _lifetime.Token);
+        };
 
         // Start hidden in the tray when configured (and a tray actually
         // exists; otherwise the window must show or nothing is reachable).
@@ -48,8 +57,10 @@ public partial class MainWindow : Window
         };
         Closed += async (_, _) =>
         {
+            _lifetime.Cancel();
             _tray?.Dispose();
             await _client.DisposeAsync();
+            _lifetime.Dispose();
             // A window that started hidden is not the lifetime's MainWindow,
             // so closing it for real must end the process explicitly.
             if (Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop
@@ -97,6 +108,12 @@ public partial class MainWindow : Window
 
     private void OnAbout(object? sender, RoutedEventArgs e)
         => new AboutWindow().ShowDialog(this);
+
+    private void OnUpdates(object? sender, RoutedEventArgs e)
+        => new UpdatesWindow { DataContext = _vm.Updates }.ShowDialog(this);
+
+    private void OnDismissUpdate(object? sender, RoutedEventArgs e)
+        => _vm.Updates.DismissBanner();
 
     private async void OnProfileSave(object? sender, RoutedEventArgs e)
     {

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -20,6 +20,7 @@ public sealed class OptionsViewModel : ViewModelBase
 
     /// <summary>Exposed for the diagnostics collector in the Options window.</summary>
     public DaemonClient Client => _client;
+    public UpdatesViewModel Updates => _main.Updates;
 
     public OptionsViewModel(DaemonClient client, MainViewModel main)
     {
@@ -31,6 +32,7 @@ public sealed class OptionsViewModel : ViewModelBase
         _openWindowAtLogin = s.OpenWindowAtLogin;
         _minimizeToTray = s.MinimizeToTray;
         _startMinimized = s.StartMinimized;
+        _checkForUpdates = s.CheckForUpdates;
         // No saved choice means the daemon runs whatever its unit asked for,
         // which for every shipped unit is the submixer on.
         _submixer = DaemonPrefs.Load().Submixer ?? true;
@@ -46,6 +48,13 @@ public sealed class OptionsViewModel : ViewModelBase
     }
 
     // --- startup behaviour ---
+
+    private bool _checkForUpdates;
+    public bool CheckForUpdates
+    {
+        get => _checkForUpdates;
+        set { if (Set(ref _checkForUpdates, value)) Persist(); }
+    }
 
     private bool _startDaemonAtLogin;
     public bool StartDaemonAtLogin
@@ -134,6 +143,7 @@ public sealed class OptionsViewModel : ViewModelBase
         OpenWindowAtLogin = _openWindowAtLogin,
         MinimizeToTray = _minimizeToTray,
         StartMinimized = _startMinimized,
+        CheckForUpdates = _checkForUpdates,
     }).Save();
 
     // --- enforced system defaults ---

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -46,6 +46,21 @@
 
     <Border Classes="card">
       <StackPanel Spacing="6">
+        <TextBlock Text="UPDATES" Classes="h"/>
+        <CheckBox Content="Check GitHub for stable releases at startup (at most once per day)"
+                  IsChecked="{Binding CheckForUpdates, Mode=TwoWay}"/>
+        <TextBlock Text="Off by default. Check now makes one explicit request. Nothing is downloaded or installed."
+                   FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
+        <TextBlock Text="{Binding Updates.Title}" Foreground="#5ba8f5" TextWrapping="Wrap"/>
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <Button Content="Check now" Click="OnCheckUpdates" IsEnabled="{Binding !Updates.Busy}"/>
+          <Button Content="View result" Click="OnUpdates"/>
+        </StackPanel>
+      </StackPanel>
+    </Border>
+
+    <Border Classes="card">
+      <StackPanel Spacing="6">
         <TextBlock Text="SYSTEM DEFAULT DEVICES" Classes="h"/>
         <TextBlock Text="When set, OpenXLR holds these as the system defaults and reverts any outside change, like Wave Link does. Applications that follow the system default will use them."
                    FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>

--- a/src/OpenXLR.UI/OptionsWindow.axaml.cs
+++ b/src/OpenXLR.UI/OptionsWindow.axaml.cs
@@ -38,4 +38,15 @@ public partial class OptionsWindow : Window
     }
 
     private void OnClose(object? sender, RoutedEventArgs e) => Close();
+
+    private async void OnCheckUpdates(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is OptionsViewModel vm) await vm.Updates.CheckAsync(manual: true);
+    }
+
+    private void OnUpdates(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is OptionsViewModel vm)
+            new UpdatesWindow { DataContext = vm.Updates }.ShowDialog(this);
+    }
 }

--- a/src/OpenXLR.UI/UiSettings.cs
+++ b/src/OpenXLR.UI/UiSettings.cs
@@ -18,6 +18,12 @@ public sealed record UiSettings
     public bool OpenWindowAtLogin { get; init; }
     public bool MinimizeToTray { get; init; }
     public bool StartMinimized { get; init; }
+    /// <summary>Opt-in only. False means the UI performs no startup network request.</summary>
+    public bool CheckForUpdates { get; init; }
+    /// <summary>Successful or failed automatic checks are limited to once per day.</summary>
+    public DateTimeOffset? LastUpdateCheckUtc { get; init; }
+    /// <summary>Release tag whose banner the user dismissed.</summary>
+    public string? DismissedUpdate { get; init; }
     /// <summary>Names of the main window's tiles the user collapsed (INPUTS, HEADPHONES, ...).</summary>
     public IReadOnlyList<string> CollapsedSections { get; init; } = [];
 

--- a/src/OpenXLR.UI/UpdateChecker.cs
+++ b/src/OpenXLR.UI/UpdateChecker.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenXLR.UI;
+
+public sealed record UpdateResult(bool Available, string Tag, string Title, string Details, string? Url);
+
+/// <summary>
+/// Read-only release check against the upstream repository. It never downloads
+/// or installs a package, follows no redirects, and renders release notes as
+/// plain text.
+/// </summary>
+public sealed class UpdateChecker
+{
+    private const string ReleasesEndpoint = "https://api.github.com/repos/emaspa/openxlr/releases/latest";
+    private readonly HttpClient _http;
+    private static readonly HttpClient SharedHttp = new(new HttpClientHandler { AllowAutoRedirect = false })
+    { Timeout = TimeSpan.FromSeconds(8) };
+
+    public UpdateChecker() : this(SharedHttp) { }
+    internal UpdateChecker(HttpClient http) => _http = http;
+
+    public async Task<UpdateResult> CheckAsync(string installedVersion, CancellationToken cancellation = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, ReleasesEndpoint);
+        request.Headers.UserAgent.ParseAdd("OpenXLR-UpdateCheck/1.0");
+        request.Headers.Accept.ParseAdd("application/vnd.github+json");
+        using HttpResponseMessage response = await _http.SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, cancellation).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        const int limit = 512 * 1024;
+        if (response.Content.Headers.ContentLength is > limit)
+            throw new InvalidDataException("GitHub response exceeds the update-check size limit.");
+        await using Stream input = await response.Content.ReadAsStreamAsync(cancellation).ConfigureAwait(false);
+        using var content = new MemoryStream();
+        var buffer = new byte[8192];
+        int length;
+        while ((length = await input.ReadAsync(buffer, cancellation).ConfigureAwait(false)) > 0)
+        {
+            if (content.Length + length > limit)
+                throw new InvalidDataException("GitHub response exceeds the update-check size limit.");
+            content.Write(buffer, 0, length);
+        }
+
+        using JsonDocument document = JsonDocument.Parse(content.ToArray());
+        JsonElement root = document.RootElement;
+        string tag = String(root, "tag_name");
+        bool released = !Flag(root, "draft") && !Flag(root, "prerelease");
+        if (!released || !Newer(tag, installedVersion))
+            return new(false, tag, "OpenXLR is up to date",
+                $"Installed version: {installedVersion}. Latest stable release: {tag}.", null);
+
+        string details = String(root, "body");
+        if (details.Length > 12000) details = details[..12000] + "\n… Open GitHub for the complete notes.";
+        return new(true, tag, $"New OpenXLR release {tag}", details,
+            $"https://github.com/emaspa/openxlr/releases/tag/{Uri.EscapeDataString(tag)}");
+    }
+
+    internal static bool Newer(string tag, string installed)
+    {
+        static Version? Parse(string value) =>
+            Version.TryParse(value.TrimStart('v', 'V').Split('+', '-')[0], out Version? parsed)
+                ? new Version(parsed.Major, parsed.Minor, Math.Max(0, parsed.Build), Math.Max(0, parsed.Revision))
+                : null;
+        Version? remote = Parse(tag), local = Parse(installed);
+        return !tag.Contains('-', StringComparison.Ordinal) && remote is not null && local is not null && remote > local;
+    }
+
+    private static string String(JsonElement value, string key)
+        => value.ValueKind == JsonValueKind.Object && value.TryGetProperty(key, out JsonElement item)
+            && item.ValueKind == JsonValueKind.String ? item.GetString() ?? "" : "";
+    private static bool Flag(JsonElement value, string key)
+        => value.TryGetProperty(key, out JsonElement item) && item.ValueKind == JsonValueKind.True;
+}
+
+/// <summary>Coalesced UI state for manual and opt-in daily checks.</summary>
+public sealed class UpdatesViewModel : ViewModelBase
+{
+    private readonly Func<CancellationToken, Task<UpdateResult>> _check;
+    private readonly Func<DateTimeOffset> _clock;
+
+    public UpdatesViewModel() : this(
+        token => new UpdateChecker().CheckAsync(AppVersion.Current, token),
+        () => DateTimeOffset.UtcNow) { }
+
+    internal UpdatesViewModel(Func<CancellationToken, Task<UpdateResult>> check,
+        Func<DateTimeOffset>? clock = null)
+    {
+        _check = check;
+        _clock = clock ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    private bool _busy;
+    public bool Busy { get => _busy; private set => Set(ref _busy, value); }
+    private bool _available;
+    public bool Available { get => _available; private set => Set(ref _available, value); }
+    private bool _bannerVisible;
+    public bool BannerVisible { get => _bannerVisible; private set => Set(ref _bannerVisible, value); }
+    private string _title = "Updates have not been checked";
+    public string Title { get => _title; private set => Set(ref _title, value); }
+    private string _details = "No network request is made unless you check manually or opt in below.";
+    public string Details { get => _details; private set => Set(ref _details, value); }
+    private string? _url;
+    public string? Url { get => _url; private set => Set(ref _url, value); }
+    private string? _tag;
+
+    public static bool AutomaticCheckDue(UiSettings settings, DateTimeOffset now)
+        => settings.CheckForUpdates &&
+           (settings.LastUpdateCheckUtc is null || now - settings.LastUpdateCheckUtc >= TimeSpan.FromHours(24));
+
+    public async Task CheckAsync(bool manual, CancellationToken cancellation = default)
+    {
+        if (Busy) return;
+        UiSettings settings = UiSettings.Load();
+        if (!manual && !AutomaticCheckDue(settings, _clock())) return;
+        Busy = true;
+        try
+        {
+            UpdateResult result = await _check(cancellation);
+            Available = result.Available;
+            _tag = result.Tag;
+            Title = result.Title;
+            Details = result.Details;
+            Url = result.Url;
+            BannerVisible = result.Available && settings.DismissedUpdate != result.Tag;
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { }
+        catch (Exception)
+        {
+            Available = false;
+            BannerVisible = false;
+            Url = null;
+            Title = "Update check unavailable";
+            Details = "Audio is unaffected. Retry later or open the release page manually.";
+        }
+        finally
+        {
+            // A failed endpoint must not be retried on every UI launch either.
+            (UiSettings.Load() with { LastUpdateCheckUtc = _clock() }).Save();
+            Busy = false;
+        }
+    }
+
+    public void DismissBanner()
+    {
+        if (_tag is not null) (UiSettings.Load() with { DismissedUpdate = _tag }).Save();
+        BannerVisible = false;
+    }
+}

--- a/src/OpenXLR.UI/UpdateChecker.cs
+++ b/src/OpenXLR.UI/UpdateChecker.cs
@@ -18,14 +18,24 @@ public sealed class UpdateChecker
 {
     private const string ReleasesEndpoint = "https://api.github.com/repos/emaspa/openxlr/releases/latest";
     private readonly HttpClient _http;
+    private readonly TimeSpan _timeout;
     private static readonly HttpClient SharedHttp = new(new HttpClientHandler { AllowAutoRedirect = false })
     { Timeout = TimeSpan.FromSeconds(8) };
 
     public UpdateChecker() : this(SharedHttp) { }
-    internal UpdateChecker(HttpClient http) => _http = http;
+    internal UpdateChecker(HttpClient http, TimeSpan? timeout = null)
+    {
+        _http = http;
+        _timeout = timeout ?? TimeSpan.FromSeconds(8);
+    }
 
     public async Task<UpdateResult> CheckAsync(string installedVersion, CancellationToken cancellation = default)
     {
+        // ResponseHeadersRead ends HttpClient's timeout at the headers. Keep
+        // one deadline over the body too, including a server that stops sending.
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        deadline.CancelAfter(_timeout);
+        cancellation = deadline.Token;
         using var request = new HttpRequestMessage(HttpMethod.Get, ReleasesEndpoint);
         request.Headers.UserAgent.ParseAdd("OpenXLR-UpdateCheck/1.0");
         request.Headers.Accept.ParseAdd("application/vnd.github+json");

--- a/src/OpenXLR.UI/UpdatesWindow.axaml
+++ b/src/OpenXLR.UI/UpdatesWindow.axaml
@@ -1,0 +1,19 @@
+<Window xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:OpenXLR.UI" x:Class="OpenXLR.UI.UpdatesWindow" x:DataType="vm:UpdatesViewModel"
+        Title="OpenXLR updates" Width="660" Height="520" MinWidth="420" MinHeight="300"
+        WindowStartupLocation="CenterOwner" Background="#16181d">
+  <Grid Margin="18" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="12">
+    <TextBlock Text="{Binding Title}" FontSize="19" FontWeight="SemiBold"
+               Foreground="#e6e9f0" TextWrapping="Wrap"/>
+    <TextBlock Grid.Row="1" Text="Release notes are plain text. OpenXLR never installs an update automatically."
+               Foreground="#8b93a7" TextWrapping="Wrap"/>
+    <ScrollViewer Grid.Row="2">
+      <SelectableTextBlock Text="{Binding Details}" TextWrapping="Wrap" Foreground="#d2d6df"/>
+    </ScrollViewer>
+    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+      <Button Content="Check again" Click="OnCheck" IsEnabled="{Binding !Busy}"/>
+      <Button Content="Open on GitHub" Click="OnOpen" IsVisible="{Binding Available}"/>
+      <Button Content="Close" Click="OnClose"/>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/OpenXLR.UI/UpdatesWindow.axaml.cs
+++ b/src/OpenXLR.UI/UpdatesWindow.axaml.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace OpenXLR.UI;
+
+public partial class UpdatesWindow : Window
+{
+    public UpdatesWindow() => InitializeComponent();
+
+    private async void OnCheck(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is UpdatesViewModel vm) await vm.CheckAsync(manual: true);
+    }
+
+    private void OnOpen(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not UpdatesViewModel { Url: { } url }) return;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
+            uri.Scheme != "https" || uri.Host != "github.com") return;
+        try
+        {
+            var start = new ProcessStartInfo("xdg-open") { UseShellExecute = false };
+            start.ArgumentList.Add(url);
+            Process.Start(start)?.Dispose();
+        }
+        catch (Exception) { /* opening a browser is best effort */ }
+    }
+
+    private void OnClose(object? sender, RoutedEventArgs e) => Close();
+}

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -33,6 +33,7 @@ public abstract class ViewModelBase : INotifyPropertyChanged
 public sealed class MainViewModel : ViewModelBase
 {
     public DaemonRestartViewModel DaemonRestart { get; } = new();
+    public UpdatesViewModel Updates { get; } = new();
 
     private readonly DaemonClient _client;
     private bool _applying;


### PR DESCRIPTION
## Summary

This extracts the update-notice part of #10 into a focused pull request.

- keep update checks disabled by default and require an explicit opt-in
- check at most once per day, with a separate manual **Check now** action
- query only the official `emaspa/openxlr` GitHub releases endpoint
- accept stable releases only and compare numeric semantic versions
- never download or install anything automatically
- bound the response size and timeout, reject redirects, and construct the release link locally
- render release notes as plain text and allow a release to be dismissed

## Verification

- `dotnet test OpenXLR.slnx -c Release` — 95/95 passed
- `git diff --check`
- tests cover default-off behavior, daily throttling, semantic version ordering, safe release URLs/plain-text notes, ignored drafts/prereleases, oversized responses, and a stalled response body after headers

This intentionally does not include the authenticated HTTP API or any unrelated mixer/UI work from #10.
