### PR TITLE
Persist live channel and virtual-mix order without graph changes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,6 +54,7 @@ Commands are single JSON objects with a `cmd` field:
 | `setSoftClipGuard` | `value` | software ClipGuard (post-ADC limiter at -3 dB); enabling is rejected if `swh-plugins` is unavailable, without replacing or disconnecting the live microphone route |
 | `setLevel` | `channel`, `mix`, `value` | one send fader |
 | `createChannel` | `name` | add an application channel without rebuilding existing nodes; succeeds only after settings are saved, with its generated stable ID in the next state |
+| `setLayoutOrder` | `channels[]`, `mixes[]` | complete ordered lists of application-channel and virtual-microphone IDs; structural nodes stay fixed; succeeds only after saving |
 | `setChannelMuted` | `channel`, `mix`, `value` | one send mute |
 | `setMixVolume` / `setMixMuted` | `mix`, `value` | mix masters |
 | `setMonitorOutputs` | `devices[]` | every sink the monitor mixes feed; a newly listed output is fed by the first monitor mix |

--- a/docs/mixer-layout.md
+++ b/docs/mixer-layout.md
@@ -38,6 +38,12 @@ saved. A failed save removes the new channel and reports an error; existing
 channels and virtual microphones remain in place. Ordinary fader saves retain
 their best-effort retry behavior.
 
+`setLayoutOrder {channels, mixes}` changes the list order while running. Supply
+every application-channel ID in `channels` and every virtual-microphone ID in
+`mixes`, each exactly once. Hardware inputs, Monitor A/B and Aux are excluded
+and remain in their structural positions. Duplicate, missing and unknown IDs
+are errors. Success means the order was saved; a failed write restores the
+previous order. No PipeWire node or link changes during this operation.
+
 Other manual changes, including external PipeWire descriptions, take effect at
-startup. A desktop layout editor and other live layout commands are not yet
-provided.
+startup. The desktop layout editor is not yet provided.

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -71,6 +71,24 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
     public IReadOnlyDictionary<string, double[]> ReadMeters() => _meters.Read();
 
     public MixerConfig Config => _config;
+
+    /// <summary>Save an order change without touching any PipeWire node or link.</summary>
+    public void SetLayoutOrder(IReadOnlyList<string> channels, IReadOnlyList<string> mixes,
+        Func<MixerSettings, string?> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            MixerConfig previous = _config;
+            _config = _config.WithOrder(channels, mixes);
+            try
+            {
+                if (persist(ExportSettings()) is string error) throw new IOException(error);
+            }
+            catch { _config = previous; throw; }
+        }
+    }
     public bool Built => _built;
 
     private static string Cell(string channel, string mix) => $"{channel}|{mix}";

--- a/src/OpenXLR.Core/Mixing/MixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/MixerLayout.cs
@@ -6,6 +6,29 @@ public sealed partial record MixerConfig
     public const int MaxApplicationChannels = 32;
     public const int MaxVirtualMixes = 16;
 
+    /// <summary>Reorder editable nodes only; every existing ID must occur exactly once.</summary>
+    public MixerConfig WithOrder(IReadOnlyList<string> channels, IReadOnlyList<string> mixes)
+    {
+        var apps = Channels.Where(c => c.InputPair is null).ToDictionary(c => c.Id);
+        var virtualMics = Mixes.Where(m => m.Kind == MixKind.VirtualMic).ToDictionary(m => m.Id);
+        Check(channels, apps.Keys, MaxApplicationChannels, "channels");
+        Check(mixes, virtualMics.Keys, MaxVirtualMixes, "mixes");
+        return this with
+        {
+            Channels = [.. Channels.Where(c => c.InputPair is not null), .. channels.Select(id => apps[id])],
+            Mixes = [.. Mixes.Where(m => m.Kind == MixKind.Monitor), .. mixes.Select(id => virtualMics[id]),
+                .. Mixes.Where(m => m.Kind == MixKind.AuxPort)],
+        };
+
+        static void Check(IReadOnlyList<string> order, IEnumerable<string> existing, int limit, string kind)
+        {
+            ArgumentNullException.ThrowIfNull(order);
+            var expected = existing.ToHashSet(StringComparer.Ordinal);
+            if (order.Count > limit || order.Count != expected.Count || order.Any(id => id is null || !expected.Remove(id)))
+                throw new InvalidOperationException($"{kind}: provide every editable ID exactly once; structural IDs cannot be reordered");
+        }
+    }
+
     /// <summary>Keep obsolete app rules out of hardware inputs after a layout change.</summary>
     public string ResolveApplicationChannel(string requested)
         => requested == StreamMatcher.Ignore ? requested

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -27,6 +27,13 @@ public static class CommandValidation
             case "createChannel":
                 return cmd.Name is null || cmd.Name.Length > 60 || string.IsNullOrWhiteSpace(cmd.Name) || cmd.Name.Any(char.IsControl)
                     ? "createChannel: name must contain 1 to 60 printable characters" : null;
