### PR TITLE
Generate OpenDeck mixer choices from daemon state

### DIFF
--- a/plugin/com.emaspa.openxlr.sdPlugin/layout-choices.mjs
+++ b/plugin/com.emaspa.openxlr.sdPlugin/layout-choices.mjs
@@ -1,0 +1,68 @@
+// Pure helpers for the editable mixer layout. Targets always carry stable
+// daemon ids; labels come from the latest state so renames do not invalidate
+// existing OpenDeck actions.
+
+const LEGACY_CHANNELS = {
+  xlr1: "XLR 1", xlr2: "XLR 2", aux: "Aux In", game: "Game",
+  music: "Music", browser: "Browser", system: "System",
+  voicechat: "Voice Chat", sfx: "SFX",
+};
+const LEGACY_MIXES = { monitor: "Monitor A", monitor2: "Monitor B", stream: "Stream", chat: "Chat", auxout: "Aux" };
+
+export function channelName(mixer, id) {
+  return mixer?.channels?.find((channel) => channel.id === id)?.name
+    ?? LEGACY_CHANNELS[id] ?? id;
+}
+
+export function mixName(mixer, id) {
+  return mixer?.mixes?.find((mix) => mix.id === id)?.name
+    ?? LEGACY_MIXES[id] ?? id;
+}
+
+export function mixShortName(mixer, id) {
+  if (id === "all") return "All";
+  const name = mixName(mixer, id);
+  if (id === "monitor" && name === "Monitor A") return "MonA";
+  if (id === "monitor2" && name === "Monitor B") return "MonB";
+  return name.length <= 5 ? name : `${name.slice(0, 4)}…`;
+}
+
+const option = (target, label) => ({ target, label });
+
+export function layoutChoices(mixer) {
+  const mixes = mixer?.mixes ?? [];
+  const channels = mixer?.channels ?? [];
+  if (!mixes.length || !channels.length) return { toggleGroups: [], levelGroups: [] };
+
+  const toggleGroups = [{
+    id: "layout-mix-mutes",
+    label: "Mix mutes",
+    items: mixes.map((mix) => option(`mixmute:${mix.id}`, `${mix.name} mix mute`)),
+  }];
+  for (const mix of mixes) toggleGroups.push({
+    id: `layout-send-mutes-${mix.id}`,
+    label: `Send mutes: ${mix.name}`,
+    items: channels.map((channel) => option(
+      `sendmute:${channel.id}:${mix.id}`, `${channel.name} in ${mix.name}`)),
+  });
+
+  const levelGroups = [
+    {
+      id: "layout-mix-levels",
+      label: "Mix masters",
+      items: mixes.map((mix) => option(`mixvol:${mix.id}`, `${mix.name} mix master`)),
+    },
+    {
+      id: "layout-all-sends",
+      label: "Sends: all mixes",
+      items: channels.map((channel) => option(`send:${channel.id}:all`, `${channel.name} in all mixes`)),
+    },
+  ];
+  for (const mix of mixes) levelGroups.push({
+    id: `layout-send-levels-${mix.id}`,
+    label: `Sends: ${mix.name}`,
+    items: channels.map((channel) => option(
+      `send:${channel.id}:${mix.id}`, `${channel.name} in ${mix.name}`)),
+  });
+  return { toggleGroups, levelGroups };
+}

--- a/plugin/com.emaspa.openxlr.sdPlugin/plugin.mjs
+++ b/plugin/com.emaspa.openxlr.sdPlugin/plugin.mjs
@@ -4,6 +4,7 @@
 // and dials stay in sync with the UI (and with the hardware) for free.
 
 import process from "node:process";
+import { channelName, mixName, mixShortName, layoutChoices } from "./layout-choices.mjs";
 import fs from "node:fs";
 import os from "node:os";
 
@@ -17,14 +18,6 @@ const pluginUUID = arg("-pluginUUID");
 const registerEvent = arg("-registerEvent");
 
 // ---------- static naming ----------
