### PR TITLE
Add versioned HTTP API with the existing session token

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,8 @@
 # WebSocket API
 
+The [versioned local HTTP API](http-api.md) provides request/response access to
+the same commands and uses the same per-session credential.
+
 The daemon serves `ws://127.0.0.1:37890/ws` on the loopback interface
 only. A handshake that carries a browser `Origin` header from anywhere
 but localhost is refused with 403, so a web page you happen to visit

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,45 @@
+# Local HTTP API v1
+
+The daemon listens on `127.0.0.1:37890`. HTTP requests use the same per-session
+token as the existing WebSocket clients, presented as `Authorization: Bearer
+<token>`. Read it from `$XDG_RUNTIME_DIR/openxlr/token`, or from
+`$XDG_CONFIG_HOME/openxlr/token` (`~/.config/openxlr/token`) when the runtime
+directory is unset. The daemon creates the private token file at startup.
+There is no second credential or change to the existing UI/OpenDeck login.
+
+Foreign browser Origins are refused even with a valid token. JSON commands
+require `Content-Type: application/json` with UTF-8 encoding. Credentials in
+query strings are not accepted. Keep the token out of logs and bug reports.
+
+| Endpoint | Response |
+|---|---|
+| `GET /healthz` | Unauthenticated process liveness only, not hardware readiness |
+| `GET /api/v1` | Version and endpoint discovery |
+| `GET /api/v1/state` | Combined state message |
+| `GET /api/v1/plugins` | v1 result containing a plugins message |
+| `POST /api/v1/commands` | Execute one existing cmd object |
+| `WS /api/v1/events` | Same authenticated protocol as /ws |
+
+Both WebSocket paths require the existing first-message authentication:
+`{"cmd":"auth","token":"..."}`. They send no state before authentication.
+HTTP's Bearer header does not replace that WebSocket exchange. Ping, close,
+message deadlines and command budgets remain the same on both socket paths.
+
+Commands use the names and fields in [the WebSocket API](api.md), including
+current Monitor A/B feed commands. Both transports share the dispatcher,
+validation and broadcasts. HTTP returns
+`{"apiVersion":"1","ok":true,"messages":[]}` after a successful mutation.
+Read replies are in `messages`; rejected commands return HTTP 400, `ok:false`
+and an error message. Some rejected optimistic edits also include current state.
+This reports execution, not a new durability guarantee: saving follows each
+existing command's behavior. Never automatically retry a mutation after losing
+the connection; it may already have executed.
+
+Error status codes: 401 missing/wrong token, 403 foreign Origin, 408 body-read
+deadline, 413 body over 64 KiB, 415 wrong Content-Type, 429 budget exhausted or
+another HTTP mutation in flight. Chunked bodies have the same 64 KiB cap and
+five-second deadline. One HTTP command runs at a time, with no waiting queue.
+All authenticated HTTP responses use `Cache-Control: no-store`.
+
+The [OpenAPI document](openapi-v1.json) describes the HTTP endpoints. Restarting
+the daemon rotates its existing per-session token; clients must reread it.

