### PR TITLE
Bind HTTP authorization to resolved API endpoints

### DIFF
--- a/src/OpenXLR.Daemon/ApiEndpoints.cs
+++ b/src/OpenXLR.Daemon/ApiEndpoints.cs
@@ -40,32 +40,31 @@ internal static class ApiEndpoints
     /// </summary>
     internal static void Map(WebApplication app)
     {
-        app.Use(async (context, next) =>
+        // Bind access control to the resolved endpoints, not a request-path
+        // exception. Events use first-frame authentication in WebSocketHub.
+        var api = app.MapGroup("/api/v1").AddEndpointFilter(async (invocation, next) =>
         {
-            if (context.Request.Path.StartsWithSegments("/api/v1"))
+            HttpContext context = invocation.HttpContext;
+            context.Response.Headers.CacheControl = "no-store";
+            if (!LoopbackOrigin.IsAllowed(context.Request.Headers.Origin))
+                return Results.StatusCode(403);
+            if (!Authorized(context.Request, ApiToken.Current))
             {
-                context.Response.Headers.CacheControl = "no-store";
-                if (!LoopbackOrigin.IsAllowed(context.Request.Headers.Origin))
-                { context.Response.StatusCode = 403; return; }
-                if (context.Request.Path != "/api/v1/events" && !Authorized(context.Request, ApiToken.Current))
-                {
-                    context.Response.Headers.WWWAuthenticate = "Bearer";
-                    context.Response.StatusCode = 401;
-                    return;
-                }
+                context.Response.Headers.WWWAuthenticate = "Bearer";
+                return Results.StatusCode(401);
             }
-            await next(context);
+            return await next(invocation);
         });
 
         app.MapGet("/healthz", () => Results.Json(new { status = "alive" }));
-        app.MapGet("/api/v1", () => Results.Json(new { apiVersion = "1", state = "/api/v1/state",
+        api.MapGet("", () => Results.Json(new { apiVersion = "1", state = "/api/v1/state",
             plugins = "/api/v1/plugins", commands = "/api/v1/commands", events = "/api/v1/events" }));
-        app.MapGet("/api/v1/state", (WebSocketHub hub) => Results.Json(hub.Snapshot()));
-        app.MapGet("/api/v1/plugins", async (WebSocketHub hub) =>
+        api.MapGet("/state", (WebSocketHub hub) => Results.Json(hub.Snapshot()));
+        api.MapGet("/plugins", async (WebSocketHub hub) =>
             Results.Json(await hub.ExecuteForApiAsync("{\"cmd\":\"listPlugins\"}")));
         var budget = new CommandBudget();
         var commandGate = new SemaphoreSlim(1, 1);
-        app.MapPost("/api/v1/commands", async (HttpContext context, WebSocketHub hub) =>
+        api.MapPost("/commands", async (HttpContext context, WebSocketHub hub) =>
         {
             if (!IsJson(context.Request.ContentType)) return Results.StatusCode(415);
             if (context.Request.ContentLength > MaxCommandBytes) return Results.StatusCode(413);
@@ -88,6 +87,9 @@ internal static class ApiEndpoints
         });
         app.Map("/api/v1/events", async (HttpContext context, WebSocketHub hub) =>
         {
+            context.Response.Headers.CacheControl = "no-store";
+            if (!LoopbackOrigin.IsAllowed(context.Request.Headers.Origin))
+            { context.Response.StatusCode = 403; return; }
             if (!context.WebSockets.IsWebSocketRequest) { context.Response.StatusCode = 400; return; }
             using var socket = await context.WebSockets.AcceptWebSocketAsync(new WebSocketAcceptContext
             {

--- a/src/OpenXLR.Tests/HttpApiTests.cs
+++ b/src/OpenXLR.Tests/HttpApiTests.cs
@@ -62,6 +62,22 @@ public sealed class HttpApiTests
             using var http = new HttpClient { BaseAddress = new Uri(address) };
             using var denied = await http.GetAsync("/api/v1");
             Assert.Equal(HttpStatusCode.Unauthorized, denied.StatusCode);
+            foreach (string path in new[] { "/api/v1/state", "/API/V1/state", "/api/v1/state/", "/api/v1/plugins" })
+            {
+                using var protectedRequest = await http.GetAsync(path);
+                Assert.Equal(HttpStatusCode.Unauthorized, protectedRequest.StatusCode);
+            }
+            using var deniedCommand = await http.PostAsync("/API/V1/commands/",
+                new StringContent("{\"cmd\":\"getDiagnostics\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.Unauthorized, deniedCommand.StatusCode);
+            using var health = await http.GetAsync("/healthz");
+            Assert.Equal(HttpStatusCode.OK, health.StatusCode);
+            using var noUpgrade = await http.GetAsync("/api/v1/events");
+            Assert.Equal(HttpStatusCode.BadRequest, noUpgrade.StatusCode);
+            http.DefaultRequestHeaders.Add("Origin", "https://foreign.example");
+            using var foreignEvents = await http.GetAsync("/api/v1/events");
+            Assert.Equal(HttpStatusCode.Forbidden, foreignEvents.StatusCode);
+            http.DefaultRequestHeaders.Remove("Origin");
             http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             using var accepted = await http.GetAsync("/api/v1");
             Assert.Equal(HttpStatusCode.OK, accepted.StatusCode);


### PR DESCRIPTION
Follow-up to #24 and its CodeQL alert at ApiEndpoints.cs:50. HTTP access control is now an endpoint-group filter instead of middleware that exempts a caller-selected path. Every HTTP API endpoint requires the live bearer token and allowed Origin. The events endpoint is mapped separately, retains its Origin check, and continues to authenticate the first WebSocket frame through WebSocketHub. Health remains public.

Tests exercise unauthenticated state/plugins/commands, case and trailing-slash routing, the events Origin boundary, public health, authorized commands and body limits. All 167 Release tests pass. This does not claim a demonstrated token bypass in the prior implementation; it removes the path-dependent security boundary flagged by CodeQL. No suppression or security-rule changes. The commit is GitHub-signed and verified.