+            case "setLayoutOrder":
+                if (cmd.Channels is null || cmd.Mixes is null) return "setLayoutOrder: need 'channels' and 'mixes'";
+                if (cmd.Channels.Count > MixerConfig.MaxApplicationChannels || cmd.Mixes.Count > MixerConfig.MaxVirtualMixes)
+                    return "setLayoutOrder: too many IDs";
+                if (cmd.Channels.Concat(cmd.Mixes).Any(id => id is null || id.Length is 0 or > 36))
+                    return "setLayoutOrder: invalid ID";
+                return null; // The mixer validates exact membership under its state lock.
             case "setLevel":
             case "setChannelMuted":
                 if (cmd.Channel is not null && !layout.HasChannel(cmd.Channel)) return $"{cmd.Cmd}: unknown channel '{Short(cmd.Channel)}'";

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -284,10 +284,13 @@ public sealed class MixerService : IHostedService, IDisposable
             switch (cmd.Cmd)
             {
                 case "createChannel":
-                    if (cmd.Name is null) return "createChannel: need 'name'";
+                case "setLayoutOrder":
                     lock (_saveGate)
                     {
-                        _mixer.CreateApplicationChannel(cmd.Name, settings => settings.Save());
+                        if (cmd.Cmd == "createChannel")
+                            _mixer.CreateApplicationChannel(cmd.Name!, settings => settings.Save());
+                        else
+                            _mixer.SetLayoutOrder(cmd.Channels!, cmd.Mixes!, settings => settings.Save());
                         _saveDirty = false;
                         _lastSaveError = null;
                         _retryDelay = SaveDelay;

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -33,6 +33,10 @@ public sealed record Command
     /// <summary>Mixer commands: which mix.</summary>
     [JsonPropertyName("mix")] public string? Mix { get; init; }
 
+    /// <summary>setLayoutOrder: complete ordered lists of editable stable IDs.</summary>
+    [JsonPropertyName("channels")] public List<string>? Channels { get; init; }
+    [JsonPropertyName("mixes")] public List<string>? Mixes { get; init; }
+
     /// <summary>"assignStream": the PipeWire stream (sink-input) id to route.</summary>
     [JsonPropertyName("streamId")] public int? StreamId { get; init; }
 

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -188,6 +188,7 @@ public sealed class WebSocketHub
                 if (err is not null) await reply(new ErrorMessage(err));
                 break;
             case "createChannel":
+            case "setLayoutOrder":
             case "setLevel":
             case "setChannelMuted":
             case "setMixVolume":

--- a/src/OpenXLR.Tests/LayoutOrderTests.cs
+++ b/src/OpenXLR.Tests/LayoutOrderTests.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+public sealed class LayoutOrderTests
+{
+    [Fact]
+    public void ReorderPreservesDefinitionsIdsAndStructuralNodes()
+    {
+        var original = MixerConfig.Default();
+        var apps = original.Channels.Where(c => c.InputPair is null).Reverse().ToArray();
+        var ordered = original.WithOrder(apps.Select(c => c.Id).ToArray(), ["chat", "stream"]);
+        Assert.Equal(["xlr1", "xlr2", "aux", .. apps.Select(c => c.Id)], ordered.Channels.Select(c => c.Id));
+        Assert.Equal(["monitor", "monitor2", "chat", "stream", "auxout"], ordered.Mixes.Select(m => m.Id));
+        foreach (var channel in original.Channels) Assert.Same(channel, ordered.Channels.Single(c => c.Id == channel.Id));
+        foreach (var mix in original.Mixes) Assert.Same(mix, ordered.Mixes.Single(m => m.Id == mix.Id));
+        Assert.Equal("game", original.Channels[3].Id); // The original snapshot was not mutated.
+    }
+
+    [Theory]
+    [InlineData("duplicate")]
+    [InlineData("missing")]
+    [InlineData("unknown")]
+    [InlineData("hardware")]
+    [InlineData("null")]
+    public void InvalidChannelPermutationIsRejected(string kind)
+    {
+        var config = MixerConfig.Default();
+        var ids = config.Channels.Where(c => c.InputPair is null).Select(c => c.Id).ToList();
+        if (kind == "missing") ids.RemoveAt(0);
+        else ids[0] = kind switch { "duplicate" => ids[1], "hardware" => "xlr1", "null" => null!, _ => "unknown" };
+        Assert.Throws<InvalidOperationException>(() => config.WithOrder(ids, ["stream", "chat"]));
+    }
+
+    [Theory]
+    [InlineData("monitor")]
+    [InlineData("monitor2")]
+    [InlineData("auxout")]
+    [InlineData("chat")]
+    public void StructuralAndDuplicateMixIdsAreRejected(string replacement)
+    {
+        var config = MixerConfig.Default();
+        Assert.Throws<InvalidOperationException>(() => config.WithOrder(
+            config.Channels.Where(c => c.InputPair is null).Select(c => c.Id).ToArray(), [replacement, "chat"]));
+    }
+
+    [Fact]
+    public void EmptyVirtualMixLayoutCanBeReordered()
+    {
+        var config = MixerConfig.FromSettings(new MixerSettings { UserMixes = [], UserChannels = [new("only", "Only")] });
+        Assert.Equal(config.Mixes, config.WithOrder(["only"], []).Mixes);
+    }
+
+    [Fact]
+    public void CommandListsAreDeserializedAndValidated()
+    {
+        var command = JsonSerializer.Deserialize<Command>("""{"cmd":"setLayoutOrder","channels":["system"],"mixes":[]} """)!;
+        using var mixer = new Mixer();
+        Assert.Equal("system", Assert.Single(command.Channels!));
+        Assert.Empty(command.Mixes!);
+        Assert.Null(CommandValidation.Check(command, mixer, _ => null));
+        Assert.NotNull(CommandValidation.Check(command with { Mixes = null }, mixer, _ => null));
+        Assert.NotNull(CommandValidation.Check(command with { Channels = Enumerable.Repeat("x", 33).ToList() }, mixer, _ => null));
+    }
+}


### PR DESCRIPTION
Ports the persistent layout-order portion of original fork commit 10f4ae0 onto current main, independently of live channel creation (#34).

Adds setLayoutOrder {channels, mixes}: complete permutations of editable application-channel and virtual-microphone IDs. Hardware inputs, Monitor A/B and Aux remain structural. Rejects missing, duplicate, unknown, oversized and structural IDs. The mixer retains existing definition objects, IDs, routes, levels and mutes; only display order changes. Save failure restores the exact prior config object and returns an error. Success broadcasts only after persistence. Ordinary fader saves retain their existing best-effort/retry behavior.

Both request fields are consumed by the production dispatcher and mixer, and deserialization/membership tests cover them. 185 Release tests pass. External private PipeWire acceptance through MixerService.Apply verifies successful persistence before the event, plus a real read-only mount failure with no success event, unchanged settings, restored order, and unchanged IDs/serials for every node and link. The commit is GitHub-signed and verified.

No desktop-editor changes, themes, release/CI modifications or general monitor-routing redesign. This completes the backend order operation only; desktop controls and other #22 live edits remain separate.