--- a/docs/openapi-v1.json
+++ b/docs/openapi-v1.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.3",
+  "info": {"title": "OpenXLR local API", "version": "1"},
+  "servers": [{"url": "http://127.0.0.1:37890"}],
+  "security": [{"localToken": []}],
+  "paths": {
+    "/healthz": {"get": {"security": [], "responses": {"200": {"description": "Process alive, not hardware readiness"}}}},
+    "/api/v1": {"get": {"responses": {"200": {"description": "Endpoint discovery"}, "401": {"description": "Credential required"}}}},
+    "/api/v1/state": {"get": {"responses": {"200": {"description": "Combined state message"}, "401": {"description": "Credential required"}}}},
+    "/api/v1/plugins": {"get": {"responses": {"200": {"description": "v1 result containing plugins message"}, "401": {"description": "Credential required"}}}},
+    "/api/v1/commands": {"post": {
+      "description": "Execute the existing cmd protocol. Foreign browser origins are rejected. Maximum UTF-8 body size is 65536 bytes, including chunked requests.",
+      "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["cmd"], "properties": {"cmd": {"type": "string"}}, "additionalProperties": true}}}},
+      "responses": {
+        "200": {"description": "Executed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CommandResult"}}}},
+        "400": {"description": "Invalid or rejected command", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CommandResult"}}}},
+        "401": {"description": "Credential required"}, "403": {"description": "Foreign Origin"},
+        "408": {"description": "Body-read deadline"}, "413": {"description": "Body too large"},
+        "415": {"description": "UTF-8 application/json required"}, "429": {"description": "Budget exhausted or command in flight"}
+      }
+    }},
+    "/api/v1/events": {"get": {"description": "Authenticated WebSocket upgrade; the existing state, meters and command protocol", "responses": {"101": {"description": "WebSocket connected"}, "400": {"description": "Upgrade required"}, "401": {"description": "Credential required"}}}}
+  },
+  "components": {
+    "securitySchemes": {"localToken": {"type": "http", "scheme": "bearer", "description": "Existing per-session token from OpenXlrPaths.TokenPath"}},
+    "schemas": {"CommandResult": {"type": "object", "required": ["apiVersion", "ok", "messages"], "properties": {
+      "apiVersion": {"type": "string", "enum": ["1"]}, "ok": {"type": "boolean"},
+      "messages": {"type": "array", "items": {"type": "object", "additionalProperties": true}}
+    }}}
+  }
+}