-const CHANNELS = {
-  xlr1: "XLR 1", xlr2: "XLR 2", aux: "Aux In", game: "Game",
-  music: "Music", browser: "Browser", system: "System",
-  voicechat: "Voice Chat", sfx: "SFX",
-};
-const MIXES = { monitor: "Monitor A", monitor2: "Monitor B", stream: "Stream", chat: "Chat", auxout: "Aux" };
-const MIX_SHORT = { monitor: "MonA", monitor2: "MonB", stream: "Str", chat: "Cht", auxout: "Aux", all: "All" };
-
 // Toggle targets on the device state block, with short key labels.
 const DEVICE_TOGGLES = {
   mute: "XLR 1\nMute", mute2: "XLR 2\nMute",
@@ -44,6 +37,16 @@ const MUTE_LIKE = new Set(["mute", "mute2"]);
 
 // ---------- daemon connection ----------
 let daemon = null;
+const layoutInspectors = new Set();
+let lastLayout = "";
+function publishLayout() {
+  const choices = layoutChoices(daemonState?.mixer);
+  const serialized = JSON.stringify(choices);
+  if (serialized === lastLayout) return;
+  lastLayout = serialized;
+  for (const context of layoutInspectors)
+    send({ event: "sendToPropertyInspector", context, payload: choices });
+}
 let daemonState = null;   // last full {"type":"state"} message
 let daemonUp = false;
 let meterLevels = null;   // last {"type":"meters"} levels, keyed ch:/mix:
@@ -86,7 +89,7 @@ function connectDaemon() {
     if (daemon !== socket) return;
     let m;
     try { m = JSON.parse(e.data); } catch { return; }
-    if (m.type === "state") { daemonState = m; refreshAll(); }
+    if (m.type === "state") { daemonState = m; refreshAll(); publishLayout(); }
     else if (m.type === "meters") { meterLevels = m.levels; refreshMeters(); }
     else if (m.type === "plugins") {
       catalog = new Map((m.plugins ?? []).map((p) => [p.plugin, p]));
@@ -150,9 +153,9 @@ const isInsertTarget = (t) =>
 
 // Chains the daemon exposes, in the order the UI shows them.
 const chainName = (ch) =>
-  ch.startsWith("mix:") ? `${MIXES[ch.slice(4)] ?? ch.slice(4)} mix` : CHANNELS[ch] ?? ch;
+  ch.startsWith("mix:") ? `${mixName(mixer(), ch.slice(4))} mix` : channelName(mixer(), ch);
 const chainShort = (ch) =>
-  ch.startsWith("mix:") ? `${MIX_SHORT[ch.slice(4)] ?? ch.slice(4)} mix` : CHANNELS[ch] ?? ch;
+  ch.startsWith("mix:") ? `${mixShortName(mixer(), ch.slice(4))} mix` : channelName(mixer(), ch);
 const insertsOf = (ch) => (mixer()?.inserts?.[ch] ?? []).map((s) => s.insert ?? s);
 
 // A short plugin name for a key face: drop the vendor prefix and the
@@ -308,7 +311,12 @@ host.onmessage = (e) => {
       break;
     }
     case "sendToPlugin":
-      if (m.payload?.request === "outputs")
+      if (m.payload?.request === "layout") {
+        layoutInspectors.add(m.context);
+        send({ event: "sendToPropertyInspector", context: m.context,
+               payload: layoutChoices(daemonState?.mixer) });
+      }
+      else if (m.payload?.request === "outputs")
         send({ event: "sendToPropertyInspector", context: m.context,
                payload: { outputs: outputDevices() } });
       else if (m.payload?.request === "inserts")
@@ -317,6 +325,9 @@ host.onmessage = (e) => {
       else if (m.payload?.request === "profiles")
         send({ event: "sendToPropertyInspector", context: m.context,
                payload: { profiles: profileChoices() } });
+      break;
+    case "propertyInspectorDidDisappear":
+      layoutInspectors.delete(m.context);
       break;
   }
 };
@@ -453,10 +464,10 @@ function toggleLabel(target, inst) {
     const name = d?.description ?? sink.split(".").pop();
     return `${name}\nMonitor ${feedLetters(feedOf(sink))}`;
   }
-  if (target.startsWith("mixmute:")) return `${MIXES[target.slice(8)] ?? target.slice(8)}\nMute`;
+  if (target.startsWith("mixmute:")) return `${mixName(mixer(), target.slice(8))}\nMute`;
   if (target.startsWith("sendmute:")) {
     const [, ch, mix] = target.split(":");
-    return `${CHANNELS[ch] ?? ch}\n· ${MIX_SHORT[mix] ?? mix}`;
+    return `${channelName(mixer(), ch)}\n· ${mixShortName(mixer(), mix)}`;
   }
   return DEVICE_TOGGLES[target] ?? target;
 }
@@ -485,8 +496,8 @@ function dialValue(target, inst) {
     const muted = mix === "all"
       ? Object.keys(ch.levels ?? {}).every((m) => ch.mutedIn?.includes(m))
       : ch.mutedIn?.includes(mix) ?? false;
-    return { pin: CHANNELS[chId] ?? chId,
-             scroll: mix === "all" ? "All mixes" : MIXES[mix] ?? mix,
+    return { pin: channelName(mixer(), chId),
+             scroll: mix === "all" ? "All mixes" : mixName(mixer(), mix),
              pct: pct(v), text: muted ? "MUTED" : `${pct(v)}%`, muted };
   }
   if (target.startsWith("mixvol:")) {

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/dial.html
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/dial.html
@@ -29,79 +29,6 @@
       <option value="auxLevel">Aux In level</option>
       <option value="crossfade">Mic / PC crossfade</option>
     </optgroup>
-    <optgroup label="Mix masters">
-      <option value="mixvol:monitor">Monitor A mix master</option>
-      <option value="mixvol:monitor2">Monitor B mix master</option>
-      <option value="mixvol:stream">Stream mix master</option>
-      <option value="mixvol:chat">Chat mix master</option>
-      <option value="mixvol:auxout">Aux mix master</option>
-    </optgroup>
-    <optgroup label="Sends: all mixes">
-      <option value="send:xlr1:all">XLR 1 in all mixes</option>
-      <option value="send:xlr2:all">XLR 2 in all mixes</option>
-      <option value="send:aux:all">Aux In in all mixes</option>
-      <option value="send:game:all">Game in all mixes</option>
-      <option value="send:music:all">Music in all mixes</option>
-      <option value="send:browser:all">Browser in all mixes</option>
-      <option value="send:system:all">System in all mixes</option>
-      <option value="send:voicechat:all">Voice Chat in all mixes</option>
-      <option value="send:sfx:all">SFX in all mixes</option>
-    </optgroup>
-    <optgroup label="Sends: Monitor A">
-      <option value="send:xlr1:monitor">XLR 1 in Monitor A</option>
-      <option value="send:xlr2:monitor">XLR 2 in Monitor A</option>
-      <option value="send:aux:monitor">Aux In in Monitor A</option>
-      <option value="send:game:monitor">Game in Monitor A</option>
-      <option value="send:music:monitor">Music in Monitor A</option>
-      <option value="send:browser:monitor">Browser in Monitor A</option>
-      <option value="send:system:monitor">System in Monitor A</option>
-      <option value="send:voicechat:monitor">Voice Chat in Monitor A</option>
-      <option value="send:sfx:monitor">SFX in Monitor A</option>
-    </optgroup>
-    <optgroup label="Sends: Monitor B">
-      <option value="send:xlr1:monitor2">XLR 1 in Monitor B</option>
-      <option value="send:xlr2:monitor2">XLR 2 in Monitor B</option>
-      <option value="send:aux:monitor2">Aux In in Monitor B</option>
-      <option value="send:game:monitor2">Game in Monitor B</option>
-      <option value="send:music:monitor2">Music in Monitor B</option>
-      <option value="send:browser:monitor2">Browser in Monitor B</option>
-      <option value="send:system:monitor2">System in Monitor B</option>
-      <option value="send:voicechat:monitor2">Voice Chat in Monitor B</option>
-      <option value="send:sfx:monitor2">SFX in Monitor B</option>
-    </optgroup>
-    <optgroup label="Sends: Stream">
-      <option value="send:xlr1:stream">XLR 1 in Stream</option>
-      <option value="send:xlr2:stream">XLR 2 in Stream</option>
-      <option value="send:aux:stream">Aux In in Stream</option>
-      <option value="send:game:stream">Game in Stream</option>
-      <option value="send:music:stream">Music in Stream</option>
-      <option value="send:browser:stream">Browser in Stream</option>
-      <option value="send:system:stream">System in Stream</option>
-      <option value="send:voicechat:stream">Voice Chat in Stream</option>
-      <option value="send:sfx:stream">SFX in Stream</option>
-    </optgroup>
-    <optgroup label="Sends: Chat">
-      <option value="send:xlr1:chat">XLR 1 in Chat</option>
-      <option value="send:xlr2:chat">XLR 2 in Chat</option>
-      <option value="send:aux:chat">Aux In in Chat</option>
-      <option value="send:game:chat">Game in Chat</option>
-      <option value="send:music:chat">Music in Chat</option>
-      <option value="send:browser:chat">Browser in Chat</option>
-      <option value="send:system:chat">System in Chat</option>
-      <option value="send:voicechat:chat">Voice Chat in Chat</option>
-      <option value="send:sfx:chat">SFX in Chat</option>
-    </optgroup>
-    <optgroup label="Sends: Aux">
-      <option value="send:xlr1:auxout">XLR 1 in Aux</option>
-      <option value="send:xlr2:auxout">XLR 2 in Aux</option>
-      <option value="send:aux:auxout">Aux In in Aux</option>
-      <option value="send:game:auxout">Game in Aux</option>
-      <option value="send:music:auxout">Music in Aux</option>
-      <option value="send:browser:auxout">Browser in Aux</option>
-      <option value="send:system:auxout">System in Aux</option>
-      <option value="send:voicechat:auxout">Voice Chat in Aux</option>
-      <option value="send:sfx:auxout">SFX in Aux</option>
-    </optgroup>
   </select>
   <button id="add">Add to stack</button>
   <ul id="stack"></ul>
@@ -110,6 +37,7 @@
     <label style="display:inline"><input type="radio" name="gesture" value="tap" checked> Screen tap</label>
     <label style="display:inline; margin-left:14px"><input type="radio" name="gesture" value="push"> Dial press</label>
   </div>
+  <script src="layout-options.js"></script>
   <script>
     let ws = null, piUuid = null, settings = {};
 
@@ -131,13 +59,19 @@
           });
         render();
         // The plugin lists the loaded inserts' controls from live state.
-        ws.send(JSON.stringify({ event: "sendToPlugin", context: actionInfo.context,
-                                 payload: { request: "inserts" } }));
+        for (const request of ["layout", "inserts"])
+          ws.send(JSON.stringify({ event: "sendToPlugin", context: actionInfo.context,
+                                   payload: { request } }));
       };
       ws.onmessage = (e) => {
         let m;
         try { m = JSON.parse(e.data); } catch { return; }
-        if (m.event !== "sendToPropertyInspector" || !Array.isArray(m.payload?.params)) return;
+        if (m.event !== "sendToPropertyInspector") return;
+        if (Array.isArray(m.payload?.levelGroups)) {
+          replaceLayoutOptions(m.payload.levelGroups);
+          render();
+        }
+        if (!Array.isArray(m.payload?.params)) return;
         const sel = document.getElementById("target");
         if (document.getElementById("param-group") || !m.payload.params.length) return;
         const group = document.createElement("optgroup");
@@ -163,7 +97,7 @@
       ws.send(JSON.stringify({ event: "setSettings", context: piUuid, payload: settings }));
     }
     function labelFor(v) {
-      const o = document.querySelector('#target option[value="' + v + '"]');
+      const o = Array.from(document.getElementById("target").options).find(option => option.value === v);
       return o ? o.textContent : v;
     }
     function render() {

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/dial.html
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/dial.html
@@ -29,6 +29,9 @@
       <option value="auxLevel">Aux In level</option>
       <option value="crossfade">Mic / PC crossfade</option>
     </optgroup>
+    <!-- The mix master and send groups are generated from the daemon's
+         state and inserted here, ahead of the insert groups. -->
+    <optgroup data-layout-anchor hidden></optgroup>
   </select>
   <button id="add">Add to stack</button>
   <ul id="stack"></ul>

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/layout-options.js
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/layout-options.js
@@ -1,0 +1,30 @@
+// Replace only mixer-layout groups. Hardware, output/feed, insert and profile
+// groups belong to their existing code paths and remain in the selector.
+function replaceLayoutOptions(groups, wanted) {
+  const select = document.getElementById("target");
+  const selected = select.value || wanted || "";
+  for (const group of select.querySelectorAll("[data-layout-group]")) group.remove();
+  document.getElementById("unavailable-layout-target")?.remove();
+  for (const group of groups) {
+    const element = document.createElement("optgroup");
+    element.dataset.layoutGroup = "true";
+    element.label = group.label;
+    for (const item of group.items) {
+      const option = document.createElement("option");
+      option.value = item.target;
+      option.textContent = item.label;
+      element.appendChild(option);
+    }
+    select.appendChild(element);
+  }
+  if (/^(mixvol:|mixmute:|send:|sendmute:)/.test(selected) &&
+      !Array.from(select.options).some(option => option.value === selected)) {
+    const unavailable = document.createElement("option");
+    unavailable.id = "unavailable-layout-target";
+    unavailable.value = selected;
+    unavailable.textContent = "Unavailable: " + selected;
+    unavailable.disabled = true;
+    select.appendChild(unavailable);
+  }
+  select.value = selected;
+}

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/layout-options.js
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/layout-options.js
@@ -1,8 +1,12 @@
 // Replace only mixer-layout groups. Hardware, output/feed, insert and profile
-// groups belong to their existing code paths and remain in the selector.
+// groups belong to their existing code paths and remain in the selector. The
+// generated groups go where the page's anchor sits (right after the static
+// groups, ahead of the feed, insert and profile groups), not at the end.
 function replaceLayoutOptions(groups, wanted) {
   const select = document.getElementById("target");
   const selected = select.value || wanted || "";
+  const anchor = select.querySelector ? select.querySelector("[data-layout-anchor]") : null;
+  const place = (node) => anchor ? select.insertBefore(node, anchor) : select.appendChild(node);
   for (const group of select.querySelectorAll("[data-layout-group]")) group.remove();
   document.getElementById("unavailable-layout-target")?.remove();
   for (const group of groups) {
@@ -15,7 +19,7 @@ function replaceLayoutOptions(groups, wanted) {
       option.textContent = item.label;
       element.appendChild(option);
     }
-    select.appendChild(element);
+    place(element);
   }
   if (/^(mixvol:|mixmute:|send:|sendmute:)/.test(selected) &&
       !Array.from(select.options).some(option => option.value === selected)) {
@@ -24,7 +28,7 @@ function replaceLayoutOptions(groups, wanted) {
     unavailable.value = selected;
     unavailable.textContent = "Unavailable: " + selected;
     unavailable.disabled = true;
-    select.appendChild(unavailable);
+    place(unavailable);
   }
   select.value = selected;
 }

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/pi.js
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/pi.js
@@ -12,7 +12,7 @@ function connect(inPort, inPropertyInspectorUUID, inRegisterEvent, inInfo, inAct
   const actionInfo = JSON.parse(inActionInfo);
   actionContext = actionInfo.context;
   const settings = actionInfo.payload?.settings ?? {};
-  const wanted = settings.target;
+  let wanted = settings.target;
 
   ws = new WebSocket("ws://localhost:" + inPort);
   ws.onopen = () => {
@@ -23,6 +23,7 @@ function connect(inPort, inPropertyInspectorUUID, inRegisterEvent, inInfo, inAct
     if (iconSel && settings.icon) iconSel.value = settings.icon;
     const save = () => {
       settings.target = sel.value;
+      wanted = sel.value;
       if (iconSel) settings.icon = iconSel.value;
       // Insert options carry {plugin, index} so the key survives a chain
       // rebuild that hands the insert a new id.
@@ -37,7 +38,7 @@ function connect(inPort, inPropertyInspectorUUID, inRegisterEvent, inInfo, inAct
     iconSel?.addEventListener("change", save);
     // Ask the plugin for the live output-device list, the insert chains and
     // the saved profiles.
-    for (const request of ["outputs", "inserts", "profiles"])
+    for (const request of ["layout", "outputs", "inserts", "profiles"])
       ws.send(JSON.stringify({ event: "sendToPlugin", context: actionContext, payload: { request } }));
   };
 
@@ -45,6 +46,7 @@ function connect(inPort, inPropertyInspectorUUID, inRegisterEvent, inInfo, inAct
     let m;
     try { m = JSON.parse(e.data); } catch { return; }
     if (m.event !== "sendToPropertyInspector") return;
+    if (Array.isArray(m.payload?.toggleGroups)) replaceLayoutOptions(m.payload.toggleGroups, wanted);
     if (Array.isArray(m.payload?.outputs)) fillMonitors(m.payload.outputs, wanted);
     if (Array.isArray(m.payload?.inserts)) {
       fillGroup("insert-group", "Insert bypass", m.payload.inserts, wanted);

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/toggle.html
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/toggle.html
@@ -40,68 +40,6 @@
       <option value="outLineOut">Line Out</option>
       <option value="auxPort">Aux mix to USB Aux port</option>
     </optgroup>
-    <optgroup label="Mix mutes">
-      <option value="mixmute:monitor">Monitor A mix mute</option>
-      <option value="mixmute:monitor2">Monitor B mix mute</option>
-      <option value="mixmute:stream">Stream mix mute</option>
-      <option value="mixmute:chat">Chat mix mute</option>
-      <option value="mixmute:auxout">Aux mix mute</option>
-    </optgroup>
-    <optgroup label="Send mutes: Monitor A">
-      <option value="sendmute:xlr1:monitor">XLR 1 in Monitor A</option>
-      <option value="sendmute:xlr2:monitor">XLR 2 in Monitor A</option>
-      <option value="sendmute:aux:monitor">Aux In in Monitor A</option>
-      <option value="sendmute:game:monitor">Game in Monitor A</option>
-      <option value="sendmute:music:monitor">Music in Monitor A</option>
-      <option value="sendmute:browser:monitor">Browser in Monitor A</option>
-      <option value="sendmute:system:monitor">System in Monitor A</option>
-      <option value="sendmute:voicechat:monitor">Voice Chat in Monitor A</option>
-      <option value="sendmute:sfx:monitor">SFX in Monitor A</option>
-    </optgroup>
-    <optgroup label="Send mutes: Monitor B">
-      <option value="sendmute:xlr1:monitor2">XLR 1 in Monitor B</option>
-      <option value="sendmute:xlr2:monitor2">XLR 2 in Monitor B</option>
-      <option value="sendmute:aux:monitor2">Aux In in Monitor B</option>
-      <option value="sendmute:game:monitor2">Game in Monitor B</option>
-      <option value="sendmute:music:monitor2">Music in Monitor B</option>
-      <option value="sendmute:browser:monitor2">Browser in Monitor B</option>
-      <option value="sendmute:system:monitor2">System in Monitor B</option>
-      <option value="sendmute:voicechat:monitor2">Voice Chat in Monitor B</option>
-      <option value="sendmute:sfx:monitor2">SFX in Monitor B</option>
-    </optgroup>
-    <optgroup label="Send mutes: Stream">
-      <option value="sendmute:xlr1:stream">XLR 1 in Stream</option>
-      <option value="sendmute:xlr2:stream">XLR 2 in Stream</option>
-      <option value="sendmute:aux:stream">Aux In in Stream</option>
-      <option value="sendmute:game:stream">Game in Stream</option>
-      <option value="sendmute:music:stream">Music in Stream</option>
-      <option value="sendmute:browser:stream">Browser in Stream</option>
-      <option value="sendmute:system:stream">System in Stream</option>
-      <option value="sendmute:voicechat:stream">Voice Chat in Stream</option>
-      <option value="sendmute:sfx:stream">SFX in Stream</option>
-    </optgroup>
-    <optgroup label="Send mutes: Chat">
-      <option value="sendmute:xlr1:chat">XLR 1 in Chat</option>
-      <option value="sendmute:xlr2:chat">XLR 2 in Chat</option>
-      <option value="sendmute:aux:chat">Aux In in Chat</option>
-      <option value="sendmute:game:chat">Game in Chat</option>
-      <option value="sendmute:music:chat">Music in Chat</option>
-      <option value="sendmute:browser:chat">Browser in Chat</option>
-      <option value="sendmute:system:chat">System in Chat</option>
-      <option value="sendmute:voicechat:chat">Voice Chat in Chat</option>
-      <option value="sendmute:sfx:chat">SFX in Chat</option>
-    </optgroup>
-    <optgroup label="Send mutes: Aux">
-      <option value="sendmute:xlr1:auxout">XLR 1 in Aux</option>
-      <option value="sendmute:xlr2:auxout">XLR 2 in Aux</option>
-      <option value="sendmute:aux:auxout">Aux In in Aux</option>
-      <option value="sendmute:game:auxout">Game in Aux</option>
-      <option value="sendmute:music:auxout">Music in Aux</option>
-      <option value="sendmute:browser:auxout">Browser in Aux</option>
-      <option value="sendmute:system:auxout">System in Aux</option>
-      <option value="sendmute:voicechat:auxout">Voice Chat in Aux</option>
-      <option value="sendmute:sfx:auxout">SFX in Aux</option>
-    </optgroup>
   </select>
   <label for="icon" style="margin-top:12px">Key icon</label>
   <select id="icon">
@@ -113,5 +51,6 @@
     <option value="fader">Faders</option>
     <option value="knob">Knob</option>
   </select>
+  <script src="layout-options.js"></script>
   <script src="pi.js"></script>
 </body></html>

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/toggle.html
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/toggle.html
@@ -40,6 +40,9 @@
       <option value="outLineOut">Line Out</option>
       <option value="auxPort">Aux mix to USB Aux port</option>
     </optgroup>
+    <!-- The mix and send groups are generated from the daemon's state and
+         inserted here, ahead of the feed, insert and profile groups. -->
+    <optgroup data-layout-anchor hidden></optgroup>
   </select>
   <label for="icon" style="margin-top:12px">Key icon</label>
   <select id="icon">

--- a/plugin/tests/layout-choices.test.mjs
+++ b/plugin/tests/layout-choices.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { channelName, layoutChoices, mixName } from "../com.emaspa.openxlr.sdPlugin/layout-choices.mjs";
+
+const mixer = {
+  mixes: [
+    { id: "monitor", name: "My Ears" },
+    { id: "broadcast-vod", name: "Broadcast + VOD" },
+  ],
+  channels: [
+    { id: "xlr1", name: "Host Mic" },
+    { id: "alerts-new", name: "Alerts & SFX" },
+  ],
+};
+
+test("editable names are paired with stable ids", () => {
+  const choices = layoutChoices(mixer);
+  assert.deepEqual(choices.toggleGroups[0].items, [
+    { target: "mixmute:monitor", label: "My Ears mix mute" },
+    { target: "mixmute:broadcast-vod", label: "Broadcast + VOD mix mute" },
+  ]);
+  assert.ok(choices.toggleGroups.some((group) => group.items.some((item) =>
+    item.target === "sendmute:alerts-new:broadcast-vod" && item.label === "Alerts & SFX in Broadcast + VOD")));
+  assert.ok(choices.levelGroups.some((group) => group.items.some((item) =>
+    item.target === "send:alerts-new:broadcast-vod")));
+  assert.equal(channelName(mixer, "alerts-new"), "Alerts & SFX");
+  assert.equal(mixName(mixer, "broadcast-vod"), "Broadcast + VOD");
+});
+
+test("deleted layout entries disappear from new choices", () => {
+  const afterDelete = {
+    mixes: mixer.mixes.filter((entry) => entry.id !== "broadcast-vod"),
+    channels: mixer.channels.filter((entry) => entry.id !== "alerts-new"),
+  };
+  assert.doesNotMatch(JSON.stringify(layoutChoices(afterDelete)), /broadcast-vod|alerts-new/);
+});

--- a/plugin/tests/layout-options.test.mjs
+++ b/plugin/tests/layout-options.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { layoutChoices, mixShortName } from "../com.emaspa.openxlr.sdPlugin/layout-choices.mjs";
+
+// Minimal selector DOM: exercise selection and group replacement without a
+// running OpenDeck instance or changing real action settings.
+class Element {
+  constructor(tag) { this.tag = tag; this.children = []; this.dataset = {}; this._value = ""; }
+  appendChild(child) { child.parent = this; this.children.push(child); }
+  remove() { this.parent.children = this.parent.children.filter(child => child !== this); }
+  get options() { return this.children.flatMap(child => child.tag === "option" ? [child] : child.options); }
+  get value() { return this.tag === "select" ? (this.options.some(o => o.value === this._value) ? this._value : "") : this._value; }
+  set value(value) { this._value = value; }
+  querySelectorAll() { return this.children.filter(child => child.dataset.layoutGroup); }
+}
+
+test("state refresh preserves a selected feed and only replaces layout groups", () => {
+  const select = new Element("select");
+  select.id = "target";
+  const feed = new Element("optgroup"); feed.id = "feed-group";
+  const option = new Element("option"); option.value = "feed:alsa_output.test";
+  feed.appendChild(option); select.appendChild(feed); select.value = option.value;
+  const all = node => [node, ...node.children.flatMap(all)];
+  const document = { createElement: tag => new Element(tag), getElementById: id => all(select).find(node => node.id === id) };
+  const context = vm.createContext({ document });
+  vm.runInContext(readFileSync(new URL("../com.emaspa.openxlr.sdPlugin/propertyInspector/layout-options.js", import.meta.url), "utf8"), context);
+  const apply = groups => context.replaceLayoutOptions(groups);
+  const state = { channels: [{id:"system",name:"System"}], mixes:[{id:"monitor",name:"Monitor A"},{id:"monitor2",name:"Monitor B"}] };
+  apply(layoutChoices(state).toggleGroups);
+  assert.equal(select.value, "feed:alsa_output.test");
+  assert.equal(document.getElementById("feed-group"), feed);
+  select.value = "mixmute:monitor2";
+  state.mixes[1].name = "Headset chat";
+  apply(layoutChoices(state).toggleGroups);
+  assert.equal(select.value, "mixmute:monitor2");
+  assert.equal(select.options.find(o => o.value === select.value).textContent, "Headset chat mix mute");
+  state.mixes.pop();
+  apply(layoutChoices(state).toggleGroups);
+  assert.equal(select.value, "mixmute:monitor2");
+  assert.equal(document.getElementById("unavailable-layout-target").disabled, true);
+  state.mixes.push({id:"monitor2",name:"Monitor B"});
+  apply(layoutChoices(state).toggleGroups);
+  assert.equal(select.value, "mixmute:monitor2");
+  assert.equal(document.getElementById("unavailable-layout-target"), undefined);
+  assert.equal(select.options.filter(o => o.value === "mixmute:monitor2").length, 1);
+});
+
+test("both structural monitor mixes retain distinct dial labels and choices", () => {
+  assert.equal(mixShortName(null, "monitor"), "MonA");
+  assert.equal(mixShortName(null, "monitor2"), "MonB");
+  const choices = layoutChoices({channels:[{id:"game",name:"Game"}], mixes:[
+    {id:"monitor",name:"Monitor A"},{id:"monitor2",name:"Monitor B"},{id:"stream",name:"Stream"}]});
+  assert.ok(choices.levelGroups.flatMap(g => g.items).some(i => i.target === "send:game:monitor2"));
+  assert.ok(choices.toggleGroups.flatMap(g => g.items).some(i => i.target === "mixmute:monitor"));
+});

--- a/plugin/tests/layout-options.test.mjs
+++ b/plugin/tests/layout-options.test.mjs
@@ -9,6 +9,8 @@ import { layoutChoices, mixShortName } from "../com.emaspa.openxlr.sdPlugin/layo
 class Element {
   constructor(tag) { this.tag = tag; this.children = []; this.dataset = {}; this._value = ""; }
   appendChild(child) { child.parent = this; this.children.push(child); }
+  insertBefore(child, ref) { child.parent = this; this.children.splice(this.children.indexOf(ref), 0, child); }
+  querySelector(sel) { return sel === "[data-layout-anchor]" ? this.children.find(child => "layoutAnchor" in child.dataset) ?? null : null; }
   remove() { this.parent.children = this.parent.children.filter(child => child !== this); }
   get options() { return this.children.flatMap(child => child.tag === "option" ? [child] : child.options); }
   get value() { return this.tag === "select" ? (this.options.some(o => o.value === this._value) ? this._value : "") : this._value; }
@@ -21,7 +23,11 @@ test("state refresh preserves a selected feed and only replaces layout groups", 
   select.id = "target";
   const feed = new Element("optgroup"); feed.id = "feed-group";
   const option = new Element("option"); option.value = "feed:alsa_output.test";
-  feed.appendChild(option); select.appendChild(feed); select.value = option.value;
+  feed.appendChild(option);
+  // As in the pages: static groups, the anchor, then the groups pi.js appends.
+  const anchor = new Element("optgroup"); anchor.dataset.layoutAnchor = "";
+  select.appendChild(anchor);
+  select.appendChild(feed); select.value = option.value;
   const all = node => [node, ...node.children.flatMap(all)];
   const document = { createElement: tag => new Element(tag), getElementById: id => all(select).find(node => node.id === id) };
   const context = vm.createContext({ document });
@@ -31,6 +37,9 @@ test("state refresh preserves a selected feed and only replaces layout groups", 
   apply(layoutChoices(state).toggleGroups);
   assert.equal(select.value, "feed:alsa_output.test");
   assert.equal(document.getElementById("feed-group"), feed);
+  // Generated groups sit at the anchor, ahead of the feed group, never after it.
+  assert.ok(select.children.indexOf(select.children.find(c => c.dataset.layoutGroup)) < select.children.indexOf(feed));
+  assert.equal(select.children[select.children.length - 1], feed);
   select.value = "mixmute:monitor2";
   state.mixes[1].name = "Headset chat";
   apply(layoutChoices(state).toggleGroups);

--- a/plugin/tests/plugin-layout-integration.test.mjs
+++ b/plugin/tests/plugin-layout-integration.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("plugin publishes layout updates and keeps monitor feed commands intact", async () => {
+  const previous = globalThis.WebSocket;
+  const previousInterval = globalThis.setInterval;
+  const intervals = [];
+  globalThis.setInterval = (...args) => {
+    const interval = previousInterval(...args);
+    intervals.push(interval);
+    return interval;
+  };
+  const sockets = [];
+  class Socket {
+    static OPEN = 1;
+    readyState = 1;
+    messages = [];
+    constructor(url) { this.url = url; sockets.push(this); }
+    send(text) { this.messages.push(JSON.parse(text)); }
+    receive(message) { this.onmessage({data: JSON.stringify(message)}); }
+  }
+  globalThis.WebSocket = Socket;
+  try {
+    await import("../com.emaspa.openxlr.sdPlugin/plugin.mjs");
+    const daemon = sockets.find(socket => socket.url.includes(":37890/"));
+    const host = sockets.find(socket => socket !== daemon);
+    daemon.onopen();
+    const state = {type:"state", profiles:[], devices:[{kind:0,name:"qa-output",description:"QA speakers"}], mixer:{
+      channels:[{id:"system",name:"Desktop",levels:{monitor:1,monitor2:1}}],
+      mixes:[{id:"monitor",name:"Monitor A"},{id:"monitor2",name:"Monitor B"}],
+      monitorOutputs:["qa-output"], monitorFeeds:{}, inserts:{}
+    }};
+    daemon.receive(state);
+    host.receive({event:"sendToPlugin",context:"qa",payload:{request:"layout"}});
+    assert.ok(host.messages.at(-1).payload.levelGroups.flatMap(g => g.items)
+      .some(item => item.target === "send:system:monitor2"));
+    host.receive({event:"willAppear",context:"feed-key",action:"com.emaspa.openxlr.toggle",payload:{settings:{target:"feed:qa-output"}}});
+    host.receive({event:"keyDown",context:"feed-key"});
+    assert.deepEqual(daemon.messages.at(-1), {cmd:"setMonitorFeed",device:"qa-output",mix:"monitor2"});
+    state.mixer.monitorFeeds["qa-output"] = "monitor2";
+    state.mixer.channels[0].name = "Renamed Desktop";
+    daemon.receive(state);
+    const update = host.messages.filter(message => message.event === "sendToPropertyInspector" && message.context === "qa").at(-1);
+    assert.ok(update.payload.levelGroups.flatMap(g => g.items).some(item => item.label === "Renamed Desktop in Monitor B"));
+    host.receive({event:"keyDown",context:"feed-key"});
+    assert.deepEqual(daemon.messages.at(-1), {cmd:"setMonitorFeed",device:"qa-output",mix:"monitor+monitor2"});
+    host.receive({event:"propertyInspectorDidDisappear",context:"qa"});
+    const count = host.messages.filter(m => m.event === "sendToPropertyInspector").length;
+    state.mixer.channels[0].name = "Another name";
+    daemon.receive(state);
+    assert.equal(host.messages.filter(m => m.event === "sendToPropertyInspector").length, count);
+  }
+  finally {
+    intervals.forEach(clearInterval);
+    globalThis.setInterval = previousInterval;
+    globalThis.WebSocket = previous;
+  }
+});


### PR DESCRIPTION
Generates OpenDeck channel/mix choices and labels from the current daemon state, as the standalone OpenDeck portion requested in #22. Built directly on current main's Monitor A/B/A+B feed model.

- Stable existing targets remain unchanged: mix masters/mutes, send levels/mutes, hardware controls, monitor outputs and feed switching.
- Open property inspectors receive changed layout lists; rename, insertion and deletion update choices without rewriting saved action settings.
- Missing saved mixer targets are shown as unavailable instead of silently selecting a different action.
- Monitor A and B retain distinct dial labels. Feed groups, feed cycling, authentication, profiles and insert controls retain their current implementations.

Verification: five Node tests cover stable IDs/current names, deleted entries, selection preservation across state refreshes, both monitor mixes, and the actual plugin's property-inspector subscriptions and A/B/A+B feed commands. Plugin/inspector JavaScript syntax and `git diff --check` pass. GitHub CI passes on `93ef59f`.

This is independently mergeable before the editable-layout backend. It adds no daemon, routing, desktop-theme or release changes.
