### PR TITLE
Restore ordered user mixer layout from settings

### DIFF
--- a/docs/mixer-layout.md
+++ b/docs/mixer-layout.md
@@ -1,0 +1,36 @@
+# Saved mixer layout
+
+The daemon reads the layout from `mixer.json` before building its graph.
+Stop the daemon before editing this file manually: while running, its normal
+settings saves overwrite the file with the live configuration.
+
+`userChannels` is an ordered list of application channels and `userMixes` an
+ordered list of virtual microphones. Each entry has a stable `id` and a display
+`name`. For example:
+
+```json
+{
+  "userChannels": [{"id": "podcast", "name": "Interview"}],
+  "userMixes": [{"id": "recording", "name": "Recording"}]
+}
+```
+
+These are fields in the existing settings object; retain its other fields when
+editing. Missing or null lists keep the legacy defaults. An empty mix list
+removes the editable virtual microphones. An empty application list falls back
+to System so incoming applications have a destination.
+
+Hardware inputs, Monitor A (`monitor`), Monitor B (`monitor2`) and Aux
+(`auxout`) remain structural. The `ignore` application target is reserved.
+Invalid or duplicate entries are ignored. IDs contain at most 36 lowercase
+ASCII letters, digits, underscores or hyphens, beginning with a letter. Names
+contain 1 to 60 printable characters. At most 32 application channels and 16
+virtual microphones are restored.
+
+Node names derive from IDs, not labels. The list order survives a settings
+save and restart. Removed application destinations fall back to the first
+application channel, never a hardware input; ignored applications stay ignored.
+Existing monitor-feed settings and profile semantics are unchanged.
+
+This format does not provide live layout commands or a desktop layout editor.
+Manual changes, including external PipeWire descriptions, take effect at startup.

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -799,6 +799,10 @@ public sealed class Mixer : IDisposable, ILayoutInfo
         {
             return new MixerSettings
             {
+                UserChannels = [.. _config.Channels.Where(c => c.InputPair is null)
+                    .Select(c => new UserChannelDefinition(c.Id, c.Name))],
+                UserMixes = [.. _config.Mixes.Where(m => m.Kind == MixKind.VirtualMic)
+                    .Select(m => new UserMixDefinition(m.Id, m.Name))],
                 MixVolumes = new Dictionary<string, double>(_mixVolume),
                 MixMuted = [.. _mixMuted],
                 Levels = new Dictionary<string, double>(_levels),
@@ -836,7 +840,7 @@ public sealed class Mixer : IDisposable, ILayoutInfo
                 if (_cells.Contains(cell)) _muted.Add(cell);
 
             foreach ((string identity, string channelId) in s.AppOverrides)
-                Matcher.SetOverride(StreamMatcher.MigrateIdentity(Sanitize(identity)), channelId);
+                Matcher.SetOverride(StreamMatcher.MigrateIdentity(Sanitize(identity)), _config.ResolveApplicationChannel(channelId));
 
             // Remembered apps come back inactive until a stream appears.
             // Identities saved before the "(deleted)" fix are migrated here so
@@ -846,7 +850,7 @@ public sealed class Mixer : IDisposable, ILayoutInfo
                 string identity = StreamMatcher.MigrateIdentity(Sanitize(app.Identity));
                 if (PipeWireAdapter.IsPlumbingIdentity(identity)) continue;   // pre-filter leftovers
                 if (!_apps.ContainsKey(identity))
-                    _apps[identity] = new StreamAssignment(0, 0, Sanitize(app.Label), identity, app.ChannelId) { Active = false, Running = false };
+                    _apps[identity] = new StreamAssignment(0, 0, Sanitize(app.Label), identity, _config.ResolveApplicationChannel(app.ChannelId)) { Active = false, Running = false };
             }
 
             static string Sanitize(string v) => v.EndsWith(" (deleted)", StringComparison.Ordinal) ? v[..^10] : v;
@@ -1381,7 +1385,7 @@ public sealed class Mixer : IDisposable, ILayoutInfo
                 liveIdentities.Add(s.Identity);
                 if (_streams.ContainsKey(s.Id)) continue;
 
-                string channelId = Matcher.Match(s);
+                string channelId = _config.ResolveApplicationChannel(Matcher.Match(s));
                 if (channelId == StreamMatcher.Ignore)
                 {
                     // Not managed: the stream stays where the desktop put it.
@@ -1397,7 +1401,7 @@ public sealed class Mixer : IDisposable, ILayoutInfo
                     continue;
                 }
                 ChannelDefinition? ch = _config.Channels.FirstOrDefault(c => c.Id == channelId)
-                                        ?? _config.Channels.FirstOrDefault();
+                                        ?? _config.Channels.FirstOrDefault(c => c.InputPair is null);
                 if (ch is null) continue;
 
                 try
@@ -1441,7 +1445,7 @@ public sealed class Mixer : IDisposable, ILayoutInfo
                 if (!_apps.ContainsKey(identity))
                 {
                     _apps[identity] = new StreamAssignment(0, 0, client.Label, identity,
-                        Matcher.Match(client)) { Active = false, Running = true };
+                        _config.ResolveApplicationChannel(Matcher.Match(client))) { Active = false, Running = true };
                     changed = true;
                 }
                 else if (!_apps[identity].Active && _apps[identity].Label != client.Label &&

--- a/src/OpenXLR.Core/Mixing/MixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/MixerLayout.cs
@@ -1,0 +1,74 @@
+namespace OpenXLR.Core.Mixing;
+
+public sealed partial record MixerConfig
+{
+    // Bound graph growth even for hand-edited settings files.
+    public const int MaxApplicationChannels = 32;
+    public const int MaxVirtualMixes = 16;
+
+    /// <summary>Keep obsolete app rules out of hardware inputs after a layout change.</summary>
+    public string ResolveApplicationChannel(string requested)
+        => requested == StreamMatcher.Ignore ? requested
+            : (Channels.FirstOrDefault(c => c.InputPair is null && c.Id == requested)
+                ?? Channels.FirstOrDefault(c => c.InputPair is null))?.Id ?? StreamMatcher.Ignore;
+
+    /// <summary>
+    /// Restore ordered user nodes without replacing hardware or monitor buses.
+    /// Old files retain the default layout. Invalid entries are ignored, and
+    /// an empty application list heals to System as a safe routing destination.
+    /// </summary>
+    public static MixerConfig FromSettings(MixerSettings? settings)
+    {
+        MixerConfig defaults = Default();
+        var structuralMixes = defaults.Mixes.Where(m => m.Kind != MixKind.VirtualMic).ToList();
+        var hardware = defaults.Channels.Where(c => c.InputPair is not null).ToList();
+        var mixEntries = settings?.UserMixes is null
+            ? defaults.Mixes.Where(m => m.Kind == MixKind.VirtualMic).Select(m => ((string?)m.Id, (string?)m.Name))
+            : settings.UserMixes.Select(m => (m?.Id, m?.Name));
+        var channelEntries = settings?.UserChannels is null
+            ? defaults.Channels.Where(c => c.InputPair is null).Select(c => ((string?)c.Id, (string?)c.Name))
+            : settings.UserChannels.Select(c => (c?.Id, c?.Name));
+
+        var mixes = structuralMixes.Where(m => m.Kind == MixKind.Monitor).ToList();
+        mixes.AddRange(ValidEntries(mixEntries, structuralMixes.Select(m => m.Id), MaxVirtualMixes)
+            .Select(m => new MixDefinition(m.Id, m.Name, MixKind.VirtualMic)));
+        mixes.AddRange(structuralMixes.Where(m => m.Kind == MixKind.AuxPort));
+
+        var apps = ValidEntries(channelEntries, hardware.Select(c => c.Id).Append(StreamMatcher.Ignore), MaxApplicationChannels).ToList();
+        if (apps.Count == 0) apps.Add(("system", "System"));
+        var channels = hardware.Select(Normalize).ToList();
+        channels.AddRange(apps.Select(c => Normalize(
+            (defaults.Channels.FirstOrDefault(d => d.Id == c.Id) ?? new ChannelDefinition(c.Id, c.Name))
+            with { Name = c.Name })));
+        return new MixerConfig { Mixes = mixes, Channels = channels };
+
+        ChannelDefinition Normalize(ChannelDefinition channel)
+        {
+            var levels = new Dictionary<string, double>();
+            var muted = new HashSet<string>();
+            foreach (MixDefinition mix in mixes)
+            {
+                bool feedback = channel.Id == "aux" && mix.Kind == MixKind.AuxPort;
+                levels[mix.Id] = feedback ? 0 : channel.Levels.GetValueOrDefault(mix.Id, 1);
+                if (feedback || channel.MutedIn.Contains(mix.Id)) muted.Add(mix.Id);
+            }
+            return channel with { Levels = levels, MutedIn = muted };
+        }
+    }
+
+    private static IEnumerable<(string Id, string Name)> ValidEntries(
+        IEnumerable<(string? Id, string? Name)> entries, IEnumerable<string> reserved, int limit)
+    {
+        var used = new HashSet<string>(reserved, StringComparer.OrdinalIgnoreCase);
+        int count = 0;
+        foreach (var (id, label) in entries)
+        {
+            string? name = label?.Trim();
+            if (id is not { Length: > 0 and <= 36 } || id[0] is < 'a' or > 'z' ||
+                !id.All(c => c is >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_') ||
+                name is not { Length: > 0 and <= 60 } || name.Any(char.IsControl) || !used.Add(id)) continue;
+            yield return (id, name);
+            if (++count == limit) yield break;
+        }
+    }
+}

--- a/src/OpenXLR.Core/Mixing/MixerModel.cs
+++ b/src/OpenXLR.Core/Mixing/MixerModel.cs
@@ -11,7 +11,7 @@ namespace OpenXLR.Core.Mixing;
 /// a level or mute change never rebuilds the graph. Direct port links carry the
 /// completed mixes to hardware outputs.
 /// </summary>
-public sealed record MixerConfig
+public sealed partial record MixerConfig
 {
     public required IReadOnlyList<MixDefinition> Mixes { get; init; }
     public required IReadOnlyList<ChannelDefinition> Channels { get; init; }

--- a/src/OpenXLR.Core/Mixing/MixerSettings.cs
+++ b/src/OpenXLR.Core/Mixing/MixerSettings.cs
@@ -13,6 +13,12 @@ namespace OpenXLR.Core.Mixing;
 /// </summary>
 public sealed record MixerSettings
 {
+    /// <summary>Ordered application channels; null preserves the legacy defaults.</summary>
+    public List<UserChannelDefinition>? UserChannels { get; init; }
+
+    /// <summary>Ordered virtual microphones; null preserves Stream and Chat.</summary>
+    public List<UserMixDefinition>? UserMixes { get; init; }
+
     /// <summary>
     /// The saved settings with the monitor selection replaced by an
     /// environment or command-line override, when one is given. Both the
@@ -121,3 +127,6 @@ public sealed record MixerSettings
 
 /// <summary>A remembered application: identity, display label, channel.</summary>
 public sealed record SavedApp(string Identity, string Label, string ChannelId);
+
+public sealed record UserChannelDefinition(string Id, string Name);
+public sealed record UserMixDefinition(string Id, string Name);

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -156,11 +156,11 @@ public sealed class MixerService : IHostedService, IDisposable
 
         try
         {
-            _mixer.Build(MixerConfig.Default(), output);
+            MixerSettings? saved = MixerSettings.Load();
+            _mixer.Build(MixerConfig.FromSettings(saved), output);
 
             // Restore the user's saved levels, mutes, device picks, and per-app
             // assignments. Env vars, when set, still win for the device picks.
-            MixerSettings? saved = MixerSettings.Load();
             if (saved is not null)
             {
                 _mixer.ApplySettings(saved.WithMonitorOverride(output));

--- a/src/OpenXLR.Tests/MixerLayoutSettingsTests.cs
+++ b/src/OpenXLR.Tests/MixerLayoutSettingsTests.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class MixerLayoutSettingsTests
+{
+    [Fact]
+    public void OldSettingsRetainEveryDefaultNodeAndHardwareMute()
+    {
+        var expected = MixerConfig.Default();
+        var actual = MixerConfig.FromSettings(new MixerSettings());
+        Assert.Equal(expected.Mixes, actual.Mixes);
+        Assert.Equal(expected.Channels.Select(c => (c.Id, c.Name, c.InputPair)),
+            actual.Channels.Select(c => (c.Id, c.Name, c.InputPair)));
+        foreach (var c in expected.Channels)
+        {
+            var restored = actual.Channels.Single(a => a.Id == c.Id);
+            Assert.Equal(c.Levels, restored.Levels);
+            Assert.True(c.MutedIn.SetEquals(restored.MutedIn));
+        }
+    }
+
+    [Fact]
+    public void CustomLayoutPreservesBothMonitorsAuxAndHardware()
+    {
+        var config = MixerConfig.FromSettings(new MixerSettings
+        {
+            UserChannels = [new("podcast", "Interview"), new("music", "My music")],
+            UserMixes = [new("recording", "Archive")],
+        });
+        Assert.Equal(["monitor", "monitor2", "recording", "auxout"], config.Mixes.Select(m => m.Id));
+        Assert.Equal(["xlr1", "xlr2", "aux", "podcast", "music"], config.Channels.Select(c => c.Id));
+        Assert.Equal("OpenXLR_ch_podcast", config.Channels[3].SinkName);
+        Assert.Equal("Interview", config.Channels[3].Name);
+        Assert.All(config.Channels, c => Assert.Equal(config.Mixes.Select(m => m.Id), c.Levels.Keys));
+        Assert.Contains("auxout", config.Channels[2].MutedIn);
+        Assert.Equal(0, config.Channels[2].Levels["auxout"]);
+    }
+
+    [Fact]
+    public void CorruptEntriesCannotReplaceStructuralNodesOrCreateIgnoreSink()
+    {
+        var settings = JsonSerializer.Deserialize<MixerSettings>("""
+            {"UserChannels":[null,{"Id":null,"Name":"X"},{"Id":"ignore","Name":"X"},
+              {"Id":"xlr1","Name":"X"},{"Id":"bad|id","Name":"X"},
+              {"Id":"ok","Name":"Good"},{"Id":"ok","Name":"Duplicate"},
+              {"Id":"bad","Name":"Line\nbreak"}],
+             "UserMixes":[{"Id":"monitor2","Name":"Bad"},{"Id":"auxout","Name":"Bad"},null]}
+            """)!;
+        var config = MixerConfig.FromSettings(settings);
+        Assert.Equal(["xlr1", "xlr2", "aux", "ok"], config.Channels.Select(c => c.Id));
+        Assert.Equal(["monitor", "monitor2", "auxout"], config.Mixes.Select(m => m.Id));
+        Assert.Equal("Monitor B", config.Mixes[1].Name);
+    }
+
+    [Fact]
+    public void GraphSizeIsBoundedAndEmptyApplicationsHaveSafeFallback()
+    {
+        var config = MixerConfig.FromSettings(new MixerSettings
+        {
+            UserChannels = Enumerable.Range(0, 100).Select(i => new UserChannelDefinition($"c{i}", "C")).ToList(),
+            UserMixes = Enumerable.Range(0, 100).Select(i => new UserMixDefinition($"m{i}", "M")).ToList(),
+        });
+        Assert.Equal(MixerConfig.MaxApplicationChannels, config.Channels.Count(c => c.InputPair is null));
+        Assert.Equal(MixerConfig.MaxVirtualMixes, config.Mixes.Count(m => m.Kind == MixKind.VirtualMic));
+        var empty = MixerConfig.FromSettings(new MixerSettings { UserChannels = [], UserMixes = [] });
+        Assert.Equal("system", Assert.Single(empty.Channels, c => c.InputPair is null).Id);
+        Assert.DoesNotContain(empty.Mixes, m => m.Kind == MixKind.VirtualMic);
+    }
+
+    [Fact]
+    public void MissingAppRulesCannotRouteIntoHardwareAndIgnoreSurvives()
+    {
+        var config = MixerConfig.FromSettings(new MixerSettings { UserChannels = [new("podcast", "Podcast")] });
+        Assert.Equal("podcast", config.ResolveApplicationChannel("game"));
+        Assert.Equal("podcast", config.ResolveApplicationChannel("xlr1"));
+        Assert.Equal("podcast", config.ResolveApplicationChannel("podcast"));
+        Assert.Equal("ignore", config.ResolveApplicationChannel("ignore"));
+    }
+
+    [Fact]
+    public void RoundTripPreservesOrderNamesAndMonitorFeeds()
+    {
+        string dir = Directory.CreateTempSubdirectory("openxlr-layout-").FullName;
+        string path = Path.Combine(dir, "mixer.json");
+        try
+        {
+            var settings = new MixerSettings
+            {
+                UserChannels = [new("second", "Second"), new("first", "First")],
+                UserMixes = [], MonitorFeeds = new() { ["headset"] = "monitor+monitor2" },
+            };
+            Assert.Null(settings.Save(path));
+            var loaded = Assert.IsType<MixerSettings>(MixerSettings.Load(path));
+            Assert.Equal(settings.UserChannels, loaded.UserChannels);
+            Assert.Empty(loaded.UserMixes!);
+            Assert.Equal(settings.MonitorFeeds, loaded.MonitorFeeds);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
Small current-main foundation extracted from #22: the persisted layout format and startup restoration only. It is independently usable by editing mixer.json while the daemon is stopped; it does not introduce live layout commands or desktop editing.

- Ordered userChannels/userMixes with stable IDs and display names; null preserves old defaults.
- Monitor A, Monitor B, Aux and hardware inputs remain structural. Existing monitorFeeds and profile semantics are untouched.
- Reject malformed/null/duplicate/reserved entries and cap graph growth. Empty app lists retain a safe System sink.
- Obsolete application rules/assignments fall back to an application sink instead of the first hardware input. Ignore remains ignore.
- Production startup consumes the format; ExportSettings retains the live layout on subsequent ordinary saves. No unused API parameters or unconsumed schema fields.

Verification: 173 Release tests pass. An external private PipeWire/Pulse/WirePlumber run built the custom layout, restored it after a settings round trip and graph restart, and checked old assignments and both monitors. A bubblewrap read-only mount confirmed the existing Save result reports failure and preserves the prior file. No test tools or package changes are added here. Signed/verified commit 7b2c06f.

This deliberately does NOT claim to close the structural-command acknowledgement bug or live rename blocker in #22. Incremental live edits with strict save acknowledgement and the separate desktop editor follow this storage foundation. No graph recreation is introduced for a live rename because there is no live rename command in this PR.