--- a/src/OpenXLR.Daemon/ApiEndpoints.cs
+++ b/src/OpenXLR.Daemon/ApiEndpoints.cs
@@ -1,0 +1,97 @@
+using System.Net.Http.Headers;
+using System.Text;
+using OpenXLR.Core;
+using System.Text.Json;
+
+namespace OpenXLR.Daemon;
+
+internal static class ApiEndpoints
+{
+    internal const int MaxCommandBytes = 64 * 1024;
+    internal static bool Authorized(HttpRequest request, string? secret)
+        => request.Headers.Authorization.Count == 1 &&
+           AuthenticationHeaderValue.TryParse(request.Headers.Authorization, out var header) &&
+           header.Scheme.Equals("Bearer", StringComparison.OrdinalIgnoreCase) &&
+           header.Parameter is { Length: 64 } token &&
+           ApiToken.Matches(secret, JsonSerializer.SerializeToUtf8Bytes(new { cmd = "auth", token }));
+
+    internal static bool IsJson(string? contentType)
+        => MediaTypeHeaderValue.TryParse(contentType, out var value) &&
+           value.MediaType?.Equals("application/json", StringComparison.OrdinalIgnoreCase) == true &&
+           (value.CharSet is null || value.CharSet.Trim('"').Equals("utf-8", StringComparison.OrdinalIgnoreCase));
+
+    internal static async Task<string?> ReadCommandAsync(Stream body, CancellationToken stop)
+    {
+        using var content = new MemoryStream();
+        var buffer = new byte[8192];
+        int read;
+        while ((read = await body.ReadAsync(buffer, stop)) != 0)
+        {
+            if (content.Length + read > MaxCommandBytes) return null;
+            content.Write(buffer, 0, read);
+        }
+        return new UTF8Encoding(false, true).GetString(content.ToArray());
+    }
+
+    internal static void Map(WebApplication app, string? secret)
+    {
+        app.Use(async (context, next) =>
+        {
+            if (context.Request.Path.StartsWithSegments("/api/v1"))
+            {
+                context.Response.Headers.CacheControl = "no-store";
+                if (!LoopbackOrigin.IsAllowed(context.Request.Headers.Origin))
+                { context.Response.StatusCode = 403; return; }
+                if (context.Request.Path != "/api/v1/events" && !Authorized(context.Request, secret))
+                {
+                    context.Response.Headers.WWWAuthenticate = "Bearer";
+                    context.Response.StatusCode = 401;
+                    return;
+                }
+            }
+            await next(context);
+        });
+
+        app.MapGet("/healthz", () => Results.Json(new { status = "alive" }));
+        app.MapGet("/api/v1", () => Results.Json(new { apiVersion = "1", state = "/api/v1/state",
+            plugins = "/api/v1/plugins", commands = "/api/v1/commands", events = "/api/v1/events" }));
+        app.MapGet("/api/v1/state", (WebSocketHub hub) => Results.Json(hub.Snapshot()));
+        app.MapGet("/api/v1/plugins", async (WebSocketHub hub) =>
+            Results.Json(await hub.ExecuteForApiAsync("{\"cmd\":\"listPlugins\"}")));
+        var budget = new CommandBudget();
+        var commandGate = new SemaphoreSlim(1, 1);
+        app.MapPost("/api/v1/commands", async (HttpContext context, WebSocketHub hub) =>
+        {
+            if (!IsJson(context.Request.ContentType)) return Results.StatusCode(415);
+            if (context.Request.ContentLength > MaxCommandBytes) return Results.StatusCode(413);
+            lock (budget) if (!budget.TryTake()) return Results.StatusCode(429);
+            // One in-flight HTTP mutation, without an unbounded command queue.
+            if (!await commandGate.WaitAsync(0, context.RequestAborted)) return Results.StatusCode(429);
+            try
+            {
+                string? text;
+                using var deadline = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted);
+                deadline.CancelAfter(TimeSpan.FromSeconds(5));
+                try { text = await ReadCommandAsync(context.Request.Body, deadline.Token); }
+                catch (DecoderFallbackException) { return Results.BadRequest(); }
+                catch (OperationCanceledException) { return Results.StatusCode(408); }
+                if (text is null) return Results.StatusCode(413);
+                ApiCommandResult result = await hub.ExecuteForApiAsync(text);
+                return Results.Json(result, statusCode: result.Ok ? 200 : 400);
+            }
+            finally { commandGate.Release(); }
+        });
+        app.Map("/api/v1/events", async (HttpContext context, WebSocketHub hub) =>
+        {
+            if (!context.WebSockets.IsWebSocketRequest) { context.Response.StatusCode = 400; return; }
+            using var socket = await context.WebSockets.AcceptWebSocketAsync(new WebSocketAcceptContext
+            {
+                KeepAliveInterval = SocketGuard.KeepAliveInterval,
+                KeepAliveTimeout = SocketGuard.KeepAliveTimeout,
+            });
+            await hub.HandleAsync(socket);
+        });
+    }
+}
+
+internal sealed record ApiCommandResult(string ApiVersion, bool Ok, IReadOnlyList<object> Messages);

--- a/src/OpenXLR.Daemon/ApiEndpoints.cs
+++ b/src/OpenXLR.Daemon/ApiEndpoints.cs
@@ -33,7 +33,12 @@ internal static class ApiEndpoints
         return new UTF8Encoding(false, true).GetString(content.ToArray());
     }
 
