### PR TITLE
Create application channels without rebuilding the graph

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -53,6 +53,7 @@ Commands are single JSON objects with a `cmd` field:
 | `setLowCutHz` | `value` | software low cut: 0, 80, or 120 |
 | `setSoftClipGuard` | `value` | software ClipGuard (post-ADC limiter at -3 dB); enabling is rejected if `swh-plugins` is unavailable, without replacing or disconnecting the live microphone route |
 | `setLevel` | `channel`, `mix`, `value` | one send fader |
+| `createChannel` | `name` | add an application channel without rebuilding existing nodes; succeeds only after settings are saved, with its generated stable ID in the next state |
 | `setChannelMuted` | `channel`, `mix`, `value` | one send mute |
 | `setMixVolume` / `setMixMuted` | `mix`, `value` | mix masters |
 | `setMonitorOutputs` | `devices[]` | every sink the monitor mixes feed; a newly listed output is fed by the first monitor mix |

--- a/docs/mixer-layout.md
+++ b/docs/mixer-layout.md
@@ -32,5 +32,12 @@ save and restart. Removed application destinations fall back to the first
 application channel, never a hardware input; ignored applications stay ignored.
 Existing monitor-feed settings and profile semantics are unchanged.
 
-This format does not provide live layout commands or a desktop layout editor.
-Manual changes, including external PipeWire descriptions, take effect at startup.
+The `createChannel {name}` command adds an application channel while running,
+without rebuilding existing nodes. It succeeds only after the new layout is
+saved. A failed save removes the new channel and reports an error; existing
+channels and virtual microphones remain in place. Ordinary fader saves retain
+their best-effort retry behavior.
+
+Other manual changes, including external PipeWire descriptions, take effect at
+startup. A desktop layout editor and other live layout commands are not yet
+provided.

--- a/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
@@ -1,0 +1,75 @@
+namespace OpenXLR.Core.Mixing;
+
+public sealed partial class Mixer
+{
+    /// <summary>
+    /// Add only the new application sink. Readers cannot observe its layout
+    /// until persistence succeeds. A failed save removes only the new module.
+    /// The caller serializes its save callback with other settings writers.
+    /// </summary>
+    public void CreateApplicationChannel(string name, Func<MixerSettings, string?> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        name = name.Trim();
+        if (name.Length is 0 or > 60 || name.Any(char.IsControl))
+            throw new InvalidOperationException("channel name must contain 1 to 60 printable characters");
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            if (_config.Channels.Count(c => c.InputPair is null) >= MixerConfig.MaxApplicationChannels)
+                throw new InvalidOperationException("application channel limit reached");
+            string id = NewChannelId(name, _config.Channels.Select(c => c.Id));
+            var channel = new ChannelDefinition(id, name)
+            { Levels = _config.Mixes.ToDictionary(m => m.Id, _ => 1.0) };
+            MixerConfig previous = _config;
+            uint module = _pw.CreateCombineSink(channel.SinkName,
+                _config.Mixes.Select(m => m.SinkName), $"OpenXLR {name}");
+            try
+            {
+                _config = _config with { Channels = [.. _config.Channels, channel] };
+                _combineModules[id] = module;
+                var legs = _pw.FindCombineLegs(module);
+                foreach (var mix in _config.Mixes)
+                {
+                    string cell = Cell(id, mix.Id);
+                    _cells.Add(cell);
+                    _levels[cell] = 1.0;
+                    if (legs.TryGetValue(mix.SinkName, out int index)) _legIndex[cell] = index;
+                    ApplyCellLocked(id, mix.Id);
+                }
+                if (persist(ExportSettings()) is string error) throw new IOException(error);
+            }
+            catch (Exception editError)
+            {
+                _config = previous;
+                _combineModules.Remove(id);
+                foreach (var mix in previous.Mixes)
+                {
+                    string cell = Cell(id, mix.Id);
+                    _cells.Remove(cell);
+                    _levels.Remove(cell);
+                    _muted.Remove(cell);
+                    _legIndex.Remove(cell);
+                }
+                try { _pw.UnloadModule(module); }
+                catch (Exception cleanupError)
+                { throw new AggregateException("channel creation failed and its module could not be removed", editError, cleanupError); }
+                throw;
+            }
+            _meters.Add($"ch:{id}", channel.SinkName);
+        }
+    }
+
+    internal static string NewChannelId(string name, IEnumerable<string> existing)
+    {
+        string slug = new(name.ToLowerInvariant().Select(c => char.IsAsciiLetterOrDigit(c) ? c : '-').ToArray());
+        slug = string.Join('-', slug.Split('-', StringSplitOptions.RemoveEmptyEntries));
+        if (slug.Length == 0) slug = "channel";
+        if (!char.IsAsciiLetter(slug[0])) slug = "channel-" + slug;
+        if (slug.Length > 28) slug = slug[..28].TrimEnd('-');
+        var used = new HashSet<string>(existing.Append(StreamMatcher.Ignore), StringComparer.OrdinalIgnoreCase);
+        string id = slug;
+        for (int n = 2; used.Contains(id); n++) id = $"{slug}-{n}";
+        return id;
+    }
+}

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -18,7 +18,7 @@ namespace OpenXLR.Core.Mixing;
 /// The graph is built once; level changes touch only stream volumes, so audio
 /// is never interrupted.
 /// </summary>