-    internal static void Map(WebApplication app, string? secret)
+    /// <summary>
+    /// The token is read per request: the daemon publishes it only once the
+    /// port is bound (see ApiToken), which is after these endpoints are
+    /// mapped, and a restart rotates it.
+    /// </summary>
+    internal static void Map(WebApplication app)
     {
         app.Use(async (context, next) =>
         {
@@ -42,7 +47,7 @@ internal static class ApiEndpoints
                 context.Response.Headers.CacheControl = "no-store";
                 if (!LoopbackOrigin.IsAllowed(context.Request.Headers.Origin))
                 { context.Response.StatusCode = 403; return; }
-                if (context.Request.Path != "/api/v1/events" && !Authorized(context.Request, secret))
+                if (context.Request.Path != "/api/v1/events" && !Authorized(context.Request, ApiToken.Current))
                 {
                     context.Response.Headers.WWWAuthenticate = "Bearer";
                     context.Response.StatusCode = 401;

--- a/src/OpenXLR.Daemon/Program.cs
+++ b/src/OpenXLR.Daemon/Program.cs
@@ -47,6 +47,7 @@ app.Services.GetRequiredService<WebSocketHub>();   // construct so it subscribes
 ApiToken.PublishWhenListening(app.Lifetime, app.Logger);
 
 app.UseWebSockets();
+ApiEndpoints.Map(app, ApiToken.Current);
 
 app.Map("/ws", async (HttpContext ctx, WebSocketHub hub) =>
 {

--- a/src/OpenXLR.Daemon/Program.cs
+++ b/src/OpenXLR.Daemon/Program.cs
@@ -47,7 +47,7 @@ app.Services.GetRequiredService<WebSocketHub>();   // construct so it subscribes
 ApiToken.PublishWhenListening(app.Lifetime, app.Logger);
 
 app.UseWebSockets();
-ApiEndpoints.Map(app, ApiToken.Current);
+ApiEndpoints.Map(app);
 
 app.Map("/ws", async (HttpContext ctx, WebSocketHub hub) =>
 {

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -60,7 +60,7 @@ public sealed class WebSocketHub
     // Last recalled or saved profile per device id, for the state message.
     private readonly ConcurrentDictionary<string, string> _activeProfile = new();
 
-    private StateMessage Snapshot() =>
+    internal StateMessage Snapshot() =>
         _devices.Snapshot() with
         {
             DaemonVersion = OpenXLR.Daemon.DaemonVersion.Current,
@@ -150,32 +150,42 @@ public sealed class WebSocketHub
         }
     }
 
-    private async Task Dispatch(Client client, string text)
+    private Task Dispatch(Client client, string text)
+        => DispatchAsync(message => client.SendAsync(Serialize(message)), text);
+
+    internal async Task<ApiCommandResult> ExecuteForApiAsync(string text)
+    {
+        var messages = new List<object>();
+        await DispatchAsync(message => { messages.Add(message); return Task.CompletedTask; }, text);
+        return new("1", !messages.Any(message => message is ErrorMessage), messages);
+    }
+
+    private async Task DispatchAsync(Func<object, Task> reply, string text)
     {
         Command? cmd;
         try { cmd = JsonSerializer.Deserialize<Command>(text, Json); }
-        catch (JsonException ex) { await client.SendAsync(Serialize(new ErrorMessage($"bad json: {ex.Message}"))); return; }
-        if (cmd is null) return;
+        catch (JsonException ex) { await reply(new ErrorMessage($"bad json: {ex.Message}")); return; }
+        if (cmd is null) { await reply(new ErrorMessage("command must be an object")); return; }
 
         switch (cmd.Cmd)
         {
             case "auth":
                 break;   // already authenticated on this socket; a repeat is harmless
             case "getState":
-                await client.SendAsync(Serialize(Snapshot()));
+                await reply(Snapshot());
                 break;
             case "getDiagnostics":
-                await client.SendAsync(Serialize(new DiagnosticsMessage(_devices.DumpBlocks())));
+                await reply(new DiagnosticsMessage(_devices.DumpBlocks()));
                 break;
             case "listPlugins":
                 // The first call may block on lilv's scan; keep it off the socket loop's thread.
                 IReadOnlyList<OpenXLR.Core.Mixing.PluginInfo> plugins = await Task.Run(() => OpenXLR.Core.Mixing.Lv2Catalog.Plugins);
-                await client.SendAsync(Serialize(new PluginsMessage(plugins)));
+                await reply(new PluginsMessage(plugins));
                 break;
             case "set":
-                if (cmd.Control is null) { await client.SendAsync(Serialize(new ErrorMessage("set: missing 'control'"))); break; }
+                if (cmd.Control is null) { await reply(new ErrorMessage("set: missing 'control'")); break; }
                 string? err = _devices.Apply(cmd.Control, cmd.Value);  // broadcasts on success
-                if (err is not null) await client.SendAsync(Serialize(new ErrorMessage(err)));
+                if (err is not null) await reply(new ErrorMessage(err));
                 break;
             case "setLevel":
             case "setChannelMuted":
@@ -198,37 +208,37 @@ public sealed class WebSocketHub
                 string? mixErr = _mixer.Apply(cmd);                     // broadcasts on success
                 if (mixErr is not null)
                 {
-                    await client.SendAsync(Serialize(new ErrorMessage(mixErr)));
+                    await reply(new ErrorMessage(mixErr));
                     // Controls are optimistic in both clients. Follow an error
                     // with authoritative state so a rejected ClipGuard/plugin
                     // change snaps back instead of looking enabled forever.
-                    await client.SendAsync(Serialize(Snapshot()));
+                    await reply(Snapshot());
                 }
                 break;
             case "setActiveDevice":
-                if (cmd.Device is null) { await client.SendAsync(Serialize(new ErrorMessage("setActiveDevice: missing 'device'"))); break; }
+                if (cmd.Device is null) { await reply(new ErrorMessage("setActiveDevice: missing 'device'")); break; }
                 string? devSelErr = _devices.SetActiveDevice(cmd.Device);
-                if (devSelErr is not null) await client.SendAsync(Serialize(new ErrorMessage(devSelErr)));
+                if (devSelErr is not null) await reply(new ErrorMessage(devSelErr));
                 break;
             case "saveProfile":
             case "loadProfile":
             case "deleteProfile":
                 string? profErr = HandleProfile(cmd);
-                if (profErr is not null) await client.SendAsync(Serialize(new ErrorMessage(profErr)));
+                if (profErr is not null) await reply(new ErrorMessage(profErr));
                 else Broadcast(Snapshot());   // list (and loaded state) changed
                 break;
             case "setRecallOnConnect":
                 string? recallErr = HandleRecallOnConnect(cmd);
-                if (recallErr is not null) await client.SendAsync(Serialize(new ErrorMessage(recallErr)));
+                if (recallErr is not null) await reply(new ErrorMessage(recallErr));
                 else Broadcast(Snapshot());
                 break;
             case "resetDevice":
                 string? resetErr = _devices.ResetToDefaults();   // the state change broadcasts itself
-                if (resetErr is not null) await client.SendAsync(Serialize(new ErrorMessage(resetErr)));
+                if (resetErr is not null) await reply(new ErrorMessage(resetErr));
                 else _log.LogInformation("reset {dev} to its firmware defaults", ActiveDeviceId());
                 break;
             default:
-                await client.SendAsync(Serialize(new ErrorMessage($"unknown cmd '{cmd.Cmd}'")));
+                await reply(new ErrorMessage($"unknown cmd '{cmd.Cmd}'"));
                 break;
         }
     }

--- a/src/OpenXLR.Tests/HttpApiTests.cs
+++ b/src/OpenXLR.Tests/HttpApiTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenXLR.Core;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+public sealed class HttpApiTests
+{
+    [Fact]
+    public async Task ChunkedBodyCannotBypassTheSizeLimit()
+    {
+        using var stream = new MemoryStream(new byte[ApiEndpoints.MaxCommandBytes + 1]);
+        Assert.Null(await ApiEndpoints.ReadCommandAsync(stream, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("application/json", true)]
+    [InlineData("application/json; charset=utf-8", true)]
+    [InlineData("application/json; charset=utf-16", false)]
+    [InlineData("text/plain", false)]
+    [InlineData("application/x-www-form-urlencoded", false)]
+    [InlineData(null, false)]
+    public void JsonContentTypeIsRequired(string? type, bool accepted)
+        => Assert.Equal(accepted, ApiEndpoints.IsJson(type));
+
+    [Fact]
+    public async Task RealHttpRequestsEnforceAuthenticationOriginAndCommandLimits()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        // Deliberately do not register hosted services: no USB/audio graph starts.
+        builder.Services.AddSingleton<DeviceManager>();
+        builder.Services.AddSingleton<MixerService>();
+        builder.Services.AddSingleton<WebSocketHub>();
+        await using var app = builder.Build();
+        app.UseWebSockets();
+        const string token = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        ApiEndpoints.Map(app, token);
+        await app.StartAsync();
+        try
+        {
+            var address = app.Services.GetRequiredService<IServer>().Features
+                .Get<IServerAddressesFeature>()!.Addresses.Single();
+            using var http = new HttpClient { BaseAddress = new Uri(address) };
+            using var denied = await http.GetAsync("/api/v1");
+            Assert.Equal(HttpStatusCode.Unauthorized, denied.StatusCode);
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var accepted = await http.GetAsync("/api/v1");
+            Assert.Equal(HttpStatusCode.OK, accepted.StatusCode);
+            http.DefaultRequestHeaders.Add("Origin", "https://foreign.example");
+            using var foreign = await http.GetAsync("/api/v1");
+            Assert.Equal(HttpStatusCode.Forbidden, foreign.StatusCode);
+            http.DefaultRequestHeaders.Remove("Origin");
+            using var plain = await http.PostAsync("/api/v1/commands", new StringContent("{}"));
+            Assert.Equal(HttpStatusCode.UnsupportedMediaType, plain.StatusCode);
+            using var oversized = await http.PostAsync("/api/v1/commands",
+                new StringContent(new string(' ', ApiEndpoints.MaxCommandBytes + 1), Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, oversized.StatusCode);
+            using var invalid = await http.PostAsync("/api/v1/commands",
+                new StringContent("null", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.BadRequest, invalid.StatusCode);
+            using var valid = await http.PostAsync("/api/v1/commands",
+                new StringContent("{\"cmd\":\"getDiagnostics\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, valid.StatusCode);
+            Assert.Contains("\"ok\":true", await valid.Content.ReadAsStringAsync());
+        }
+        finally { await app.StopAsync(); }
+    }
+}

--- a/src/OpenXLR.Tests/HttpApiTests.cs
+++ b/src/OpenXLR.Tests/HttpApiTests.cs
@@ -12,6 +12,8 @@ using OpenXLR.Daemon;
 
 namespace OpenXLR.Tests;
 
+// Publishes a token file under a redirected runtime directory, like the other store tests.
+[Collection("xdg-config")]
 public sealed class HttpApiTests
 {
     [Fact]
@@ -43,8 +45,15 @@ public sealed class HttpApiTests
         builder.Services.AddSingleton<WebSocketHub>();
         await using var app = builder.Build();
         app.UseWebSockets();
-        const string token = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        ApiEndpoints.Map(app, token);
+        // The endpoints read the daemon's live token per request; publish one
+        // into a scratch runtime directory the way the daemon does at start.
+        string runtimeDir = Path.Combine(Path.GetTempPath(), "openxlr-test-" + Guid.NewGuid().ToString("N"));
+        string? previousRuntime = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+        Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", runtimeDir);
+        string token;
+        try { ApiToken.Initialize(); token = ApiToken.Current!; }
+        finally { Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", previousRuntime); try { Directory.Delete(runtimeDir, recursive: true); } catch (IOException) { } }
+        ApiEndpoints.Map(app);
         await app.StartAsync();
         try
         {


### PR DESCRIPTION
Adds versioned HTTP access to the existing command dispatcher on current main. HTTP clients use the daemon's existing per-session token in a Bearer header; the window, OpenDeck and `/ws` retain their current authentication behavior.

- state, plugin catalog and command endpoints, plus `/api/v1/events` using the existing authenticated WebSocket protocol
- Origin and UTF-8 JSON Content-Type checks; 64 KiB limit including chunked bodies, body-read deadline, command budget and no waiting mutation queue
- shared validation, command dispatch and broadcasts, including current Monitor A/B feed commands
- HTTP/OpenAPI documentation with token paths, failure statuses and retry semantics

Verification: 158 Release tests passed, including real HTTP requests for authentication, foreign Origin, content type, oversized body, rejected commands and successful dispatch; `git diff --check` passed. Current upstream tests emit existing CA1416 platform warnings in ApiTokenTests/PrivateFilesTests; this PR does not suppress them.

This is the HTTP API portion of #10, rebuilt on upstream's authentication and socket hardening. It adds no second credential system, layout change, native host, version change or CI tooling.