-public sealed class Mixer : IDisposable, ILayoutInfo
+public sealed partial class Mixer : IDisposable, ILayoutInfo
 {
     private readonly PipeWireAdapter _pw;
     private readonly Dictionary<string, double> _levels = [];   // "channel|mix" -> level

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -197,6 +197,14 @@ public sealed class PipeWireAdapter
         return id;
     }
 
+    /// <summary>Remove one owned module, retaining it for teardown if unloading fails.</summary>
+    public void UnloadModule(uint id)
+    {
+        if (!_modules.Contains(id)) throw new InvalidOperationException("module is not owned by this mixer");
+        Run("pactl", "unload-module", id.ToString());
+        _modules.Remove(id);
+    }
+
     /// <summary>A "sink#suffix" pseudo-device address without its suffix.</summary>
     private static string BareSink(string sinkName)
     {

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -24,6 +24,9 @@ public static class CommandValidation
     {
         switch (cmd.Cmd)
         {
+            case "createChannel":
+                return cmd.Name is null || cmd.Name.Length > 60 || string.IsNullOrWhiteSpace(cmd.Name) || cmd.Name.Any(char.IsControl)
+                    ? "createChannel: name must contain 1 to 60 printable characters" : null;
             case "setLevel":
             case "setChannelMuted":
                 if (cmd.Channel is not null && !layout.HasChannel(cmd.Channel)) return $"{cmd.Cmd}: unknown channel '{Short(cmd.Channel)}'";

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -283,6 +283,18 @@ public sealed class MixerService : IHostedService, IDisposable
         {
             switch (cmd.Cmd)
             {
+                case "createChannel":
+                    if (cmd.Name is null) return "createChannel: need 'name'";
+                    lock (_saveGate)
+                    {
+                        _mixer.CreateApplicationChannel(cmd.Name, settings => settings.Save());
+                        _saveDirty = false;
+                        _lastSaveError = null;
+                        _retryDelay = SaveDelay;
+                        _saveDebounce?.Change(Timeout.Infinite, Timeout.Infinite);
+                    }
+                    Changed?.Invoke();
+                    return null;
                 case "setLevel":
                     if (cmd.Channel is null || cmd.Mix is null) return "setLevel: need 'channel' and 'mix'";
                     _mixer.SetLevel(cmd.Channel, cmd.Mix, cmd.Value.GetDouble());

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -187,6 +187,7 @@ public sealed class WebSocketHub
                 string? err = _devices.Apply(cmd.Control, cmd.Value);  // broadcasts on success
                 if (err is not null) await reply(new ErrorMessage(err));
                 break;
+            case "createChannel":
             case "setLevel":
             case "setChannelMuted":
             case "setMixVolume":

--- a/src/OpenXLR.Tests/LiveMixerLayoutTests.cs
+++ b/src/OpenXLR.Tests/LiveMixerLayoutTests.cs
@@ -1,0 +1,39 @@
+using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+public sealed class LiveMixerLayoutTests
+{
+    [Theory]
+    [InlineData("Podcast", "podcast")]
+    [InlineData("123", "channel-123")]
+    [InlineData("ignore", "ignore-2")]
+    [InlineData("🎙", "channel")]
+    [InlineData("Studio \"A\"", "studio-a")]
+    public void StableIdsAreSafeAndNeverUseTheIgnoreTarget(string name, string id)
+        => Assert.Equal(id, Mixer.NewChannelId(name, []));
+
+    [Fact]
+    public void StableIdsAvoidExistingHardwareAndApplicationIds()
+        => Assert.Equal("xlr1-3", Mixer.NewChannelId("XLR1", ["xlr1", "xlr1-2"]));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("bad\nname")]
+    public void InvalidNamesAreRejectedBeforeGraphWork(string? name)
+    {
+        using var mixer = new Mixer();
+        Assert.NotNull(CommandValidation.Check(new Command { Cmd = "createChannel", Name = name }, mixer, _ => null));
+    }
+
+    [Fact]
+    public void LongNamesAreRejectedAndOrdinaryNamesAccepted()
+    {
+        using var mixer = new Mixer();
+        Assert.NotNull(CommandValidation.Check(new Command { Cmd = "createChannel", Name = new string('a', 61) }, mixer, _ => null));
+        Assert.Null(CommandValidation.Check(new Command { Cmd = "createChannel", Name = "Studio A" }, mixer, _ => null));
+    }
+}


### PR DESCRIPTION
Next small live-layout piece from #22, built on the merged #33 and current main. Adds createChannel {name} through the existing WebSocket/HTTP dispatcher. A stable ID is generated, graph growth is bounded, and only the new combine sink is created; existing channels, virtual microphones and Monitor A/B/Aux routing are not rebuilt.

The service serializes this structural save with its ordinary writer. The mixer holds its state lock until the save succeeds. Failure removes the new module and restores the previous in-memory layout; the command returns an error without a success broadcast. Existing fader saves keep their best-effort/retry behavior.

Verification: 184 Release tests pass. A private PipeWire/Pulse/WirePlumber test called the real MixerService.Apply path and confirmed persistence precedes the Changed event. A second process with the config directory bind-mounted read-only confirmed an error, no success event, no leaked node or layout entry, and an unchanged settings file. All 18 pre-existing OpenXLR nodes retained their object.serial values in both runs. External acceptance tooling remains outside the PR. The commit is GitHub signed and verified.

This is application-channel creation only, not a claim to complete #22. Live rename/delete/reorder, incremental virtual-mix changes and the desktop editor remain separate work. No unsupported pactl rename command or new native build dependency is introduced.