### PR TITLE
Mixer layout editing: rename, delete, mix creation, the desktop editor

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -6,6 +6,9 @@ if [ "$1" = "configure" ] && [ -z "$2" ]; then
 OpenXLR: replug your interface once so the udev rule applies.
 Start the daemon:  systemctl --user enable --now openxlr-daemon
 Start the mixer:   openxlr   (or from your application menu)
+The package raises pipewire-pulse's open-file limit (a drop-in under
+/usr/lib/systemd/user/pipewire-pulse.service.d); it applies at your next
+login, or now with:  systemctl --user daemon-reload; systemctl --user restart pipewire-pulse
 Stream Deck via OpenDeck:
   cp -r /usr/share/openxlr/com.emaspa.openxlr.sdPlugin ~/.config/opendeck/plugins/
 MSG

--- a/debian/rules
+++ b/debian/rules
@@ -58,6 +58,8 @@ override_dh_auto_install:
 		packaging/openxlr-daemon.service > $(OUT)/openxlr-daemon.service
 	install -Dm644 $(OUT)/openxlr-daemon.service \
 		$(PKG)/usr/lib/systemd/user/openxlr-daemon.service
+	install -Dm644 packaging/pipewire-pulse-openxlr.conf \
+		$(PKG)/usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf
 
 	install -Dm644 packaging/openxlr.desktop \
 		$(PKG)/usr/share/applications/openxlr.desktop

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,9 +42,16 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `state` | on connect and on every change | `daemonVersion`, device state, capabilities, mixer state, the device list, the app registry, profile names, `activeProfile` (the profile last recalled or saved for the active device; not cleared by later manual changes), `recallOnConnect` (the profile recalled when the device connects, or null), `warning` (one sentence the user should see, or null: mixer settings that cannot be written to disk, which the daemon keeps retrying with backoff, or a device set aside after three hung USB transfers in one run) |
 | `meters` | 15 Hz while the mixer is built | live stereo levels per channel and mix |
 | `plugins` | in answer to `listPlugins` | the installed LV2 plugins with their controls; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
-| `error` | when a command is rejected | `message` |
+| `error` | when a command without a `requestId` is rejected | `message` |
+| `commandResult` | in answer to a command that carried a `requestId` | `requestId`, `error` (null on success); preceded by the state the result refers to |
 
-Commands are single JSON objects with a `cmd` field:
+Commands are single JSON objects with a `cmd` field. The layout commands
+(`createChannel` through `setLayoutOrder` below) succeed only after the
+new layout is written to `mixer.json`; a failed write restores the previous
+layout and answers with an error. Any command may carry a `requestId`; the
+daemon then answers with a `commandResult {requestId, error}` message after
+the state that reflects the outcome (`error` is null on success) instead of
+a bare `error` message, so an editor can wait for the acknowledgement:
 
 | Command | Fields | Purpose |
 |---|---|---|
@@ -53,8 +60,13 @@ Commands are single JSON objects with a `cmd` field:
 | `setLowCutHz` | `value` | software low cut: 0, 80, or 120 |
 | `setSoftClipGuard` | `value` | software ClipGuard (post-ADC limiter at -3 dB); enabling is rejected if `swh-plugins` is unavailable, without replacing or disconnecting the live microphone route |
 | `setLevel` | `channel`, `mix`, `value` | one send fader |
-| `createChannel` | `name` | add an application channel without rebuilding existing nodes; succeeds only after settings are saved, with its generated stable ID in the next state |
-| `setLayoutOrder` | `channels[]`, `mixes[]` | complete ordered lists of application-channel and virtual-microphone IDs; structural nodes stay fixed; succeeds only after saving |
+| `createChannel` | `name` | add an application channel, muted in every mix, without touching existing nodes; its generated stable id is in the next state |
+| `renameChannel` | `channel`, `name` | rename an application channel; its playback device is reloaded under the new name and the streams on it are put back (a short gap on that channel only) |
+| `deleteChannel` | `channel` | remove an application channel; apps and remembered assignments on it move to the first remaining application channel. The last application channel cannot be removed |
+| `createMix` | `name` | add a virtual microphone; every channel gets a muted send into it before the capture device is published |
+| `renameMix` | `mix`, `name` | rename a virtual microphone in OpenXLR; the PipeWire device keeps its old description until the daemon restarts (reloading it would throw recording apps off), and the state's `renamedSinceStart` says so |
+| `deleteMix` | `mix` | remove a virtual microphone with its sends, inserts and capture device |
+| `setLayoutOrder` | `channels[]`, `mixes[]` | complete ordered lists of application-channel and virtual-microphone ids; structural nodes stay fixed |
 | `setChannelMuted` | `channel`, `mix`, `value` | one send mute |
 | `setMixVolume` / `setMixMuted` | `mix`, `value` | mix masters |
 | `setMonitorOutputs` | `devices[]` | every sink the monitor mixes feed; a newly listed output is fed by the first monitor mix |

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,7 +64,7 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `renameChannel` | `channel`, `name` | rename an application channel; its playback device is reloaded under the new name and the streams on it are put back (a short gap on that channel only) |
 | `deleteChannel` | `channel` | remove an application channel; apps and remembered assignments on it move to the first remaining application channel. The last application channel cannot be removed |
 | `createMix` | `name` | add a virtual microphone; every channel gets a muted send into it before the capture device is published |
-| `renameMix` | `mix`, `name` | rename a virtual microphone in OpenXLR; the PipeWire device keeps its old description until the daemon restarts (reloading it would throw recording apps off), and the state's `renamedSinceStart` says so |
+| `renameMix` | `mix`, `name` | rename a virtual microphone in OpenXLR; the PipeWire device keeps its old description until the daemon restarts (reloading it would throw recording apps off), and the mixer state's `renamedSinceStart` says so. The mixer state's `layoutWarning` carries a sentence when pipewire-pulse nears its open-file limit |
 | `deleteMix` | `mix` | remove a virtual microphone with its sends, inserts and capture device |
 | `setLayoutOrder` | `channels[]`, `mixes[]` | complete ordered lists of application-channel and virtual-microphone ids; structural nodes stay fixed |
 | `setChannelMuted` | `channel`, `mix`, `value` | one send mute |

--- a/docs/features.md
+++ b/docs/features.md
@@ -72,6 +72,9 @@ Built from PipeWire nodes, no kernel modules or custom drivers:
   `OpenXLR Chat`, selectable in OBS or Discord like a microphone), and
   Aux (what a second computer on the USB Aux port receives)
 - Per-channel, per-mix send levels and mutes; per-mix masters
+- An editable layout: add, rename, reorder and remove application
+  channels and virtual microphones while audio plays, from the window or
+  the API, with stable ids so profiles and Stream Deck keys survive
 - The monitor mixes can play on several outputs at once, hardware
   outputs included; each output picks which monitor mix feeds it, or
   both summed (Monitor A+B), so a headset with a game sink and a chat
@@ -93,8 +96,8 @@ muted, you do not. With another device in the monitor set the software
 send carries the microphone to everything instead.
 
 Channels appear as playback devices in the desktop's audio applet, and
-the Stream and Chat virtual microphones as recording devices; the
-hardware input channels are hidden from it.
+the virtual microphones (Stream and Chat by default) as recording
+devices; the hardware input channels are hidden from it.
 
 ## Inserts
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -434,8 +434,8 @@ disappear, apps fall back to the default output, and the window shows
 "Sink not found" errors from pactl.
 
 OpenXLR refuses to add a channel or mix when the server has no room left
-and says so in the editor, and the header shows a warning once the server
-is at three quarters of its limit. The packages install a drop-in under
+and says so in the editor, which also shows a note once the server is at
+three quarters of its limit. The packages install a drop-in under
 `/usr/lib/systemd/user/pipewire-pulse.service.d/` that raises the limit
 to 65536. It applies at the next login, or right away with
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -280,6 +280,37 @@ Since 0.1.23 every client presents a token the daemon writes at start
 refused with "unauthorized" until it is updated too; the plugin zip on
 the release page matches the daemon of that release.
 
+### 3.11 Edit the mixer layout
+
+The default channels and mixes are a starting point. Edit layout… in the
+SUBMIXER card opens the layout editor: application channels on the left,
+mixes on the right, each with move up and down, Rename and Delete, and a
+box at the bottom to add one. The hardware inputs, Monitor A, Monitor B
+and Aux are listed but fixed.
+
+- A new channel appears as a playback device at once and starts muted in
+  every mix, so route an app to it and open the sends you want.
+- A new virtual microphone receives nothing until you open a send; then
+  pick it in OBS, Discord or any recorder like a microphone.
+- Renaming a channel reloads its playback device under the new name.
+  Apps playing into it keep playing after a short gap; nothing else is
+  touched.
+- Renaming a mix changes the name in OpenXLR and on the Stream Deck right
+  away. Other applications keep listing the old microphone name until the
+  daemon restarts, because reloading the device would throw them off it.
+  The window shows a restart hint; restart when nothing is recording.
+- Deleting a channel moves its apps to the first remaining application
+  channel. Deleting a mix removes its virtual microphone, and anything
+  recording from it loses the device.
+
+Every change is saved before the editor confirms it. If the settings
+file cannot be written the change is undone and the editor says why. The
+same happens when pipewire-pulse has no room for more streams; section
+5.8 explains the limit and the drop-in that raises it.
+Ids are generated from names and never change afterwards, so profiles
+and Stream Deck keys survive a rename. The layout file is described in
+[mixer-layout.md](mixer-layout.md).
+
 ## 4. Stream Deck (OpenDeck)
 
 The plugin has two actions. Both are clients of the daemon and show
@@ -393,7 +424,32 @@ daemon, to try again.
 Collect diagnostics afterwards (section 5.8): the archive contains the
 exact transfer, and that is what makes the report actionable.
 
-### 5.8 Reporting a problem
+### 5.8 Channels or mixes vanish after adding one
+
+pipewire-pulse, PipeWire's PulseAudio server, inherits systemd's default
+limit of 1024 open files. OpenXLR's send faders are streams inside that
+server, so a layout with a few channels or mixes beyond the default
+reaches the limit, and past it the server drops nodes at random: sinks
+disappear, apps fall back to the default output, and the window shows
+"Sink not found" errors from pactl.
+
+OpenXLR refuses to add a channel or mix when the server has no room left
+and says so in the editor, and the header shows a warning once the server
+is at three quarters of its limit. The packages install a drop-in under
+`/usr/lib/systemd/user/pipewire-pulse.service.d/` that raises the limit
+to 65536. It applies at the next login, or right away with
+
+```sh
+systemctl --user daemon-reload
+systemctl --user restart pipewire-pulse
+```
+
+Restarting pipewire-pulse reconnects every PulseAudio client for a moment.
+Check with `systemctl --user show pipewire-pulse -p LimitNOFILESoft`.
+A source checkout without the package can put the same two lines into
+`~/.config/systemd/user/pipewire-pulse.service.d/openxlr.conf` by hand.
+
+### 5.9 Reporting a problem
 
 Ask on the OpenXLR Discord server (<https://discord.gg/4bswtnGPW4>,
 one post per problem in its support forum), on Reddit at

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -4,8 +4,11 @@ How to use OpenXLR day to day: what it changes on your system, the
 concepts behind the mixer window, step-by-step tasks, and what to do
 when something does not work. For installing, see the README; for the
 full list of controls per device, [hardware-support.md](hardware-support.md);
-for scripting, [api.md](api.md).
+for scripting, [api.md](api.md). Every section carries a fixed anchor
+(the `<a name>` before its heading), so a link like `manual.md#open-files`
+keeps working when sections are renumbered.
 
+<a name="first-run"></a>
 ## 1. First run
 
 OpenXLR is two programs. The daemon (`openxlr-daemon`, a systemd user
@@ -23,22 +26,22 @@ happen on your system:
   SFX`, and the hardware channels) and two inputs, `OpenXLR Stream` and
   `OpenXLR Chat`, which are the virtual microphones.
 - Applications that play audio are moved onto a channel output by name
-  (section 2). They keep playing; only the device they play into
+  ([section 2](#concepts)). They keep playing; only the device they play into
   changes.
 - Your system default output and input are left as they were. The
   daemon remembers them at start and puts them back if the session
   manager switches to one of the new devices in the following seconds.
-  If you set defaults in Options (section 3.7), those are held instead.
+  If you set defaults in Options ([section 3.7](#default-devices)), those are held instead.
 - On the Wave XLR Pro the daemon parks the card on its pro-audio
   profile while it runs, so the raw multichannel device is available to
   the mixer, and restores the previous profile when it stops.
 
 The window's header shows the connected interface with a green dot.
 "No device" means the daemon cannot open the interface: replug it once
-after installing so the udev rule applies (section 5.1).
+after installing so the udev rule applies ([section 5.1](#no-device)).
 
 If you only want hardware control and no mixer, turn the submixer off
-in Options (section 3.8). The daemon restarts in hardware-control mode
+in Options ([section 3.8](#hardware-only)). The daemon restarts in hardware-control mode
 and the `OpenXLR …` devices disappear.
 
 Update checks are also controlled in Options. They are off by default. You can
@@ -47,6 +50,7 @@ startup; opted-in checks run at most once per 24 hours. A notice contains the
 upstream stable release notes as plain text and a link to GitHub. OpenXLR never
 downloads or installs an update.
 
+<a name="concepts"></a>
 ## 2. Concepts
 
 **Channels** are where audio enters the mixer. Three carry the
@@ -77,7 +81,7 @@ Zoom, Slack and other chat apps to Voice Chat; Steam, Lutris, Heroic
 and games to Game; anything else to System. Electron apps report
 "Chromium", so the process name is used instead, which is how Discord
 lands in Voice Chat. An app you move to another channel is remembered
-(section 3.3).
+([section 3.3](#apps)).
 
 **Profiles** are named scenes: the interface's hardware settings plus
 the whole submixer (sends, masters, monitor outputs, aux state, insert
@@ -90,8 +94,10 @@ each XLR input, a stereo chain on each mix. The XLR Dock and the
 original Wave XLR have no onboard DSP, so on those OpenXLR also offers
 a software low cut and ClipGuard on XLR 1.
 
+<a name="tasks"></a>
 ## 3. Tasks
 
+<a name="mic-to-call"></a>
 ### 3.1 Send your microphone to a call or a recording
 
 1. In the SUBMIXER card, make sure XLR 1 is unmuted in the Stream and
@@ -103,9 +109,10 @@ a software low cut and ClipGuard on XLR 1.
    comes from the Monitor mix, which is separate.
 
 Options has a tip for step 2: enforcing `OpenXLR Chat` as the system
-default input (section 3.7) makes every voice app pick it up without
+default input ([section 3.7](#default-devices)) makes every voice app pick it up without
 configuration.
 
+<a name="monitor"></a>
 ### 3.2 Choose what you hear and how loud
 
 1. In the MONITOR card, tick every device the monitor mixes should play
@@ -135,6 +142,7 @@ zero latency; muted, you do not. If another device (speakers, a headset)
 is ticked as well, the microphone reaches everything through the
 software mix instead, with a few milliseconds of delay.
 
+<a name="apps"></a>
 ### 3.3 Put an application on a different channel
 
 The APPLICATIONS card lists every app that is currently registered with
@@ -164,6 +172,7 @@ An app that is missing from the card is not registered with PipeWire
 as a client. That happens with some applications until they start
 playing.
 
+<a name="usb-aux"></a>
 ### 3.4 Feed a second computer over USB Aux (Wave XLR Pro)
 
 1. Connect the second computer to the Pro's USB Aux port. It sees the
@@ -177,6 +186,7 @@ playing.
 The USB Aux *input* (what the second computer sends back) is the Aux In
 channel, with its level and lock in the INPUTS card.
 
+<a name="plugins"></a>
 ### 3.5 Add a plugin to the signal path
 
 1. Under XLR 1, XLR 2 or a mix, press "Add plugin…". The picker lists
@@ -194,6 +204,7 @@ The plugin's own graphical interface, if it has one, is not shown; the
 generated controls cover every parameter the plugin exposes. VST and
 CLAP plugins cannot be loaded.
 
+<a name="profiles"></a>
 ### 3.6 Save and recall a scene
 
 1. Set everything the way you want it: hardware controls, sends,
@@ -203,7 +214,7 @@ CLAP plugins cannot be loaded.
 
 Profiles belong to the interface they were saved with; another device
 shows its own list. With the OpenDeck plugin a key can recall a
-profile (section 4).
+profile ([section 4](#stream-deck)).
 
 **Recall on connect.** The "On connect" picker under the list names a
 profile the daemon recalls by itself whenever the interface connects
@@ -226,6 +237,7 @@ stay). The defaults are recorded the first time the interface connects
 after a power cycle, so the button asks for one replug on a fresh
 install.
 
+<a name="default-devices"></a>
 ### 3.7 Hold the system default devices
 
 Session managers like to switch the system default output to a newly
@@ -234,6 +246,7 @@ SYSTEM DEFAULT DEVICES, choose the output and input OpenXLR should
 hold; it re-asserts them once a second and reverts any outside change.
 "(don't enforce)" leaves the system alone.
 
+<a name="hardware-only"></a>
 ### 3.8 Hardware control only
 
 Options, Submixer: off. The daemon restarts in hardware-control mode:
@@ -242,6 +255,7 @@ profile where one is installed), and the `OpenXLR …` devices, mixes,
 virtual microphones and inserts go away. The INPUTS and HEADPHONES
 cards keep working. Turn it on again the same way.
 
+<a name="autostart"></a>
 ### 3.9 Start at login, tray
 
 Options, STARTUP:
@@ -255,13 +269,14 @@ Options, STARTUP:
   it the first time you click it.
 
 To land on a known scene at every login, mark a profile to recall on
-connect (section 3.6). An interface without settings memory comes back
+connect ([section 3.6](#profiles)). An interface without settings memory comes back
 as you left it without one.
 
 The window also remembers which of its sections (INPUTS, HEADPHONES,
 MONITOR, APPLICATIONS, SUBMIXER) you collapsed with the chevron in
 their header, across restarts.
 
+<a name="upgrade"></a>
 ### 3.10 Upgrade
 
 Packages do not restart a running daemon. After an upgrade the window
@@ -276,10 +291,11 @@ Until then the window offers only the controls the old daemon reports.
 Toggling the submixer in Options also restarts the daemon.
 
 Since 0.1.23 every client presents a token the daemon writes at start
-(section 6). A window or OpenDeck plugin older than the daemon is
+([section 6](#files)). A window or OpenDeck plugin older than the daemon is
 refused with "unauthorized" until it is updated too; the plugin zip on
 the release page matches the daemon of that release.
 
+<a name="layout"></a>
 ### 3.11 Edit the mixer layout
 
 The default channels and mixes are a starting point. Edit layout… in the
@@ -305,12 +321,13 @@ and Aux are listed but fixed.
 
 Every change is saved before the editor confirms it. If the settings
 file cannot be written the change is undone and the editor says why. The
-same happens when pipewire-pulse has no room for more streams; section
-5.8 explains the limit and the drop-in that raises it.
+same happens when pipewire-pulse has no room for more streams;
+[section 5.8](#open-files) explains the limit and the drop-in that raises it.
 Ids are generated from names and never change afterwards, so profiles
 and Stream Deck keys survive a rename. The layout file is described in
 [mixer-layout.md](mixer-layout.md).
 
+<a name="stream-deck"></a>
 ## 4. Stream Deck (OpenDeck)
 
 The plugin has two actions. Both are clients of the daemon and show
@@ -343,8 +360,10 @@ install-from-file, or the folder the package ships in
 (copied, not linked; OpenDeck does not serve assets through a symlink).
 Restart OpenDeck after installing or updating the plugin.
 
+<a name="troubleshooting"></a>
 ## 5. Troubleshooting
 
+<a name="no-device"></a>
 ### 5.1 "No device" in the header
 
 - The interface must be replugged once after installing so the udev
@@ -356,6 +375,7 @@ Restart OpenDeck after installing or updating the plugin.
 - With more than one supported interface attached, the header shows a
   picker; the mixer's input channels follow the chosen one.
 
+<a name="dock-silent"></a>
 ### 5.2 Microphone silent on the XLR Dock
 
 The kernel starves the dock's capture when playback to it starts before
@@ -365,6 +385,7 @@ WirePlumber rule that keeps the dock's capture source always active
 `packaging/` into `~/.config/wireplumber/wireplumber.conf.d/` and
 restart WirePlumber.
 
+<a name="daemon-not-starting"></a>
 ### 5.3 Daemon does not start after an upgrade, or after a reboot
 
 - `systemctl --user status openxlr-daemon` shows the state. "203/EXEC"
@@ -378,6 +399,7 @@ restart WirePlumber.
   to a minute for it and otherwise exits for systemd to retry; nothing
   needs to be configured.
 
+<a name="missing-plugins"></a>
 ### 5.4 ClipGuard greyed out, empty plugin picker
 
 - The software ClipGuard needs the SWH LADSPA plugins (`swh-plugins`).
@@ -387,13 +409,15 @@ restart WirePlumber.
   directories (`/usr/lib/lv2`, `~/.lv2`, or `LV2_PATH`). An empty
   picker means no LV2 plugins are installed, or lilv is missing.
 
+<a name="wrong-device"></a>
 ### 5.5 Sound comes out of the wrong device
 
 The session manager switched the system default when a new device
-appeared. Set the defaults in Options (section 3.7), or pick the device
+appeared. Set the defaults in Options ([section 3.7](#default-devices)), or pick the device
 you want in your desktop's sound settings once; the daemon defends the
 defaults it saw at start only for the first seconds.
 
+<a name="control-not-applied"></a>
 ### 5.6 A control changes in the window but not on the device
 
 The daemon writes to the interface and reads the state back; if the
@@ -401,8 +425,9 @@ device ignores the write, the control snaps back. On the Wave XLR Pro
 the mute button shows a countdown after every 48V change: the firmware
 holds that input muted for about 13 seconds and unmutes it itself. On
 other devices this would be new information: collect diagnostics
-(section 5.8) and open an issue.
+([section 5.9](#reporting)) and open an issue.
 
+<a name="daemon-hang"></a>
 ### 5.7 The daemon froze, or a control hung the window
 
 The header's **Restart daemon** button restarts the systemd user service.
@@ -421,9 +446,10 @@ one run the daemon stops driving that interface and says so under the
 window's header, while the submixer and any other interface keep
 working. Unplug the interface and plug it back in, or restart the
 daemon, to try again.
-Collect diagnostics afterwards (section 5.8): the archive contains the
+Collect diagnostics afterwards ([section 5.9](#reporting)): the archive contains the
 exact transfer, and that is what makes the report actionable.
 
+<a name="open-files"></a>
 ### 5.8 Channels or mixes vanish after adding one
 
 pipewire-pulse, PipeWire's PulseAudio server, inherits systemd's default
@@ -449,6 +475,7 @@ Check with `systemctl --user show pipewire-pulse -p LimitNOFILESoft`.
 A source checkout without the package can put the same two lines into
 `~/.config/systemd/user/pipewire-pulse.service.d/openxlr.conf` by hand.
 
+<a name="reporting"></a>
 ### 5.9 Reporting a problem
 
 Ask on the OpenXLR Discord server (<https://discord.gg/4bswtnGPW4>,
@@ -466,6 +493,7 @@ text files and inside the hex dump of the vendor blocks (the XLR Dock
 stores its serial in one); review the archive anyway before attaching
 it to a public issue. Nothing is uploaded automatically.
 
+<a name="files"></a>
 ## 6. Files and services
 
 | Path | What it is |
@@ -473,7 +501,7 @@ it to a public issue. Nothing is uploaded automatically.
 | `~/.config/openxlr/mixer.json` | every mixer decision, written by the daemon |
 | `~/.config/openxlr/profiles/<vid-pid>/<name>.json` | saved profiles, one file each |
 | `~/.config/openxlr/profiles/<vid-pid>/recall-on-connect` | the profile recalled when that interface connects, when one is chosen |
-| `$XDG_RUNTIME_DIR/openxlr/token` | the control API token for this daemon run, readable by your user only; the window and the OpenDeck plugin read it, a daemon older than the window will not have it (section 3.10) |
+| `$XDG_RUNTIME_DIR/openxlr/token` | the control API token for this daemon run, readable by your user only; the window and the OpenDeck plugin read it, a daemon older than the window will not have it ([section 3.10](#upgrade)) |
 | `~/.config/openxlr/devices/<vid-pid>/last-state.json` | the settings restored on connect to an interface without settings memory |
 | `~/.config/openxlr/devices/<vid-pid>/defaults.json` | the firmware defaults of such an interface, recorded after a power cycle, written back by "Reset device to defaults" |
 | `~/.config/openxlr/daemon.json` | the submixer on/off preference |

--- a/docs/mixer-layout.md
+++ b/docs/mixer-layout.md
@@ -64,7 +64,7 @@ error. Ordinary fader saves keep their debounced, retried behaviour.
 
 Every added channel or mix costs pipewire-pulse a few dozen open files;
 the daemon refuses an addition the server has no room for, and the packages
-raise the server's limit (manual, section 5.8).
+raise the server's limit ([manual, section 5.8](manual.md#open-files)).
 
 Ids are generated from names (lowercase letters, digits and hyphens,
 starting with a letter, unique with a numeric suffix) and never change

--- a/docs/mixer-layout.md
+++ b/docs/mixer-layout.md
@@ -32,18 +32,43 @@ save and restart. Removed application destinations fall back to the first
 application channel, never a hardware input; ignored applications stay ignored.
 Existing monitor-feed settings and profile semantics are unchanged.
 
-The `createChannel {name}` command adds an application channel while running,
-without rebuilding existing nodes. It succeeds only after the new layout is
-saved. A failed save removes the new channel and reports an error; existing
-channels and virtual microphones remain in place. Ordinary fader saves retain
-their best-effort retry behavior.
+## Editing while running
 
-`setLayoutOrder {channels, mixes}` changes the list order while running. Supply
-every application-channel ID in `channels` and every virtual-microphone ID in
-`mixes`, each exactly once. Hardware inputs, Monitor A/B and Aux are excluded
-and remain in their structural positions. Duplicate, missing and unknown IDs
-are errors. Success means the order was saved; a failed write restores the
-previous order. No PipeWire node or link changes during this operation.
+The window's Edit layout button, and the commands below over the API,
+change the layout without stopping audio. Each one is saved before it is
+acknowledged; a failed save restores the previous layout and reports an
+error. Ordinary fader saves keep their debounced, retried behaviour.
 
-Other manual changes, including external PipeWire descriptions, take effect at
-startup. The desktop layout editor is not yet provided.
+- `createChannel {name}` adds an application channel. Only its sink is
+  loaded; it starts muted in every mix.
+- `renameChannel {channel, name}` saves the name and reloads that channel's
+  playback device under it, so desktop applets show the new name at once.
+  PipeWire parks the streams that were playing into it on the default
+  output for the moment the sink is away, and the daemon puts them back.
+- `deleteChannel {channel}` moves the apps routed to it, remembered
+  assignments included, to the first remaining application channel and
+  unloads its sink. The last application channel stays.
+- `createMix {name}` adds a virtual microphone. The channel sinks feed the
+  mix sinks by name pattern, so every channel grows a send into the new mix
+  by itself, muted before the capture device is published.
+- `renameMix {mix, name}` changes the name in OpenXLR only. Reloading the
+  capture device would drop every app recording from it onto another
+  source, so its PipeWire description keeps the old name until the daemon
+  restarts; the state carries `renamedSinceStart` and the window shows a
+  restart hint.
+- `deleteMix {mix}` removes the virtual microphone, its sends, inserts and
+  capture device. Anything recording from it loses the device.
+- `setLayoutOrder {channels, mixes}` reorders the editable ids. Supply every
+  application-channel id and every virtual-microphone id exactly once;
+  hardware inputs, Monitor A/B and Aux keep their positions. No node changes.
+
+Every added channel or mix costs pipewire-pulse a few dozen open files;
+the daemon refuses an addition the server has no room for, and the packages
+raise the server's limit (manual, section 5.8).
+
+Ids are generated from names (lowercase letters, digits and hyphens,
+starting with a letter, unique with a numeric suffix) and never change
+afterwards, so node names, profiles and Stream Deck keys survive a rename.
+
+Other manual changes, including external PipeWire descriptions, take effect
+at startup.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,23 +49,20 @@ the routing model and the daemon's service behaviour both changed in
 0.1.21 and the release after it, and they get to settle in users' hands
 first.
 
-- [ ] Editable application channels and virtual-microphone mixes: add,
+- [x] Editable application channels and virtual-microphone mixes: add,
   rename, delete, reorder, with stable ids separate from display names so
   PipeWire node names, profiles and Stream Deck keys survive a rename.
-  Hardware inputs, Monitor A, Monitor B and Aux stay structural. A pull
-  request (#22) implements an earlier shape of this on a single monitor
-  mix; it is being rebuilt on the two-monitor model in four pieces, each
-  mergeable on its own: the editable channels and mixes, strict
-  persistence for structural changes (a layout command is acknowledged
-  only after its save succeeded, and a failed write is an error), the
-  desktop layout editor, and Stream Deck choices generated from daemon
-  state while the monitor feed keys keep working. Renames must not
-  rebuild the graph and creation must add nodes incrementally, so
-  existing streams are never dropped. Landed so far: the Stream Deck
-  choices (#25), the saved layout format read at graph build (#33,
-  [docs/mixer-layout.md](mixer-layout.md)), live channel creation with
-  strict persistence (#34) and the saved channel and mix order (#35);
-  rename, delete and the desktop editor follow.
+  Hardware inputs, Monitor A, Monitor B and Aux stay structural. Every
+  layout command is acknowledged only after its save succeeded, a failed
+  write is an error, and no untouched node is rebuilt: the channel sinks
+  feed the mix sinks by name pattern, so a new mix grows its sends on its
+  own. Landed in pieces: the Stream Deck choices (#25), the saved layout
+  format (#33, [docs/mixer-layout.md](mixer-layout.md)), live channel
+  creation (#34), the saved order (#35), then rename, delete, mix
+  creation and the desktop editor. One known limit: a renamed virtual
+  microphone keeps its old device name in other apps until the daemon
+  restarts, since reloading the device would drop the apps recording
+  from it.
 - [ ] Per-mix customization: icon, colour and order per mix and channel,
   hide a channel without deleting its routing, a compact layout that
   keeps one selected channel visible. Icons and colours also reach the

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -46,6 +46,11 @@ in
     # records silence.
     services.pipewire.wireplumber.configPackages = [ cfg.package ];
 
+    # The submixer's send faders are PulseAudio-side streams inside
+    # pipewire-pulse, which reaches systemd's default 1024 open files with a
+    # few channels or mixes beyond the default layout and then drops nodes.
+    systemd.user.services.pipewire-pulse.serviceConfig.LimitNOFILE = 65536;
+
     systemd.user.services.openxlr-daemon = {
       description = "OpenXLR audio daemon";
       after = [ "pipewire-pulse.service" "wireplumber.service" ];

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -72,6 +72,8 @@ buildDotnetModule {
     install -Dm644 packaging/50-xlr-dock-capture-hold.conf \
       packaging/51-openxlr-pro-raw-names.conf \
       -t $out/share/wireplumber/wireplumber.conf.d
+    install -Dm644 packaging/pipewire-pulse-openxlr.conf \
+      $out/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf
     install -Dm644 packaging/openxlr.desktop -t $out/share/applications
     for s in 16 32 48 64 128 256; do
       install -Dm644 src/OpenXLR.UI/Assets/icon-$s.png \

--- a/packaging/pipewire-pulse-openxlr.conf
+++ b/packaging/pipewire-pulse-openxlr.conf
@@ -1,0 +1,11 @@
+# Installed by OpenXLR as /usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf
+#
+# OpenXLR's submixer runs one PulseAudio-side stream per channel and mix
+# (those streams are its send faders), plus a meter per node. pipewire-pulse
+# inherits systemd's default soft limit of 1024 open files and reaches it
+# with a few channels or mixes beyond the default layout; past the limit it
+# drops audio nodes at random. Raise the limit for the PulseAudio server.
+# Takes effect after "systemctl --user daemon-reload" and a restart of
+# pipewire-pulse (or the next login).
+[Service]
+LimitNOFILE=65536

--- a/packaging/rpm/openxlr.spec
+++ b/packaging/rpm/openxlr.spec
@@ -91,6 +91,9 @@ sed 's|^ExecStart=.*|ExecStart=%{_bindir}/openxlr-daemon|' \
     packaging/openxlr-daemon.service > openxlr-daemon.service
 install -Dm644 openxlr-daemon.service \
     %{buildroot}%{_userunitdir}/openxlr-daemon.service
+%{_userunitdir}/pipewire-pulse.service.d/openxlr.conf
+install -Dm644 packaging/pipewire-pulse-openxlr.conf \
+    %{buildroot}%{_userunitdir}/pipewire-pulse.service.d/openxlr.conf
 
 install -Dm644 packaging/openxlr.desktop \
     %{buildroot}%{_datadir}/applications/openxlr.desktop

--- a/src/OpenXLR.Core/Mixing/ILayoutInfo.cs
+++ b/src/OpenXLR.Core/Mixing/ILayoutInfo.cs
@@ -8,6 +8,10 @@ public interface ILayoutInfo
 {
     bool HasChannel(string id);
     bool HasMix(string id);
+    /// <summary>An editable application channel (not a hardware input).</summary>
+    bool HasApplicationChannel(string id) => HasChannel(id);
+    /// <summary>An editable virtual microphone (not a monitor or Aux mix).</summary>
+    bool HasVirtualMix(string id) => HasMix(id);
     /// <summary>A valid feed for an output: one monitor mix, or several distinct ones joined with '+' (see <see cref="MonitorFeed"/>).</summary>
     bool IsMonitorFeed(string feed);
     /// <summary>A currently selected monitor output, or the shared key of a device's pseudo-outputs.</summary>

--- a/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
@@ -27,7 +27,7 @@ public sealed partial class Mixer
     {
         if (_pw.PulseFileUsage() is not (int used, int limit)) return null;
         return used * 4 >= limit * 3
-            ? $"pipewire-pulse has {used} of its {limit} open files in use; past the limit it drops audio nodes. Raise the limit with the pipewire-pulse drop-in OpenXLR installs and restart pipewire-pulse (manual, section 5.8)."
+            ? $"pipewire-pulse has {used} of its {limit} open files in use; past the limit it drops audio nodes. Raise the limit with the pipewire-pulse drop-in OpenXLR installs and restart pipewire-pulse."
             : null;
     }
 
@@ -38,7 +38,7 @@ public sealed partial class Mixer
         int needed = newStreams * FilesPerStream + newNodes * FilesPerNode + FileReserve;
         if (used + needed <= limit) return;
         throw new InvalidOperationException(
-            $"pipewire-pulse is near its open-file limit ({used} of {limit} in use, about {needed} more needed); past it the server drops audio nodes. Raise the limit with the pipewire-pulse drop-in OpenXLR installs and restart pipewire-pulse (manual, section 5.8).");
+            $"pipewire-pulse is near its open-file limit ({used} of {limit} in use, about {needed} more needed); past it the server drops audio nodes. Raise the limit with the pipewire-pulse drop-in OpenXLR installs and restart pipewire-pulse.");
     }
 
     /// <summary>

--- a/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
@@ -1,56 +1,89 @@
 namespace OpenXLR.Core.Mixing;
 
+/// <summary>
+/// Editing the layout while the graph runs. Every operation follows the same
+/// contract: the new layout is saved before the command succeeds, a failed
+/// save restores the previous layout and reports an error, and nothing that
+/// carries audio for an untouched channel or mix is rebuilt. Channel combines
+/// feed the mix sinks by name pattern, so a new mix grows one leg in every
+/// combine on its own and a removed mix loses them; the channel nodes are
+/// never reloaded for a mix change.
+/// </summary>
 public sealed partial class Mixer
 {
+    /// <summary>How long a freshly loaded node gets to grow its combine legs.</summary>
+    private static readonly TimeSpan LegTimeout = TimeSpan.FromSeconds(3);
+
+    // What one more node costs pipewire-pulse in open files, measured on
+    // PipeWire 1.6: a mix with nine channels took 118, an application channel
+    // with five mixes 74. The estimate runs a quarter above that, plus a
+    // reserve for the pactl client connections the change itself makes.
+    private const int FilesPerStream = 10;
+    private const int FilesPerNode = 10;
+    private const int FileReserve = 16;
+
+    /// <summary>The state warning when pipewire-pulse runs close to its limit, or null.</summary>
+    public string? PulseFileWarning()
+    {
+        if (_pw.PulseFileUsage() is not (int used, int limit)) return null;
+        return used * 4 >= limit * 3
+            ? $"pipewire-pulse has {used} of its {limit} open files in use; past the limit it drops audio nodes. Raise the limit with the pipewire-pulse drop-in OpenXLR installs and restart pipewire-pulse (manual, section 5.8)."
+            : null;
+    }
+
+    /// <summary>Refuse a change that would push pipewire-pulse over its open-file limit.</summary>
+    private void EnsurePulseHeadroomLocked(int newStreams, int newNodes)
+    {
+        if (_pw.PulseFileUsage() is not (int used, int limit)) return;
+        int needed = newStreams * FilesPerStream + newNodes * FilesPerNode + FileReserve;
+        if (used + needed <= limit) return;
+        throw new InvalidOperationException(
+            $"pipewire-pulse is near its open-file limit ({used} of {limit} in use, about {needed} more needed); past it the server drops audio nodes. Raise the limit with the pipewire-pulse drop-in OpenXLR installs and restart pipewire-pulse (manual, section 5.8).");
+    }
+
     /// <summary>
-    /// Add only the new application sink. Readers cannot observe its layout
-    /// until persistence succeeds. A failed save removes only the new module.
-    /// The caller serializes its save callback with other settings writers.
+    /// Add one application channel: only its combine sink is loaded. It starts
+    /// muted in every mix, so a new channel is silent until the user opens a
+    /// send. Readers cannot observe the channel until the save succeeded.
     /// </summary>
     public void CreateApplicationChannel(string name, Func<MixerSettings, string?> persist)
     {
         ArgumentNullException.ThrowIfNull(persist);
-        name = name.Trim();
-        if (name.Length is 0 or > 60 || name.Any(char.IsControl))
-            throw new InvalidOperationException("channel name must contain 1 to 60 printable characters");
+        name = CleanName(name);
         lock (_gate)
         {
             if (!_built) throw new InvalidOperationException("mixer is not built");
             if (_config.Channels.Count(c => c.InputPair is null) >= MixerConfig.MaxApplicationChannels)
                 throw new InvalidOperationException("application channel limit reached");
+            EnsurePulseHeadroomLocked(newStreams: _config.Mixes.Count, newNodes: 2);
             string id = NewChannelId(name, _config.Channels.Select(c => c.Id));
             var channel = new ChannelDefinition(id, name)
-            { Levels = _config.Mixes.ToDictionary(m => m.Id, _ => 1.0) };
+            {
+                Levels = _config.Mixes.ToDictionary(m => m.Id, _ => 1.0),
+                MutedIn = _config.Mixes.Select(m => m.Id).ToHashSet(),
+            };
             MixerConfig previous = _config;
-            uint module = _pw.CreateCombineSink(channel.SinkName,
-                _config.Mixes.Select(m => m.SinkName), $"OpenXLR {name}");
+            uint module = _pw.CreateCombineSink(channel.SinkName, MixSinkPattern, $"OpenXLR {name}");
             try
             {
                 _config = _config with { Channels = [.. _config.Channels, channel] };
                 _combineModules[id] = module;
-                var legs = _pw.FindCombineLegs(module);
-                foreach (var mix in _config.Mixes)
+                foreach (MixDefinition mix in _config.Mixes)
                 {
                     string cell = Cell(id, mix.Id);
                     _cells.Add(cell);
                     _levels[cell] = 1.0;
-                    if (legs.TryGetValue(mix.SinkName, out int index)) _legIndex[cell] = index;
-                    ApplyCellLocked(id, mix.Id);
+                    _muted.Add(cell);
                 }
-                if (persist(ExportSettings()) is string error) throw new IOException(error);
+                WaitForLegsLocked([module], _config.Mixes.Select(m => m.SinkName));
+                foreach (MixDefinition mix in _config.Mixes) ApplyCellLocked(id, mix.Id);
+                PersistLocked(persist);
             }
             catch (Exception editError)
             {
                 _config = previous;
                 _combineModules.Remove(id);
-                foreach (var mix in previous.Mixes)
-                {
-                    string cell = Cell(id, mix.Id);
-                    _cells.Remove(cell);
-                    _levels.Remove(cell);
-                    _muted.Remove(cell);
-                    _legIndex.Remove(cell);
-                }
+                RemoveChannelCellsLocked(id, previous.Mixes);
                 try { _pw.UnloadModule(module); }
                 catch (Exception cleanupError)
                 { throw new AggregateException("channel creation failed and its module could not be removed", editError, cleanupError); }
@@ -60,16 +93,385 @@ public sealed partial class Mixer
         }
     }
 
-    internal static string NewChannelId(string name, IEnumerable<string> existing)
+    /// <summary>
+    /// Rename an application channel. The name is saved first; then the
+    /// channel's sink is reloaded under the new description so desktop
+    /// applets show it right away. Streams playing into the channel are put
+    /// back on it afterwards (PipeWire parks them on the default output while
+    /// the sink is away), so apps on that channel hear a short gap and every
+    /// other channel is untouched.
+    /// </summary>
+    public void RenameApplicationChannel(string id, string name, Func<MixerSettings, string?> persist)
     {
-        string slug = new(name.ToLowerInvariant().Select(c => char.IsAsciiLetterOrDigit(c) ? c : '-').ToArray());
-        slug = string.Join('-', slug.Split('-', StringSplitOptions.RemoveEmptyEntries));
-        if (slug.Length == 0) slug = "channel";
-        if (!char.IsAsciiLetter(slug[0])) slug = "channel-" + slug;
-        if (slug.Length > 28) slug = slug[..28].TrimEnd('-');
-        var used = new HashSet<string>(existing.Append(StreamMatcher.Ignore), StringComparer.OrdinalIgnoreCase);
-        string id = slug;
-        for (int n = 2; used.Contains(id); n++) id = $"{slug}-{n}";
-        return id;
+        ArgumentNullException.ThrowIfNull(persist);
+        name = CleanName(name);
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            ChannelDefinition channel = _config.Channels.FirstOrDefault(c => c.Id == id && c.InputPair is null)
+                ?? throw new InvalidOperationException($"'{id}' is not an application channel");
+            if (channel.Name == name) return;
+            EnsurePulseHeadroomLocked(newStreams: 0, newNodes: 1);   // the reload frees the old sink first
+            MixerConfig previous = _config;
+            _config = _config.WithChannelName(id, name);
+            try { PersistLocked(persist); }
+            catch { _config = previous; throw; }
+
+            ReloadChannelSinkLocked(channel with { Name = name }, channel.Name);
+        }
+    }
+
+    /// <summary>
+    /// Remove an application channel. Apps routed to it move to the first
+    /// remaining application channel, remembered assignments included; the
+    /// removal is saved, then the channel's sink is unloaded. The last
+    /// application channel cannot go: new streams need a destination.
+    /// </summary>
+    public void DeleteApplicationChannel(string id, Func<MixerSettings, string?> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            MixerConfig previous = _config;
+            MixerConfig next = _config.WithoutChannel(id);
+            ChannelDefinition fallback = next.Channels.First(c => c.InputPair is null);
+
+            var movedOverrides = Matcher.Overrides.Where(kv => kv.Value == id).Select(kv => kv.Key).ToList();
+            var movedApps = _apps.Where(kv => kv.Value.ChannelId == id).ToDictionary(kv => kv.Key, kv => kv.Value);
+            CellSnapshot cells = TakeChannelCellsLocked(id, previous.Mixes);
+            _config = next;
+            foreach (string identity in movedOverrides) Matcher.SetOverride(identity, fallback.Id);
+            foreach ((string identity, StreamAssignment app) in movedApps) _apps[identity] = app with { ChannelId = fallback.Id };
+            try { PersistLocked(persist); }
+            catch
+            {
+                _config = previous;
+                cells.Restore(this);
+                foreach (string identity in movedOverrides) Matcher.SetOverride(identity, id);
+                foreach ((string identity, StreamAssignment app) in movedApps) _apps[identity] = app;
+                throw;
+            }
+
+            // Whatever plays into the sink right now moves to the fallback:
+            // the registry's view and PipeWire's own (the session manager
+            // may have moved a stream since the last sweep).
+            ChannelDefinition gone = previous.Channels.First(c => c.Id == id);
+            var serials = new HashSet<int>(_pw.StreamSerialsOnSink(gone.SinkName));
+            foreach ((int streamId, StreamAssignment placed) in _streams.Where(kv => kv.Value.ChannelId == id).ToList())
+            {
+                serials.Add(placed.Serial);
+                _streams.Remove(streamId);   // the next sweep confirms the destination
+            }
+            foreach (int serial in serials)
+            {
+                try { _pw.MoveStreamToSink(serial, fallback.SinkName); }
+                catch (InvalidOperationException) { /* the stream ended meanwhile */ }
+            }
+            _meters.Remove($"ch:{id}");
+            _inserts.Remove(id);
+            _insertErrors.Remove(id);
+            if (_combineModules.Remove(id, out uint module))
+            {
+                try { _pw.UnloadModule(module); }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        $"the channel was removed, but its PipeWire sink could not be unloaded ({ex.Message}); it disappears when the daemon restarts");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Add a virtual microphone. Its mix sink is loaded first and every channel
+    /// combine grows a leg into it by itself; those legs are muted before the
+    /// capture device is published, so nothing reaches the new microphone until
+    /// the user opens a send. The layout is saved before the command succeeds.
+    /// </summary>
+    public void CreateVirtualMix(string name, Func<MixerSettings, string?> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        name = CleanName(name);
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            EnsurePulseHeadroomLocked(newStreams: _config.Channels.Count, newNodes: 4);
+            string id = MixerConfig.NewId(name, "mix", _config.Mixes.Select(m => m.Id));
+            var mix = new MixDefinition(id, name, MixKind.VirtualMic);
+            MixerConfig previous = _config;
+            MixerConfig next = _config.WithMix(mix);   // validates the limit before any node is loaded
+            string key = MixKey(mix);
+            try
+            {
+                _mixModules[id] = _pw.CreateNullSink(mix.SinkName, $"OpenXLR {name}");
+                _config = next;   // leg discovery and the cell faders go by the mix list
+                _mixVolume[id] = 1.0;
+                foreach (ChannelDefinition ch in _config.Channels)
+                {
+                    string cell = Cell(ch.Id, id);
+                    _cells.Add(cell);
+                    _levels[cell] = 1.0;
+                    _muted.Add(cell);
+                }
+                WaitForLegsLocked([.. _combineModules.Values], [mix.SinkName]);
+                foreach (ChannelDefinition ch in _config.Channels) ApplyCellLocked(ch.Id, id);
+                _postModules[id] = _pw.CreateNullSink(mix.PostSinkName, $"OpenXLR {name} (post)");
+                _virtualMicModules[id] = _pw.CreateVirtualMic(mix.VirtualMicName, $"{mix.PostSinkName}.monitor", $"OpenXLR {name}");
+                WireMixChainLocked(mix);
+                PersistLocked(persist);
+            }
+            catch (Exception editError)
+            {
+                _config = previous;
+                RemoveMixChainLocked(key);
+                RemoveMixCellsLocked(id);
+                var cleanupErrors = new List<Exception>();
+                foreach (var modules in new[] { _virtualMicModules, _postModules, _mixModules })
+                    if (modules.Remove(id, out uint module))
+                    {
+                        try { _pw.UnloadModule(module); }
+                        catch (Exception ex) { cleanupErrors.Add(ex); }
+                    }
+                if (cleanupErrors.Count > 0)
+                    throw new AggregateException("mix creation failed and its nodes could not all be removed", [editError, .. cleanupErrors]);
+                throw;
+            }
+            _meters.Add($"mix:{id}", mix.SinkName);
+        }
+    }
+
+    /// <summary>
+    /// Rename a virtual microphone. Only the layout changes: reloading the
+    /// capture device would throw every app recording from it onto another
+    /// source (verified: a recorder does not come back to a reloaded device
+    /// of the same name), so the PipeWire description keeps the old name
+    /// until the daemon restarts and the state says so.
+    /// </summary>
+    public void RenameVirtualMix(string id, string name, Func<MixerSettings, string?> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        name = CleanName(name);
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            MixDefinition mix = _config.Mixes.FirstOrDefault(m => m.Id == id && m.Kind == MixKind.VirtualMic)
+                ?? throw new InvalidOperationException($"'{id}' is not a virtual microphone");
+            if (mix.Name == name) return;
+            MixerConfig previous = _config;
+            _config = _config.WithMixName(id, name);
+            try { PersistLocked(persist); }
+            catch { _config = previous; throw; }
+            _renamedSinceBuild = true;
+        }
+    }
+
+    /// <summary>
+    /// Remove a virtual microphone: its insert chain, capture device, post
+    /// sink and mix sink go, and the channel combines drop their legs into it
+    /// on their own. Saved before the command succeeds.
+    /// </summary>
+    public void DeleteVirtualMix(string id, Func<MixerSettings, string?> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            MixDefinition mix = _config.Mixes.FirstOrDefault(m => m.Id == id && m.Kind == MixKind.VirtualMic)
+                ?? throw new InvalidOperationException($"'{id}' is not a virtual microphone");
+            string key = MixKey(mix);
+            MixerConfig previous = _config;
+            _config = _config.WithoutMix(id);
+            _inserts.Remove(key, out List<InsertDefinition>? savedInserts);
+            string? previousSource = _enforcedSource;
+            if (_enforcedSource == mix.VirtualMicName) _enforcedSource = null;
+            CellSnapshot cells = TakeMixCellsLocked(id);
+            try { PersistLocked(persist); }
+            catch
+            {
+                _config = previous;
+                cells.Restore(this);
+                if (savedInserts is not null) _inserts[key] = savedInserts;
+                _enforcedSource = previousSource;
+                throw;
+            }
+
+            RemoveMixChainLocked(key);
+            _meters.Remove($"mix:{id}");
+            var errors = new List<string>();
+            foreach (var modules in new[] { _virtualMicModules, _postModules, _mixModules })
+                if (modules.Remove(id, out uint module))
+                {
+                    try { _pw.UnloadModule(module); }
+                    catch (Exception ex) { errors.Add(ex.Message); }
+                }
+            if (errors.Count > 0)
+                throw new InvalidOperationException(
+                    $"the mix was removed, but a PipeWire node could not be unloaded ({string.Join("; ", errors)}); it disappears when the daemon restarts");
+        }
+    }
+
+    /// <summary>Save an order change without touching any PipeWire node or link.</summary>
+    public void SetLayoutOrder(IReadOnlyList<string> channels, IReadOnlyList<string> mixes,
+        Func<MixerSettings, string?> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        lock (_gate)
+        {
+            if (!_built) throw new InvalidOperationException("mixer is not built");
+            MixerConfig previous = _config;
+            _config = _config.WithOrder(channels, mixes);
+            try { PersistLocked(persist); }
+            catch { _config = previous; throw; }
+        }
+    }
+
+    internal static string NewChannelId(string name, IEnumerable<string> existing)
+        => MixerConfig.NewId(name, "channel", existing.Append(StreamMatcher.Ignore));
+
+    private static string CleanName(string name)
+    {
+        name = name?.Trim() ?? "";
+        if (name.Length is 0 or > 60 || name.Any(char.IsControl))
+            throw new InvalidOperationException("name must contain 1 to 60 printable characters");
+        return name;
+    }
+
+    private void PersistLocked(Func<MixerSettings, string?> persist)
+    {
+        if (persist(ExportSettings()) is string error) throw new IOException(error);
+    }
+
+    /// <summary>
+    /// Reload one channel's combine sink under its current name and put the
+    /// streams that played into it back. If the reload fails the sink comes
+    /// back under its old description, so audio keeps flowing either way.
+    /// </summary>
+    private void ReloadChannelSinkLocked(ChannelDefinition channel, string previousName)
+    {
+        string id = channel.Id;
+        var onIt = new HashSet<int>(_pw.StreamSerialsOnSink(channel.SinkName));
+        foreach ((int streamId, StreamAssignment placed) in _streams.Where(kv => kv.Value.ChannelId == id).ToList())
+        {
+            onIt.Add(placed.Serial);
+            _streams.Remove(streamId);   // the next sweep confirms the destination
+        }
+        string oldDescription = $"OpenXLR {previousName}";
+        _meters.Remove($"ch:{id}");
+        if (_combineModules.Remove(id, out uint old)) _pw.UnloadModule(old);
+        uint fresh;
+        try { fresh = _pw.CreateCombineSink(channel.SinkName, MixSinkPattern, $"OpenXLR {channel.Name}"); }
+        catch (Exception renameError)
+        {
+            try { fresh = _pw.CreateCombineSink(channel.SinkName, MixSinkPattern, oldDescription); }
+            catch (Exception restoreError)
+            { throw new AggregateException("the channel's sink could not be reloaded or restored", renameError, restoreError); }
+            FinishReloadLocked(channel, fresh, onIt);
+            throw new InvalidOperationException(
+                $"the name was saved, but the PipeWire sink could not be reloaded ({renameError.Message}); other apps see the new name after a daemon restart");
+        }
+        FinishReloadLocked(channel, fresh, onIt);
+    }
+
+    private void FinishReloadLocked(ChannelDefinition channel, uint module, IEnumerable<int> streamSerials)
+    {
+        _combineModules[channel.Id] = module;
+        WaitForLegsLocked([module], _config.Mixes.Select(m => m.SinkName));
+        foreach (MixDefinition mix in _config.Mixes) ApplyCellLocked(channel.Id, mix.Id);
+        foreach (int serial in streamSerials)
+        {
+            try { _pw.MoveStreamToSink(serial, channel.SinkName); }
+            catch (InvalidOperationException) { /* the stream ended meanwhile */ }
+        }
+        _meters.Add($"ch:{channel.Id}", channel.SinkName);
+    }
+
+    /// <summary>
+    /// A combine loaded with a name pattern grows its legs as the registry
+    /// scan reports the matching sinks, a moment after the load returns. Wait
+    /// for the named ones, then refresh the leg table.
+    /// </summary>
+    private void WaitForLegsLocked(IReadOnlyList<uint> modules, IEnumerable<string> sinkNames)
+    {
+        var wanted = sinkNames.ToHashSet(StringComparer.Ordinal);
+        var pending = modules.ToHashSet();
+        var deadline = DateTime.UtcNow + LegTimeout;
+        while (pending.Count > 0 && DateTime.UtcNow < deadline)
+        {
+            foreach (uint module in pending.ToList())
+                if (_pw.TryFindCombineLegs(module) is { } legs && wanted.All(legs.ContainsKey)) pending.Remove(module);
+            if (pending.Count > 0) Thread.Sleep(100);
+        }
+        DiscoverLegsLocked();
+    }
+
+    /// <summary>The fader state of removed cells, so a failed save can put them back.</summary>
+    private sealed record CellSnapshot(Dictionary<string, double> Levels, HashSet<string> Muted, Dictionary<string, int> Legs,
+        double? MixVolume, bool MixMuted, string? MixId)
+    {
+        public void Restore(Mixer m)
+        {
+            foreach ((string cell, double level) in Levels) { m._cells.Add(cell); m._levels[cell] = level; }
+            foreach (string cell in Muted) m._muted.Add(cell);
+            foreach ((string cell, int index) in Legs) m._legIndex[cell] = index;
+            if (MixId is not null && MixVolume is double volume) m._mixVolume[MixId] = volume;
+            if (MixId is not null && MixMuted) m._mixMuted.Add(MixId);
+        }
+    }
+
+    private CellSnapshot TakeChannelCellsLocked(string channelId, IEnumerable<MixDefinition> mixes)
+        => TakeCellsLocked(mixes.Select(mix => Cell(channelId, mix.Id)).ToList(), null);
+
+    private CellSnapshot TakeMixCellsLocked(string mixId)
+        => TakeCellsLocked(_cells.Where(c => c.EndsWith("|" + mixId, StringComparison.Ordinal)).ToList(), mixId);
+
+    private CellSnapshot TakeCellsLocked(List<string> cells, string? mixId)
+    {
+        var snapshot = new CellSnapshot([], [], [],
+            mixId is not null && _mixVolume.TryGetValue(mixId, out double volume) ? volume : null,
+            mixId is not null && _mixMuted.Contains(mixId), mixId);
+        foreach (string cell in cells)
+        {
+            if (_cells.Remove(cell)) snapshot.Levels[cell] = _levels.GetValueOrDefault(cell, 0.0);
+            _levels.Remove(cell);
+            if (_muted.Remove(cell)) snapshot.Muted.Add(cell);
+            if (_legIndex.Remove(cell, out int index)) snapshot.Legs[cell] = index;
+        }
+        if (mixId is not null) { _mixVolume.Remove(mixId); _mixMuted.Remove(mixId); }
+        return snapshot;
+    }
+
+    private void RemoveChannelCellsLocked(string channelId, IEnumerable<MixDefinition> mixes)
+    {
+        foreach (MixDefinition mix in mixes)
+        {
+            string cell = Cell(channelId, mix.Id);
+            _cells.Remove(cell);
+            _levels.Remove(cell);
+            _muted.Remove(cell);
+            _legIndex.Remove(cell);
+        }
+    }
+
+    private void RemoveMixCellsLocked(string mixId)
+    {
+        foreach (string cell in _cells.Where(c => c.EndsWith("|" + mixId, StringComparison.Ordinal)).ToList())
+        {
+            _cells.Remove(cell);
+            _levels.Remove(cell);
+            _muted.Remove(cell);
+            _legIndex.Remove(cell);
+        }
+        _mixVolume.Remove(mixId);
+        _mixMuted.Remove(mixId);
+    }
+
+    /// <summary>Take down one mix's insert chain and the links that read the mix.</summary>
+    private void RemoveMixChainLocked(string key)
+    {
+        if (_mixTaps.Remove(key, out PortLink? tap)) _pw.Unlink(tap);
+        if (_mixPostLinks.Remove(key, out PortLink? post)) _pw.Unlink(post);
+        if (_chains.Remove(key, out FilterHandle? chain)) _pw.StopFilter(chain);
+        _insertErrors.Remove(key);
     }
 }

--- a/src/OpenXLR.Core/Mixing/MeterReader.cs
+++ b/src/OpenXLR.Core/Mixing/MeterReader.cs
@@ -66,6 +66,18 @@ public sealed class MeterReader : IDisposable
         }
     }
 
+    /// <summary>Stop metering one sink; its process goes with it.</summary>
+    public void Remove(string id)
+    {
+        lock (_gate)
+        {
+            if (!_meters.Remove(id, out Meter? meter)) return;
+            try { if (!meter.Process.HasExited) meter.Process.Kill(entireProcessTree: true); }
+            catch (Exception) { /* already gone */ }
+            meter.Process.Dispose();
+        }
+    }
+
     /// <summary>
     /// Sum the squares of every complete stereo float frame in
     /// <paramref name="buf"/>[0..<paramref name="length"/>), move any trailing

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -72,29 +72,22 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
 
     public MixerConfig Config => _config;
 
-    /// <summary>Save an order change without touching any PipeWire node or link.</summary>
-    public void SetLayoutOrder(IReadOnlyList<string> channels, IReadOnlyList<string> mixes,
-        Func<MixerSettings, string?> persist)
-    {
-        ArgumentNullException.ThrowIfNull(persist);
-        lock (_gate)
-        {
-            if (!_built) throw new InvalidOperationException("mixer is not built");
-            MixerConfig previous = _config;
-            _config = _config.WithOrder(channels, mixes);
-            try
-            {
-                if (persist(ExportSettings()) is string error) throw new IOException(error);
-            }
-            catch { _config = previous; throw; }
-        }
-    }
     public bool Built => _built;
 
     private static string Cell(string channel, string mix) => $"{channel}|{mix}";
 
     // channel id -> its combine module; "channel|mix" -> that leg's sink-input index
     private readonly Dictionary<string, uint> _combineModules = [];
+    // mix id -> its sink module, and for virtual microphones the post sink
+    // and the published capture device, so one mix can be removed alone.
+    private readonly Dictionary<string, uint> _mixModules = [];
+    private readonly Dictionary<string, uint> _postModules = [];
+    private readonly Dictionary<string, uint> _virtualMicModules = [];
+    // A virtual microphone renamed while running keeps its old PipeWire
+    // description until the next build; clients show a restart hint.
+    private bool _renamedSinceBuild;
+    /// <summary>Every channel combine feeds every mix sink, present or future.</summary>
+    private const string MixSinkPattern = "~" + MixDefinition.SinkPrefix;
     private readonly Dictionary<string, int> _legIndex = [];
 
     /// <summary>Map every combine's internal streams to their (channel, mix) cells.</summary>
@@ -136,7 +129,7 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
             // Mixes first: the cells attach to them as masters.
             foreach (MixDefinition mix in config.Mixes)
             {
-                _pw.CreateNullSink(mix.SinkName, $"OpenXLR {mix.Name}");
+                _mixModules[mix.Id] = _pw.CreateNullSink(mix.SinkName, $"OpenXLR {mix.Name}");
                 _mixVolume[mix.Id] = mix.Volume;
                 if (mix.Muted) _mixMuted.Add(mix.Id);
             }
@@ -152,8 +145,7 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
                     if (ch.MutedIn.Contains(mix.Id)) _muted.Add(cell);
                     _cells.Add(cell);
                 }
-                _combineModules[ch.Id] = _pw.CreateCombineSink(ch.SinkName,
-                    config.Mixes.Select(m => m.SinkName),
+                _combineModules[ch.Id] = _pw.CreateCombineSink(ch.SinkName, MixSinkPattern,
                     $"OpenXLR {ch.Name}",
                     visible: ch.InputPair is null);   // hardware inputs are not playback devices
             }
@@ -168,8 +160,8 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
             // the capture device an app is recording from.
             foreach (MixDefinition mix in config.Mixes.Where(m => m.Kind == MixKind.VirtualMic))
             {
-                _pw.CreateNullSink(mix.PostSinkName, $"OpenXLR {mix.Name} (post)");
-                _pw.CreateVirtualMic(mix.VirtualMicName, $"{mix.PostSinkName}.monitor", $"OpenXLR {mix.Name}");
+                _postModules[mix.Id] = _pw.CreateNullSink(mix.PostSinkName, $"OpenXLR {mix.Name} (post)");
+                _virtualMicModules[mix.Id] = _pw.CreateVirtualMic(mix.VirtualMicName, $"{mix.PostSinkName}.monitor", $"OpenXLR {mix.Name}");
             }
 
             // Meter every channel and mix so the UI can show what is flowing.
@@ -520,6 +512,8 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
     // ILayoutInfo, for command validation ahead of the mixer methods.
     public bool HasChannel(string id) { lock (_gate) return _config.Channels.Any(c => c.Id == id); }
     public bool HasMix(string id) { lock (_gate) return _config.Mixes.Any(m => m.Id == id); }
+    public bool HasApplicationChannel(string id) { lock (_gate) return _config.Channels.Any(c => c.Id == id && c.InputPair is null); }
+    public bool HasVirtualMix(string id) { lock (_gate) return _config.Mixes.Any(m => m.Id == id && m.Kind == MixKind.VirtualMic); }
     public bool IsMonitorFeed(string feed) { lock (_gate) return NormalizeFeedLocked(feed) is not null; }
 
     /// <summary>
@@ -1617,7 +1611,9 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
                 Channels = [.. _config.Channels.Select(c => new ChannelStatus(
                     c.Id, c.Name,
                     _config.Mixes.ToDictionary(m => m.Id, m => _levels.GetValueOrDefault(Cell(c.Id, m.Id), 0.0)),
-                    [.. _config.Mixes.Where(m => _muted.Contains(Cell(c.Id, m.Id))).Select(m => m.Id)]))],
+                    [.. _config.Mixes.Where(m => _muted.Contains(Cell(c.Id, m.Id))).Select(m => m.Id)],
+                    c.InputPair is not null))],
+                RenamedSinceStart = _renamedSinceBuild,
                 MonitorOutput = _monitorOutputs.FirstOrDefault(),
                 MonitorOutputs = [.. _monitorOutputs],
                 MonitorFeeds = new Dictionary<string, string>(_monitorFeeds),
@@ -1692,6 +1688,10 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         _inputDevice = null;
         _pw.TearDown();     // unloads modules in reverse order: combines, then mixes
         _combineModules.Clear();
+        _mixModules.Clear();
+        _postModules.Clear();
+        _virtualMicModules.Clear();
+        _renamedSinceBuild = false;
         _legIndex.Clear();
         _streams.Clear();
         _cells.Clear();

--- a/src/OpenXLR.Core/Mixing/MixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/MixerLayout.cs
@@ -29,6 +29,89 @@ public sealed partial record MixerConfig
         }
     }
 
+    /// <summary>The application channel with one display name changed; everything else identical.</summary>
+    public MixerConfig WithChannelName(string id, string name)
+    {
+        ChannelDefinition channel = Channels.FirstOrDefault(c => c.Id == id && c.InputPair is null)
+            ?? throw new InvalidOperationException($"'{id}' is not an application channel");
+        return this with { Channels = [.. Channels.Select(c => ReferenceEquals(c, channel) ? c with { Name = name } : c)] };
+    }
+
+    /// <summary>The virtual microphone with one display name changed; everything else identical.</summary>
+    public MixerConfig WithMixName(string id, string name)
+    {
+        MixDefinition mix = Mixes.FirstOrDefault(m => m.Id == id && m.Kind == MixKind.VirtualMic)
+            ?? throw new InvalidOperationException($"'{id}' is not a virtual microphone");
+        return this with { Mixes = [.. Mixes.Select(m => ReferenceEquals(m, mix) ? m with { Name = name } : m)] };
+    }
+
+    /// <summary>Without one application channel. The last application channel stays: streams need a destination.</summary>
+    public MixerConfig WithoutChannel(string id)
+    {
+        if (!Channels.Any(c => c.Id == id && c.InputPair is null))
+            throw new InvalidOperationException($"'{id}' is not an application channel");
+        if (Channels.Count(c => c.InputPair is null) == 1)
+            throw new InvalidOperationException("the last application channel cannot be deleted");
+        return this with { Channels = [.. Channels.Where(c => c.Id != id)] };
+    }
+
+    /// <summary>Without one virtual microphone; the per-channel sends into it go with it.</summary>
+    public MixerConfig WithoutMix(string id)
+    {
+        if (!Mixes.Any(m => m.Id == id && m.Kind == MixKind.VirtualMic))
+            throw new InvalidOperationException($"'{id}' is not a virtual microphone");
+        return this with
+        {
+            Mixes = [.. Mixes.Where(m => m.Id != id)],
+            Channels = [.. Channels.Select(c => c with
+            {
+                Levels = c.Levels.Where(l => l.Key != id).ToDictionary(),
+                MutedIn = c.MutedIn.Where(m => m != id).ToHashSet(),
+            })],
+        };
+    }
+
+    /// <summary>
+    /// With a new virtual microphone after the existing ones, ahead of Aux.
+    /// Every channel gets a muted full-level send into it, so nothing reaches
+    /// the new microphone until the user opens a send.
+    /// </summary>
+    public MixerConfig WithMix(MixDefinition mix)
+    {
+        if (mix.Kind != MixKind.VirtualMic) throw new InvalidOperationException("only virtual microphones can be added");
+        if (Mixes.Count(m => m.Kind == MixKind.VirtualMic) >= MaxVirtualMixes)
+            throw new InvalidOperationException("virtual microphone limit reached");
+        if (Mixes.Any(m => m.Id.Equals(mix.Id, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"mix '{mix.Id}' already exists");
+        return this with
+        {
+            Mixes = [.. Mixes.Where(m => m.Kind != MixKind.AuxPort), mix, .. Mixes.Where(m => m.Kind == MixKind.AuxPort)],
+            Channels = [.. Channels.Select(c => c with
+            {
+                Levels = c.Levels.Append(new(mix.Id, 1.0)).ToDictionary(),
+                MutedIn = c.MutedIn.Append(mix.Id).ToHashSet(),
+            })],
+        };
+    }
+
+    /// <summary>
+    /// A stable id from a display name: lowercase ASCII letters and digits with
+    /// hyphens, starting with a letter, at most 28 characters, unique among
+    /// <paramref name="existing"/> (case-insensitive) with a numeric suffix.
+    /// </summary>
+    public static string NewId(string name, string fallback, IEnumerable<string> existing)
+    {
+        string slug = new(name.ToLowerInvariant().Select(c => char.IsAsciiLetterOrDigit(c) ? c : '-').ToArray());
+        slug = string.Join('-', slug.Split('-', StringSplitOptions.RemoveEmptyEntries));
+        if (slug.Length == 0) slug = fallback;
+        if (!char.IsAsciiLetter(slug[0])) slug = $"{fallback}-{slug}";
+        if (slug.Length > 28) slug = slug[..28].TrimEnd('-');
+        var used = new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase);
+        string id = slug;
+        for (int n = 2; used.Contains(id); n++) id = $"{slug}-{n}";
+        return id;
+    }
+
     /// <summary>Keep obsolete app rules out of hardware inputs after a layout change.</summary>
     public string ResolveApplicationChannel(string requested)
         => requested == StreamMatcher.Ignore ? requested

--- a/src/OpenXLR.Core/Mixing/MixerModel.cs
+++ b/src/OpenXLR.Core/Mixing/MixerModel.cs
@@ -80,8 +80,10 @@ public sealed record MixDefinition(string Id, string Name, MixKind Kind)
     public double Volume { get; init; } = 1.0;
     public bool Muted { get; init; }
 
+    /// <summary>Every mix sink shares this prefix; the channel combines follow it as a pattern.</summary>
+    public const string SinkPrefix = "OpenXLR_mix_";
     /// <summary>PipeWire node name of this mix's sink.</summary>
-    public string SinkName => $"OpenXLR_mix_{Id}";
+    public string SinkName => $"{SinkPrefix}{Id}";
     /// <summary>PipeWire node name of the published virtual capture device.</summary>
     public string VirtualMicName => $"OpenXLR_{Id}";
     /// <summary>
@@ -157,6 +159,13 @@ public sealed record MixerState
 
     /// <summary>Application streams currently placed in channels.</summary>
     public IReadOnlyList<StreamAssignment> Streams { get; init; } = [];
+
+    /// <summary>
+    /// True after a virtual microphone was renamed while running: its PipeWire
+    /// device keeps the old description until the daemon restarts, so other
+    /// applications still list the old name.
+    /// </summary>
+    public bool RenamedSinceStart { get; init; }
 }
 
 /// <param name="Kind">"monitor", "virtualMic" or "auxPort", so clients can tell monitor mixes apart.</param>
@@ -164,7 +173,8 @@ public sealed record MixStatus(string Id, string Name, double Volume, bool Muted
 
 public sealed record ChannelStatus(string Id, string Name,
     IReadOnlyDictionary<string, double> Levels,
-    IReadOnlyList<string> MutedIn);
+    IReadOnlyList<string> MutedIn,
+    bool Hardware = false);
 
 
 /// <summary>

--- a/src/OpenXLR.Core/Mixing/MixerModel.cs
+++ b/src/OpenXLR.Core/Mixing/MixerModel.cs
@@ -166,6 +166,12 @@ public sealed record MixerState
     /// applications still list the old name.
     /// </summary>
     public bool RenamedSinceStart { get; init; }
+
+    /// <summary>
+    /// pipewire-pulse close to its open-file limit (see the manual, 5.8), or
+    /// null. Shown in the layout editor, where the next addition would hit it.
+    /// </summary>
+    public string? LayoutWarning { get; init; }
 }
 
 /// <param name="Kind">"monitor", "virtualMic" or "auxPort", so clients can tell monitor mixes apart.</param>

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -181,12 +181,19 @@ public sealed class PipeWireAdapter
     /// hardware input channels are not, since nothing should play into a
     /// channel that carries a microphone.
     /// </param>
-    public uint CreateCombineSink(string nodeName, IEnumerable<string> slaveSinks, string description, bool visible = true)
+    /// <param name="slaves">
+    /// The mix sinks to feed: explicit node names separated by commas, or a
+    /// "~pattern" regular expression. PipeWire's combine sink keeps watching
+    /// the registry, so with a pattern a mix sink created later gets its own
+    /// stream (leg) without reloading the combine, and a removed mix drops
+    /// its leg. Verified on PipeWire 1.6 through pactl.
+    /// </param>
+    public uint CreateCombineSink(string nodeName, string slaves, string description, bool visible = true)
     {
         string outp = Run("pactl",
             "load-module", "module-combine-sink",
             $"sink_name={nodeName}",
-            $"slaves={string.Join(',', slaveSinks)}",
+            $"slaves={slaves}",
             // suspend-on-idle=false keeps the combine's monitor source running;
             // a suspended monitor makes the channel's level meter read silence
             // even while audio flows through the sink.
@@ -257,6 +264,64 @@ public sealed class PipeWireAdapter
                 legs[name] = index;
         }
         return legs;
+    }
+
+    /// <summary>
+    /// pipewire-pulse's open files against its soft limit, or null when the
+    /// process or its /proc entries cannot be read. Every combine leg, meter
+    /// and module costs the PulseAudio server a handful of descriptors, and
+    /// systemd's default soft limit of 1024 is reached with a few extra
+    /// channels or mixes; past it the server drops nodes at random.
+    /// </summary>
+    public (int Used, int Limit)? PulseFileUsage()
+    {
+        try
+        {
+            foreach (string dir in Directory.EnumerateDirectories("/proc"))
+            {
+                string name = Path.GetFileName(dir);
+                if (!name.All(char.IsAsciiDigit)) continue;
+                string comm;
+                try { comm = File.ReadAllText(Path.Combine(dir, "comm")).Trim(); }
+                catch (Exception) { continue; }
+                if (comm != "pipewire-pulse") continue;
+                int? limit = File.ReadLines(Path.Combine(dir, "limits"))
+                    .Where(line => line.StartsWith("Max open files", StringComparison.Ordinal))
+                    .Select(line => line[14..].Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                    .Where(columns => columns.Length >= 1 && int.TryParse(columns[0], out _))
+                    .Select(columns => (int?)int.Parse(columns[0]))
+                    .FirstOrDefault();
+                if (limit is null) return null;
+                int used = Directory.EnumerateFileSystemEntries(Path.Combine(dir, "fd")).Count();
+                return (used, limit.Value);
+            }
+        }
+        catch (Exception) { /* no /proc, or not ours to read */ }
+        return null;
+    }
+
+    /// <summary>Like <see cref="FindCombineLegs"/>, but null when pactl fails or stalls.</summary>
+    public IReadOnlyDictionary<string, int>? TryFindCombineLegs(uint combineModule)
+    {
+        try { return FindCombineLegs(combineModule); }
+        catch (InvalidOperationException) { return null; }
+    }
+
+    /// <summary>The serials of every stream currently playing into a sink.</summary>
+    public IReadOnlyList<int> StreamSerialsOnSink(string sinkName)
+    {
+        string sinks = TryRun("pactl", "list", "sinks", "short") ?? "";
+        string? sinkId = sinks.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Split('\t'))
+            .Where(columns => columns.Length >= 2 && columns[1] == sinkName)
+            .Select(columns => columns[0])
+            .FirstOrDefault();
+        if (sinkId is null) return [];
+        return [.. (TryRun("pactl", "list", "sink-inputs", "short") ?? "")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Split('\t'))
+            .Where(columns => columns.Length >= 2 && columns[1] == sinkId && int.TryParse(columns[0], out _))
+            .Select(columns => int.Parse(columns[0]))];
     }
 
     /// <summary>Volume of a sink as 0..1, parsed from pactl (first channel).</summary>

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -25,8 +25,20 @@ public static class CommandValidation
         switch (cmd.Cmd)
         {
             case "createChannel":
-                return cmd.Name is null || cmd.Name.Length > 60 || string.IsNullOrWhiteSpace(cmd.Name) || cmd.Name.Any(char.IsControl)
-                    ? "createChannel: name must contain 1 to 60 printable characters" : null;
+            case "createMix":
+                return BadName(cmd.Name) ? $"{cmd.Cmd}: name must contain 1 to 60 printable characters" : null;
+            case "renameChannel":
+            case "deleteChannel":
+                if (cmd.Channel is null) return $"{cmd.Cmd}: need 'channel'";
+                if (TooLong(cmd.Channel, 36) || !layout.HasApplicationChannel(cmd.Channel))
+                    return $"{cmd.Cmd}: '{Short(cmd.Channel)}' is not an application channel";
+                return cmd.Cmd == "renameChannel" && BadName(cmd.Name) ? "renameChannel: name must contain 1 to 60 printable characters" : null;
+            case "renameMix":
+            case "deleteMix":
+                if (cmd.Mix is null) return $"{cmd.Cmd}: need 'mix'";
+                if (TooLong(cmd.Mix, 36) || !layout.HasVirtualMix(cmd.Mix))
+                    return $"{cmd.Cmd}: '{Short(cmd.Mix)}' is not a virtual microphone";
+                return cmd.Cmd == "renameMix" && BadName(cmd.Name) ? "renameMix: name must contain 1 to 60 printable characters" : null;
             case "setLayoutOrder":
                 if (cmd.Channels is null || cmd.Mixes is null) return "setLayoutOrder: need 'channels' and 'mixes'";
                 if (cmd.Channels.Count > MixerConfig.MaxApplicationChannels || cmd.Mixes.Count > MixerConfig.MaxVirtualMixes)
@@ -119,6 +131,8 @@ public static class CommandValidation
             ? null : $"{cmd.Cmd}: '{field}' must be a finite number";
 
     private static bool TooLong(string? s, int max) => s is not null && s.Length > max;
+    private static bool BadName(string? name)
+        => name is null || name.Length > 60 || string.IsNullOrWhiteSpace(name) || name.Any(char.IsControl);
     private static string Short(string s) => s.Length <= 40 ? s : s[..40] + "...";
     private static string Tail(string uri) => uri[(uri.LastIndexOfAny(['#', '/']) + 1)..];
 

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -193,6 +193,18 @@ public sealed class MixerService : IHostedService, IDisposable
                         | _mixer.EnsureFilterRoutes()
                         | _mixer.EnsureMonitorRoutes()) Changed?.Invoke();
                     SyncOutputSelectors();
+                    // Once a minute: is the PulseAudio server close to its
+                    // open-file limit? Cheap (one /proc directory listing).
+                    if (++_sweepCount % 60 == 1)
+                    {
+                        string? warning = _mixer.PulseFileWarning();
+                        if (warning != Volatile.Read(ref _resourceWarning))
+                        {
+                            if (warning is not null) _log.LogWarning("{msg}", warning);
+                            Volatile.Write(ref _resourceWarning, warning);
+                            Changed?.Invoke();
+                        }
+                    }
                     if (_lastSweepError is not null)
                     {
                         _lastSweepError = null;
@@ -284,13 +296,28 @@ public sealed class MixerService : IHostedService, IDisposable
             switch (cmd.Cmd)
             {
                 case "createChannel":
+                case "renameChannel":
+                case "deleteChannel":
+                case "createMix":
+                case "renameMix":
+                case "deleteMix":
                 case "setLayoutOrder":
+                    // Layout commands save synchronously, under the same gate
+                    // as the debounced fader saves, and succeed only once the
+                    // new layout is on disk.
                     lock (_saveGate)
                     {
-                        if (cmd.Cmd == "createChannel")
-                            _mixer.CreateApplicationChannel(cmd.Name!, settings => settings.Save());
-                        else
-                            _mixer.SetLayoutOrder(cmd.Channels!, cmd.Mixes!, settings => settings.Save());
+                        Func<MixerSettings, string?> save = settings => settings.Save();
+                        switch (cmd.Cmd)
+                        {
+                            case "createChannel": _mixer.CreateApplicationChannel(cmd.Name!, save); break;
+                            case "renameChannel": _mixer.RenameApplicationChannel(cmd.Channel!, cmd.Name!, save); break;
+                            case "deleteChannel": _mixer.DeleteApplicationChannel(cmd.Channel!, save); break;
+                            case "createMix": _mixer.CreateVirtualMix(cmd.Name!, save); break;
+                            case "renameMix": _mixer.RenameVirtualMix(cmd.Mix!, cmd.Name!, save); break;
+                            case "deleteMix": _mixer.DeleteVirtualMix(cmd.Mix!, save); break;
+                            default: _mixer.SetLayoutOrder(cmd.Channels!, cmd.Mixes!, save); break;
+                        }
                         _saveDirty = false;
                         _lastSaveError = null;
                         _retryDelay = SaveDelay;
@@ -422,6 +449,12 @@ public sealed class MixerService : IHostedService, IDisposable
     /// state so the user knows the window's changes would not survive a
     /// restart yet.
     /// </summary>
+    private int _sweepCount;
+    private string? _resourceWarning;
+
+    /// <summary>pipewire-pulse close to its open-file limit, or null.</summary>
+    public string? ResourceWarning => Volatile.Read(ref _resourceWarning);
+
     public string? PersistenceWarning
     {
         get { lock (_saveGate) return _lastSaveError is null ? null : $"Mixer settings are not being saved ({_lastSaveError}); retrying."; }

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -106,7 +106,7 @@ public sealed class MixerService : IHostedService, IDisposable
     public event Action? Changed;
 
     /// <summary>Null until the graph is built.</summary>
-    public MixerState? Snapshot() => _mixer.Built ? _mixer.Snapshot() : null;
+    public MixerState? Snapshot() => _mixer.Built ? _mixer.Snapshot() with { LayoutWarning = ResourceWarning } : null;
 
     /// <summary>Selectable sinks and sources, or null when the mixer is off.</summary>
     public IReadOnlyList<AudioNode>? Devices() => _mixer.Built ? _mixer.ListDevices() : null;

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -21,6 +21,13 @@ public sealed record Command
     /// </summary>
     [JsonPropertyName("cmd")] public string Cmd { get; init; } = "";
 
+    /// <summary>
+    /// Optional correlation id. When present, a mixer command is answered
+    /// with a <c>commandResult</c> message carrying it, after the state that
+    /// reflects the outcome, so an editor can wait for the acknowledgement.
+    /// </summary>
+    [JsonPropertyName("requestId")] public string? RequestId { get; init; }
+
     /// <summary>For "set": the control name (see <see cref="ControlNames"/>).</summary>
     [JsonPropertyName("control")] public string? Control { get; init; }
 
@@ -155,6 +162,14 @@ public sealed record ErrorMessage
 
     [JsonPropertyName("type")] public string Type => "error";
     [JsonPropertyName("message")] public string Message { get; }
+}
+
+/// <summary>The outcome of a command that carried a requestId; error is null on success.</summary>
+public sealed record CommandResultMessage(
+    [property: JsonPropertyName("requestId")] string RequestId,
+    [property: JsonPropertyName("error")] string? Error)
+{
+    [JsonPropertyName("type")] public string Type => "commandResult";
 }
 
 /// <summary>Canonical control names accepted by "set".</summary>

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -64,7 +64,7 @@ public sealed class WebSocketHub
         _devices.Snapshot() with
         {
             DaemonVersion = OpenXLR.Daemon.DaemonVersion.Current,
-            Warning = string.Join(" ", new[] { _devices.Warning, _mixer.PersistenceWarning }.Where(w => w is not null)) is { Length: > 0 } w ? w : null,
+            Warning = string.Join(" ", new[] { _devices.Warning, _mixer.PersistenceWarning, _mixer.ResourceWarning }.Where(w => w is not null)) is { Length: > 0 } w ? w : null,
             ActiveProfile = ActiveDeviceId() is string apId && _activeProfile.TryGetValue(apId, out string? ap) ? ap : null,
             Mixer = _mixer.Snapshot(),
             Devices = _mixer.Devices(),
@@ -157,7 +157,7 @@ public sealed class WebSocketHub
     {
         var messages = new List<object>();
         await DispatchAsync(message => { messages.Add(message); return Task.CompletedTask; }, text);
-        return new("1", !messages.Any(message => message is ErrorMessage), messages);
+        return new("1", !messages.Any(message => message is ErrorMessage or CommandResultMessage { Error: not null }), messages);
     }
 
     private async Task DispatchAsync(Func<object, Task> reply, string text)
@@ -188,6 +188,11 @@ public sealed class WebSocketHub
                 if (err is not null) await reply(new ErrorMessage(err));
                 break;
             case "createChannel":
+            case "renameChannel":
+            case "deleteChannel":
+            case "createMix":
+            case "renameMix":
+            case "deleteMix":
             case "setLayoutOrder":
             case "setLevel":
             case "setChannelMuted":
@@ -208,6 +213,14 @@ public sealed class WebSocketHub
             case "setInsertBypass":
             case "setInsertParam":
                 string? mixErr = _mixer.Apply(cmd);                     // broadcasts on success
+                if (cmd.RequestId is not null)
+                {
+                    // The state first, so a waiting editor re-enables its
+                    // controls against the layout the result refers to.
+                    await reply(Snapshot());
+                    await reply(new CommandResultMessage(cmd.RequestId, mixErr));
+                    break;
+                }
                 if (mixErr is not null)
                 {
                     await reply(new ErrorMessage(mixErr));

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -64,7 +64,7 @@ public sealed class WebSocketHub
         _devices.Snapshot() with
         {
             DaemonVersion = OpenXLR.Daemon.DaemonVersion.Current,
-            Warning = string.Join(" ", new[] { _devices.Warning, _mixer.PersistenceWarning, _mixer.ResourceWarning }.Where(w => w is not null)) is { Length: > 0 } w ? w : null,
+            Warning = string.Join(" ", new[] { _devices.Warning, _mixer.PersistenceWarning }.Where(w => w is not null)) is { Length: > 0 } w ? w : null,
             ActiveProfile = ActiveDeviceId() is string apId && _activeProfile.TryGetValue(apId, out string? ap) ? ap : null,
             Mixer = _mixer.Snapshot(),
             Devices = _mixer.Devices(),

--- a/src/OpenXLR.Tests/LiveLayoutEditingTests.cs
+++ b/src/OpenXLR.Tests/LiveLayoutEditingTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+public sealed class LiveLayoutEditingTests
+{
+    private static string[] AppIds(MixerConfig c) => [.. c.Channels.Where(ch => ch.InputPair is null).Select(ch => ch.Id)];
+
+    [Fact]
+    public void NewMixSitsBeforeAuxWithMutedSendsOnEveryChannel()
+    {
+        var config = MixerConfig.Default().WithMix(new MixDefinition("podcast", "Podcast", MixKind.VirtualMic));
+        Assert.Equal(["monitor", "monitor2", "stream", "chat", "podcast", "auxout"], config.Mixes.Select(m => m.Id));
+        foreach (ChannelDefinition ch in config.Channels)
+        {
+            Assert.Equal(1.0, ch.Levels["podcast"]);
+            Assert.Contains("podcast", ch.MutedIn);
+        }
+        Assert.Throws<InvalidOperationException>(() => config.WithMix(new MixDefinition("Podcast", "Again", MixKind.VirtualMic)));
+        Assert.Throws<InvalidOperationException>(() => config.WithMix(new MixDefinition("m3", "Monitor C", MixKind.Monitor)));
+    }
+
+    [Fact]
+    public void MixLimitHoldsForCreation()
+    {
+        var config = MixerConfig.Default();
+        for (int i = config.Mixes.Count(m => m.Kind == MixKind.VirtualMic); i < MixerConfig.MaxVirtualMixes; i++)
+            config = config.WithMix(new MixDefinition($"m{i}", $"Mix {i}", MixKind.VirtualMic));
+        Assert.Throws<InvalidOperationException>(() => config.WithMix(new MixDefinition("one-more", "One more", MixKind.VirtualMic)));
+    }
+
+    [Fact]
+    public void RemovingAMixDropsItsSendsAndKeepsStructuralMixes()
+    {
+        var config = MixerConfig.Default().WithoutMix("chat");
+        Assert.Equal(["monitor", "monitor2", "stream", "auxout"], config.Mixes.Select(m => m.Id));
+        Assert.All(config.Channels, ch => { Assert.False(ch.Levels.ContainsKey("chat")); Assert.DoesNotContain("chat", ch.MutedIn); });
+        foreach (string structural in new[] { "monitor", "monitor2", "auxout", "nope" })
+            Assert.Throws<InvalidOperationException>(() => MixerConfig.Default().WithoutMix(structural));
+    }
+
+    [Fact]
+    public void RemovingAChannelKeepsHardwareAndTheLastApplicationChannel()
+    {
+        var config = MixerConfig.Default().WithoutChannel("game");
+        Assert.DoesNotContain("game", config.Channels.Select(c => c.Id));
+        Assert.Equal(["xlr1", "xlr2", "aux"], config.Channels.Where(c => c.InputPair is not null).Select(c => c.Id));
+        foreach (string id in new[] { "xlr1", "aux", "nope", StreamMatcher.Ignore })
+            Assert.Throws<InvalidOperationException>(() => MixerConfig.Default().WithoutChannel(id));
+
+        var single = MixerConfig.FromSettings(new MixerSettings { UserChannels = [new("only", "Only")] });
+        Assert.Throws<InvalidOperationException>(() => single.WithoutChannel("only"));
+    }
+
+    [Fact]
+    public void RenamesChangeOnlyTheDisplayName()
+    {
+        var original = MixerConfig.Default();
+        var renamed = original.WithChannelName("music", "Spotify").WithMixName("stream", "OBS");
+        Assert.Equal("Spotify", renamed.Channels.Single(c => c.Id == "music").Name);
+        Assert.Equal("OBS", renamed.Mixes.Single(m => m.Id == "stream").Name);
+        Assert.Equal(AppIds(original), AppIds(renamed));
+        Assert.Equal(original.Channels.Single(c => c.Id == "music").Levels, renamed.Channels.Single(c => c.Id == "music").Levels);
+        Assert.Throws<InvalidOperationException>(() => original.WithChannelName("xlr1", "Mic"));
+        Assert.Throws<InvalidOperationException>(() => original.WithMixName("monitor", "Ears"));
+    }
+
+    [Theory]
+    [InlineData("Podcast", "podcast")]
+    [InlineData("Late Night Show", "late-night-show")]
+    [InlineData("2nd stream", "mix-2nd-stream")]
+    [InlineData("!!!", "mix")]
+    [InlineData("monitor", "monitor-2")]
+    [InlineData("a-very-long-name-that-goes-on-and-on-forever", "a-very-long-name-that-goes-o")]
+    public void MixIdsAreSafeAndUnique(string name, string expected)
+        => Assert.Equal(expected, MixerConfig.NewId(name, "mix", MixerConfig.Default().Mixes.Select(m => m.Id)));
+
+    private sealed class Layout : ILayoutInfo
+    {
+        public bool HasChannel(string id) => id is "xlr1" or "game" or "music";
+        public bool HasMix(string id) => id is "monitor" or "stream" or "auxout";
+        public bool HasApplicationChannel(string id) => id is "game" or "music";
+        public bool HasVirtualMix(string id) => id == "stream";
+        public bool IsMonitorFeed(string feed) => feed == "monitor";
+        public bool IsMonitorOutput(string device) => false;
+        public bool IsInsertKey(string key) => false;
+        public int OverrideCount => 0;
+    }
+
+    private static string? Check(Command cmd) => CommandValidation.Check(cmd, new Layout(), _ => null);
+
+    [Fact]
+    public void EditCommandsOnlyTouchEditableNodes()
+    {
+        Assert.Null(Check(new Command { Cmd = "renameChannel", Channel = "game", Name = "Games" }));
+        Assert.NotNull(Check(new Command { Cmd = "renameChannel", Channel = "xlr1", Name = "Mic" }));
+        Assert.NotNull(Check(new Command { Cmd = "renameChannel", Channel = "game", Name = " " }));
+        Assert.NotNull(Check(new Command { Cmd = "renameChannel", Name = "Games" }));
+        Assert.Null(Check(new Command { Cmd = "deleteChannel", Channel = "music" }));
+        Assert.NotNull(Check(new Command { Cmd = "deleteChannel", Channel = "nope" }));
+        Assert.Null(Check(new Command { Cmd = "renameMix", Mix = "stream", Name = "OBS" }));
+        Assert.NotNull(Check(new Command { Cmd = "renameMix", Mix = "monitor", Name = "Ears" }));
+        Assert.Null(Check(new Command { Cmd = "deleteMix", Mix = "stream" }));
+        Assert.NotNull(Check(new Command { Cmd = "deleteMix", Mix = "auxout" }));
+        Assert.NotNull(Check(new Command { Cmd = "deleteMix" }));
+        Assert.Null(Check(new Command { Cmd = "createMix", Name = "Podcast" }));
+        Assert.NotNull(Check(new Command { Cmd = "createMix", Name = new string('x', 61) }));
+        Assert.NotNull(Check(new Command { Cmd = "createMix", Name = "bad\nname" }));
+    }
+
+    [Fact]
+    public async Task RequestIdRoundTripsAndIsAnsweredAfterTheState()
+    {
+        var command = JsonSerializer.Deserialize<Command>("""{"cmd":"createMix","name":"Podcast","requestId":"r1"}""")!;
+        Assert.Equal("r1", command.RequestId);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        // No hosted services: no USB, no audio graph. The hub still dispatches.
+        builder.Services.AddSingleton<DeviceManager>();
+        builder.Services.AddSingleton<MixerService>();
+        builder.Services.AddSingleton<WebSocketHub>();
+        await using var app = builder.Build();
+        var hub = app.Services.GetRequiredService<WebSocketHub>();
+
+        // The mixer is not built in a test, so the command fails; the failure
+        // still arrives as a correlated result, after an authoritative state.
+        ApiCommandResult result = await hub.ExecuteForApiAsync("""{"cmd":"createMix","name":"Podcast","requestId":"r1"}""");
+        Assert.False(result.Ok);
+        Assert.Equal(2, result.Messages.Count);
+        Assert.IsType<StateMessage>(result.Messages[0]);
+        var done = Assert.IsType<CommandResultMessage>(result.Messages[1]);
+        Assert.Equal("r1", done.RequestId);
+        Assert.Contains("not built", done.Error);
+
+        // Without a requestId the plain error message is what a client gets.
+        ApiCommandResult plain = await hub.ExecuteForApiAsync("""{"cmd":"createMix","name":"Podcast"}""");
+        Assert.False(plain.Ok);
+        Assert.Contains(plain.Messages, m => m is ErrorMessage);
+    }
+}

--- a/src/OpenXLR.UI/AppsWindow.axaml
+++ b/src/OpenXLR.UI/AppsWindow.axaml
@@ -40,7 +40,7 @@
                              ToolTip.Tip="{Binding Identity}"/>
                   <ComboBox Grid.Column="3" HorizontalAlignment="Stretch"
                             ItemsSource="{Binding Channels}"
-                            SelectedItem="{Binding ChannelId, Mode=TwoWay}"/>
+                            SelectedItem="{Binding SelectedChannel, Mode=TwoWay}"/>
                   <Button Grid.Column="5" Content="Forget" Padding="10,3" FontSize="12"
                           Click="OnForget"/>
                 </Grid>

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -27,6 +27,8 @@ public sealed class DaemonClient : IAsyncDisposable
     private Task? _disposeTask;
     private bool _disposed;
     private readonly Dictionary<string, PendingQuery> _queries = new();
+    // Layout edits wait for the daemon's commandResult with their requestId.
+    private readonly Dictionary<string, TaskCompletionSource<string?>> _edits = new();
     private const int MaxMessageBytes = 8 * 1024 * 1024;
 
     private sealed class PendingQuery
@@ -144,6 +146,8 @@ public sealed class DaemonClient : IAsyncDisposable
                 {
                     foreach (var query in _queries.Values) query.Reply.TrySetResult(null);
                     _queries.Clear();
+                    foreach (var edit in _edits.Values) edit.TrySetResult("Connection lost. Check the layout before retrying.");
+                    _edits.Clear();
                 }
                 ConnectionChanged?.Invoke(false);
             }
@@ -184,6 +188,12 @@ public sealed class DaemonClient : IAsyncDisposable
             else if (type == "state") { LastStateJson = text; StateReceived?.Invoke(node); }
             else if (type == "diagnostics") CompleteQuery(type, node);
             else if (type == "plugins") CompleteQuery(type, node["plugins"]);
+            else if (type == "commandResult" && node["requestId"]?.GetValue<string>() is string requestId)
+            {
+                TaskCompletionSource<string?>? edit;
+                lock (_lifecycle) _edits.TryGetValue(requestId, out edit);
+                edit?.TrySetResult(node["error"]?.GetValue<string>());
+            }
             else if (type == "meters" && node["levels"] is JsonNode levels) MetersReceived?.Invoke(levels);
         }
     }
@@ -225,6 +235,47 @@ public sealed class DaemonClient : IAsyncDisposable
 
     public Task SetMixMutedAsync(string mix, bool muted)
         => SendAsync(new Dictionary<string, object> { ["cmd"] = "setMixMuted", ["mix"] = mix, ["value"] = muted });
+
+    // --- layout editing: each call resolves to null on success or the daemon's error ---
+
+    public Task<string?> CreateChannelAsync(string name)
+        => EditLayoutAsync(new() { ["cmd"] = "createChannel", ["name"] = name });
+    public Task<string?> RenameChannelAsync(string channel, string name)
+        => EditLayoutAsync(new() { ["cmd"] = "renameChannel", ["channel"] = channel, ["name"] = name });
+    public Task<string?> DeleteChannelAsync(string channel)
+        => EditLayoutAsync(new() { ["cmd"] = "deleteChannel", ["channel"] = channel });
+    public Task<string?> CreateMixAsync(string name)
+        => EditLayoutAsync(new() { ["cmd"] = "createMix", ["name"] = name });
+    public Task<string?> RenameMixAsync(string mix, string name)
+        => EditLayoutAsync(new() { ["cmd"] = "renameMix", ["mix"] = mix, ["name"] = name });
+    public Task<string?> DeleteMixAsync(string mix)
+        => EditLayoutAsync(new() { ["cmd"] = "deleteMix", ["mix"] = mix });
+    public Task<string?> SetLayoutOrderAsync(IReadOnlyList<string> channels, IReadOnlyList<string> mixes)
+        => EditLayoutAsync(new() { ["cmd"] = "setLayoutOrder", ["channels"] = channels, ["mixes"] = mixes });
+
+    /// <summary>
+    /// Send a layout command and wait for its commandResult. The daemon
+    /// answers only after the new layout is saved, and sends the matching
+    /// state first, so a null result means the change is visible and durable.
+    /// </summary>
+    private async Task<string?> EditLayoutAsync(Dictionary<string, object> payload)
+    {
+        string requestId = Guid.NewGuid().ToString("N");
+        var waiter = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_lifecycle)
+        {
+            if (_disposed) return "Daemon disconnected; no change was sent.";
+            _edits[requestId] = waiter;
+        }
+        payload["requestId"] = requestId;
+        try
+        {
+            if (!await SendAsync(payload, reportErrors: false)) return "Daemon disconnected; no change was sent.";
+            return await waiter.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        catch (TimeoutException) { return "No answer from the daemon. Check the layout before retrying."; }
+        finally { lock (_lifecycle) _edits.Remove(requestId); }
+    }
 
     /// <summary>Send the monitor mix to a different output (null disconnects).</summary>
     public Task SetMonitorOutputAsync(string? device)

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -242,6 +242,18 @@
       </DockPanel>
     </Border>
 
+    <!-- a virtual microphone renamed while running keeps its old device name elsewhere -->
+    <Border Classes="card" Margin="0,0,0,8" IsVisible="{Binding RenamedSinceStart}">
+      <DockPanel>
+        <Button DockPanel.Dock="Right" Content="Restart daemon" Padding="10,3" FontSize="12"
+                IsEnabled="{Binding DaemonRestart.CanRestart}"
+                VerticalAlignment="Center" Click="OnRestartDaemon"
+                ToolTip.Tip="systemctl --user restart openxlr-daemon"/>
+        <TextBlock Text="A renamed virtual microphone keeps its old name in other applications until the daemon restarts. Restart when nothing is recording from it."
+                   Classes="h" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,12,0"/>
+      </DockPanel>
+    </Border>
+
     <!-- device controls -->
     <Border Classes="card" Margin="0,0,0,8">
       <Expander Name="InputsTile" Classes="tile" Theme="{StaticResource TileExpanderTheme}" IsExpanded="True">
@@ -504,7 +516,7 @@
                            ToolTip.Tip="{Binding StatusText}"/>
                   <TextBlock Text="{Binding Label}" Foreground="#e6e9f0" VerticalAlignment="Center"/>
                   <ComboBox ItemsSource="{Binding Channels}" MinWidth="110"
-                            SelectedItem="{Binding ChannelId, Mode=TwoWay}"/>
+                            SelectedItem="{Binding SelectedChannel, Mode=TwoWay}"/>
                 </StackPanel>
               </Border>
             </DataTemplate>
@@ -526,6 +538,12 @@
       <Expander Name="SubmixerTile" Classes="tile" Theme="{StaticResource TileExpanderTheme}" IsExpanded="True">
         <Expander.Header><TextBlock Text="SUBMIXER" Classes="h"/></Expander.Header>
       <DockPanel>
+        <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,8" IsVisible="{Binding HasMixer}">
+          <TextBlock Text="Application channels and virtual microphones can be added, renamed, reordered and removed while audio plays."
+                     FontSize="11" Foreground="#6b7285" VerticalAlignment="Center" TextWrapping="Wrap"/>
+          <Button Grid.Column="1" Content="Edit layout…" Padding="12,4" Margin="8,0,0,0"
+                  IsEnabled="{Binding CanEditLayout}" Click="OnEditLayout"/>
+        </Grid>
         <TextBlock DockPanel.Dock="Top" Text="{Binding MixerPlaceholder}" TextWrapping="Wrap"
                    Foreground="#6b7285" IsVisible="{Binding !HasMixer}"/>
 

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -242,18 +242,6 @@
       </DockPanel>
     </Border>
 
-    <!-- a virtual microphone renamed while running keeps its old device name elsewhere -->
-    <Border Classes="card" Margin="0,0,0,8" IsVisible="{Binding RenamedSinceStart}">
-      <DockPanel>
-        <Button DockPanel.Dock="Right" Content="Restart daemon" Padding="10,3" FontSize="12"
-                IsEnabled="{Binding DaemonRestart.CanRestart}"
-                VerticalAlignment="Center" Click="OnRestartDaemon"
-                ToolTip.Tip="systemctl --user restart openxlr-daemon"/>
-        <TextBlock Text="A renamed virtual microphone keeps its old name in other applications until the daemon restarts. Restart when nothing is recording from it."
-                   Classes="h" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,12,0"/>
-      </DockPanel>
-    </Border>
-
     <!-- device controls -->
     <Border Classes="card" Margin="0,0,0,8">
       <Expander Name="InputsTile" Classes="tile" Theme="{StaticResource TileExpanderTheme}" IsExpanded="True">
@@ -538,12 +526,10 @@
       <Expander Name="SubmixerTile" Classes="tile" Theme="{StaticResource TileExpanderTheme}" IsExpanded="True">
         <Expander.Header><TextBlock Text="SUBMIXER" Classes="h"/></Expander.Header>
       <DockPanel>
-        <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,8" IsVisible="{Binding HasMixer}">
-          <TextBlock Text="Application channels and virtual microphones can be added, renamed, reordered and removed while audio plays."
-                     FontSize="11" Foreground="#6b7285" VerticalAlignment="Center" TextWrapping="Wrap"/>
-          <Button Grid.Column="1" Content="Edit layout…" Padding="12,4" Margin="8,0,0,0"
-                  IsEnabled="{Binding CanEditLayout}" Click="OnEditLayout"/>
-        </Grid>
+        <Button DockPanel.Dock="Top" Content="Edit layout…" Padding="12,4" Margin="0,0,0,8"
+                HorizontalAlignment="Right" IsVisible="{Binding HasMixer}" IsEnabled="{Binding CanEditLayout}"
+                Click="OnEditLayout"
+                ToolTip.Tip="Add, rename, reorder and remove application channels and virtual microphones while audio plays"/>
         <TextBlock DockPanel.Dock="Top" Text="{Binding MixerPlaceholder}" TextWrapping="Wrap"
                    Foreground="#6b7285" IsVisible="{Binding !HasMixer}"/>
 

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -106,6 +106,9 @@ public partial class MainWindow : Window
     private void OnManageApps(object? sender, RoutedEventArgs e)
         => new AppsWindow { DataContext = _vm }.ShowDialog(this);
 
+    private void OnEditLayout(object? sender, RoutedEventArgs e)
+        => new MixerSetupWindow { DataContext = _vm }.ShowDialog(this);
+
     private void OnAbout(object? sender, RoutedEventArgs e)
         => new AboutWindow().ShowDialog(this);
 

--- a/src/OpenXLR.UI/MixerSetupWindow.axaml
+++ b/src/OpenXLR.UI/MixerSetupWindow.axaml
@@ -34,6 +34,20 @@
                  FontSize="11" Foreground="#7d8496" TextWrapping="Wrap"/>
       <TextBlock Name="Note" FontSize="11" Foreground="#e0a84a" TextWrapping="Wrap"
                  IsVisible="False"/>
+      <!-- the daemon's own notes for this window: the open-file limit, and a mix renamed since start -->
+      <DockPanel IsVisible="{Binding LayoutWarning, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+        <Button DockPanel.Dock="Right" Content="Manual, 5.8" Padding="10,3" FontSize="12" VerticalAlignment="Center"
+                Click="OnFileLimitManual" ToolTip.Tip="Open the manual section on the pipewire-pulse open-file limit"/>
+        <TextBlock Text="{Binding LayoutWarning}" FontSize="11" Foreground="#e0a84a" TextWrapping="Wrap"
+                   VerticalAlignment="Center" Margin="0,0,12,0"/>
+      </DockPanel>
+      <DockPanel IsVisible="{Binding RenamedSinceStart}">
+        <Button DockPanel.Dock="Right" Content="Restart daemon" Padding="10,3" FontSize="12"
+                IsEnabled="{Binding DaemonRestart.CanRestart}" VerticalAlignment="Center"
+                Click="OnRestartDaemon" ToolTip.Tip="systemctl --user restart openxlr-daemon"/>
+        <TextBlock Text="A renamed virtual microphone keeps its old name in other applications until the daemon restarts. Restart when nothing is recording from it."
+                   FontSize="11" Foreground="#e0a84a" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,12,0"/>
+      </DockPanel>
     </StackPanel>
     <Button DockPanel.Dock="Bottom" Content="Close" HorizontalAlignment="Right" Padding="18,6"
             Margin="0,12,0,0" Click="OnClose"/>

--- a/src/OpenXLR.UI/MixerSetupWindow.axaml
+++ b/src/OpenXLR.UI/MixerSetupWindow.axaml
@@ -1,0 +1,129 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:OpenXLR.UI"
+        x:Class="OpenXLR.UI.MixerSetupWindow"
+        x:DataType="vm:MainViewModel"
+        Title="OpenXLR Mixer layout" Width="760" Height="640" MinWidth="600" MinHeight="460"
+        WindowStartupLocation="CenterOwner" Background="#16181d">
+  <Window.Styles>
+    <Style Selector="TextBlock.h">
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="FontWeight" Value="SemiBold"/>
+      <Setter Property="Foreground" Value="#8b93a7"/>
+    </Style>
+    <Style Selector="Border.card">
+      <Setter Property="Background" Value="#1d2027"/>
+      <Setter Property="CornerRadius" Value="8"/>
+      <Setter Property="Padding" Value="14"/>
+    </Style>
+    <Style Selector="Button.small">
+      <Setter Property="Padding" Value="8,2"/>
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="MinWidth" Value="0"/>
+    </Style>
+    <Style Selector="Button.danger">
+      <Setter Property="Background" Value="#7d3035"/>
+      <Setter Property="Foreground" Value="#ffffff"/>
+    </Style>
+  </Window.Styles>
+
+  <DockPanel Margin="16">
+    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,12" Spacing="4">
+      <TextBlock Text="Mixer layout" FontSize="20" FontWeight="Bold" Foreground="#e6e9f0"/>
+      <TextBlock Text="Application channels are the playback devices you route programs into. Virtual microphones are the recording devices OBS, Discord and other apps pick up. Every change is saved before it is confirmed, and audio on the other channels keeps flowing."
+                 FontSize="11" Foreground="#7d8496" TextWrapping="Wrap"/>
+      <TextBlock Name="Note" FontSize="11" Foreground="#e0a84a" TextWrapping="Wrap"
+                 IsVisible="False"/>
+    </StackPanel>
+    <Button DockPanel.Dock="Bottom" Content="Close" HorizontalAlignment="Right" Padding="18,6"
+            Margin="0,12,0,0" Click="OnClose"/>
+
+    <Grid ColumnDefinitions="*,12,*">
+      <Border Classes="card">
+        <DockPanel>
+          <Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,8,Auto" Margin="0,10,0,0">
+            <TextBox Name="ChannelName" PlaceholderText="New channel, e.g. Podcast" MaxLength="60"
+                     KeyDown="OnChannelNameKey"/>
+            <Button Grid.Column="2" Content="Add channel" Padding="12,4"
+                    IsEnabled="{Binding CanEditLayout}" Click="OnAddChannel"/>
+          </Grid>
+          <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <TextBlock Text="CHANNELS" Classes="h"/>
+            <TextBlock Text="A new channel starts muted in every mix. Hardware inputs stay where they are."
+                       FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
+          </StackPanel>
+          <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Channels}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="vm:ChannelViewModel">
+                  <Border Background="#23262f" CornerRadius="6" Padding="10,7" Margin="0,0,0,6"
+                          IsVisible="{Binding Visible}">
+                    <Grid ColumnDefinitions="*,Auto,4,Auto,8,Auto,4,Auto">
+                      <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{Binding Name}" Foreground="#e6e9f0" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding Id}" Foreground="#6b7285" FontFamily="monospace" FontSize="10"/>
+                      </StackPanel>
+                      <TextBlock Grid.Column="1" Text="hardware input" Foreground="#6b7285" FontSize="11"
+                                 VerticalAlignment="Center" IsVisible="{Binding IsHardware}"/>
+                      <Button Grid.Column="1" Content="▲" Classes="small" ToolTip.Tip="Move up"
+                              IsVisible="{Binding IsEditable}" Click="OnChannelUp"/>
+                      <Button Grid.Column="3" Content="▼" Classes="small" ToolTip.Tip="Move down"
+                              IsVisible="{Binding IsEditable}" Click="OnChannelDown"/>
+                      <Button Grid.Column="5" Content="Rename" Classes="small"
+                              IsVisible="{Binding IsEditable}" Click="OnRenameChannel"/>
+                      <Button Grid.Column="7" Content="Delete" Classes="small danger"
+                              IsVisible="{Binding IsEditable}" Click="OnDeleteChannel"/>
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+        </DockPanel>
+      </Border>
+
+      <Border Grid.Column="2" Classes="card">
+        <DockPanel>
+          <Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,8,Auto" Margin="0,10,0,0">
+            <TextBox Name="MixName" PlaceholderText="New virtual microphone, e.g. Recording" MaxLength="60"
+                     KeyDown="OnMixNameKey"/>
+            <Button Grid.Column="2" Content="Add microphone" Padding="12,4"
+                    IsEnabled="{Binding CanEditLayout}" Click="OnAddMix"/>
+          </Grid>
+          <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <TextBlock Text="MIXES" Classes="h"/>
+            <TextBlock Text="Each virtual microphone has its own master, sends and inserts. A new one receives nothing until you open a send. Monitor A, Monitor B and Aux stay where they are."
+                       FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
+          </StackPanel>
+          <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Mixes}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="vm:MixViewModel">
+                  <Border Background="#23262f" CornerRadius="6" Padding="10,7" Margin="0,0,0,6"
+                          IsVisible="{Binding Visible}">
+                    <Grid ColumnDefinitions="*,Auto,4,Auto,8,Auto,4,Auto">
+                      <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{Binding Name}" Foreground="#e6e9f0" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding Id}" Foreground="#6b7285" FontFamily="monospace" FontSize="10"/>
+                      </StackPanel>
+                      <TextBlock Grid.Column="1" Text="{Binding KindLabel}" Foreground="#6b7285" FontSize="11"
+                                 VerticalAlignment="Center" IsVisible="{Binding !IsEditable}"/>
+                      <Button Grid.Column="1" Content="▲" Classes="small" ToolTip.Tip="Move up"
+                              IsVisible="{Binding IsEditable}" Click="OnMixUp"/>
+                      <Button Grid.Column="3" Content="▼" Classes="small" ToolTip.Tip="Move down"
+                              IsVisible="{Binding IsEditable}" Click="OnMixDown"/>
+                      <Button Grid.Column="5" Content="Rename" Classes="small"
+                              IsVisible="{Binding IsEditable}" Click="OnRenameMix"/>
+                      <Button Grid.Column="7" Content="Delete" Classes="small danger"
+                              IsVisible="{Binding IsEditable}" Click="OnDeleteMix"/>
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+        </DockPanel>
+      </Border>
+    </Grid>
+  </DockPanel>
+</Window>

--- a/src/OpenXLR.UI/MixerSetupWindow.axaml
+++ b/src/OpenXLR.UI/MixerSetupWindow.axaml
@@ -36,7 +36,7 @@
                  IsVisible="False"/>
       <!-- the daemon's own notes for this window: the open-file limit, and a mix renamed since start -->
       <DockPanel IsVisible="{Binding LayoutWarning, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-        <Button DockPanel.Dock="Right" Content="Manual, 5.8" Padding="10,3" FontSize="12" VerticalAlignment="Center"
+        <Button DockPanel.Dock="Right" Content="Manual" Padding="10,3" FontSize="12" VerticalAlignment="Center"
                 Click="OnFileLimitManual" ToolTip.Tip="Open the manual section on the pipewire-pulse open-file limit"/>
         <TextBlock Text="{Binding LayoutWarning}" FontSize="11" Foreground="#e0a84a" TextWrapping="Wrap"
                    VerticalAlignment="Center" Margin="0,0,12,0"/>

--- a/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
+++ b/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
@@ -1,0 +1,194 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+
+namespace OpenXLR.UI;
+
+/// <summary>
+/// The layout editor: add, rename, reorder and delete application channels
+/// and virtual microphones. Every action waits for the daemon's answer, which
+/// arrives after the new layout is saved; the lists update from the state
+/// push that precedes it, so nothing here is optimistic.
+/// </summary>
+public partial class MixerSetupWindow : Window
+{
+    public MixerSetupWindow() => InitializeComponent();
+
+    private MainViewModel? Vm => DataContext as MainViewModel;
+
+    private async void OnAddChannel(object? sender, RoutedEventArgs e)
+    {
+        string name = ChannelName.Text?.Trim() ?? "";
+        if (name.Length == 0 || Vm is not { } vm) return;
+        if (await Run(vm.CreateChannel(name))) ChannelName.Text = "";
+    }
+
+    private async void OnAddMix(object? sender, RoutedEventArgs e)
+    {
+        string name = MixName.Text?.Trim() ?? "";
+        if (name.Length == 0 || Vm is not { } vm) return;
+        if (await Run(vm.CreateMix(name))) MixName.Text = "";
+    }
+
+    private void OnChannelNameKey(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter) { OnAddChannel(sender, e); e.Handled = true; }
+    }
+
+    private void OnMixNameKey(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter) { OnAddMix(sender, e); e.Handled = true; }
+    }
+
+    private async void OnChannelUp(object? sender, RoutedEventArgs e)
+    {
+        if (Item<ChannelViewModel>(sender) is { } c && Vm is { } vm) await Run(vm.MoveChannel(c.Id, -1));
+    }
+
+    private async void OnChannelDown(object? sender, RoutedEventArgs e)
+    {
+        if (Item<ChannelViewModel>(sender) is { } c && Vm is { } vm) await Run(vm.MoveChannel(c.Id, +1));
+    }
+
+    private async void OnMixUp(object? sender, RoutedEventArgs e)
+    {
+        if (Item<MixViewModel>(sender) is { } m && Vm is { } vm) await Run(vm.MoveMix(m.Id, -1));
+    }
+
+    private async void OnMixDown(object? sender, RoutedEventArgs e)
+    {
+        if (Item<MixViewModel>(sender) is { } m && Vm is { } vm) await Run(vm.MoveMix(m.Id, +1));
+    }
+
+    private async void OnRenameChannel(object? sender, RoutedEventArgs e)
+    {
+        if (Item<ChannelViewModel>(sender) is not { } channel || Vm is not { } vm) return;
+        string? name = await PromptName($"Rename channel '{channel.Name}'", channel.Name,
+            "Programs playing into this channel keep playing; the playback device shows the new name right away.");
+        if (name is not null && name != channel.Name) await Run(vm.RenameChannel(channel.Id, name));
+    }
+
+    private async void OnRenameMix(object? sender, RoutedEventArgs e)
+    {
+        if (Item<MixViewModel>(sender) is not { } mix || Vm is not { } vm) return;
+        string? name = await PromptName($"Rename mix '{mix.Name}'", mix.Name,
+            "OpenXLR shows the new name at once. Other applications keep listing the old microphone name until the daemon restarts, so nothing that is recording from it is interrupted.");
+        if (name is not null && name != mix.Name) await Run(vm.RenameMix(mix.Id, name));
+    }
+
+    private async void OnDeleteChannel(object? sender, RoutedEventArgs e)
+    {
+        if (Item<ChannelViewModel>(sender) is not { } channel || Vm is not { } vm) return;
+        if (await Confirm($"Delete channel '{channel.Name}'?",
+                "Programs routed to it move to the first remaining application channel. Its playback device disappears from the desktop."))
+            await Run(vm.DeleteChannel(channel.Id));
+    }
+
+    private async void OnDeleteMix(object? sender, RoutedEventArgs e)
+    {
+        if (Item<MixViewModel>(sender) is not { } mix || Vm is not { } vm) return;
+        if (await Confirm($"Delete mix '{mix.Name}'?",
+                "Its virtual microphone disappears; anything recording from it loses the device. Its sends and inserts go with it."))
+            await Run(vm.DeleteMix(mix.Id));
+    }
+
+    private static T? Item<T>(object? sender) where T : class => (sender as Control)?.DataContext as T;
+
+    /// <summary>Run one edit with the window locked, and surface its error here as well as in the status line.</summary>
+    private async Task<bool> Run(Task<string?> edit)
+    {
+        IsEnabled = false;
+        try
+        {
+            string? error = await edit;
+            Note.Text = error ?? "";
+            Note.IsVisible = error is not null;
+            return error is null;
+        }
+        finally { IsEnabled = true; }
+    }
+
+    private async Task<string?> PromptName(string title, string current, string hint)
+    {
+        var input = new TextBox { Text = current, MinWidth = 340, MaxLength = 60 };
+        var ok = new Button { Content = "Rename", IsDefault = true };
+        var cancel = new Button { Content = "Cancel", IsCancel = true };
+        string? result = null;
+        var dialog = new Window
+        {
+            Title = title,
+            SizeToContent = SizeToContent.WidthAndHeight,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Background = Brush.Parse("#1d2027"),
+            Content = new StackPanel
+            {
+                Margin = new Avalonia.Thickness(18),
+                Spacing = 12,
+                Children =
+                {
+                    input,
+                    new TextBlock { Text = hint, TextWrapping = TextWrapping.Wrap, MaxWidth = 380, FontSize = 11,
+                        Foreground = Brush.Parse("#8b93a7") },
+                    new StackPanel
+                    {
+                        Orientation = Avalonia.Layout.Orientation.Horizontal,
+                        Spacing = 8,
+                        HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                        Children = { cancel, ok },
+                    },
+                },
+            },
+        };
+        ok.Click += (_, _) =>
+        {
+            string clean = input.Text?.Trim() ?? "";
+            if (clean.Length == 0) return;
+            result = clean;
+            dialog.Close();
+        };
+        cancel.Click += (_, _) => dialog.Close();
+        dialog.Opened += (_, _) => { input.Focus(); input.SelectAll(); };
+        await dialog.ShowDialog(this);
+        return result;
+    }
+
+    private async Task<bool> Confirm(string title, string message)
+    {
+        var yes = new Button { Content = "Delete", Background = Brush.Parse("#a03434") };
+        var no = new Button { Content = "Cancel", IsCancel = true };
+        var done = new TaskCompletionSource<bool>();
+        var dialog = new Window
+        {
+            Title = title,
+            SizeToContent = SizeToContent.WidthAndHeight,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Background = Brush.Parse("#1d2027"),
+            Content = new StackPanel
+            {
+                Margin = new Avalonia.Thickness(18),
+                Spacing = 14,
+                Children =
+                {
+                    new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap, MaxWidth = 400 },
+                    new StackPanel
+                    {
+                        Orientation = Avalonia.Layout.Orientation.Horizontal, Spacing = 8,
+                        HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                        Children = { no, yes },
+                    },
+                },
+            },
+        };
+        yes.Click += (_, _) => { done.TrySetResult(true); dialog.Close(); };
+        no.Click += (_, _) => { done.TrySetResult(false); dialog.Close(); };
+        dialog.Closed += (_, _) => done.TrySetResult(false);
+        await dialog.ShowDialog(this);
+        return await done.Task;
+    }
+
+    private void OnClose(object? sender, RoutedEventArgs e) => Close();
+}

--- a/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
+++ b/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
@@ -191,7 +191,7 @@ public partial class MixerSetupWindow : Window
     }
 
     private const string FileLimitManual =
-        "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#58-channels-or-mixes-vanish-after-adding-one";
+        "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#open-files";
 
     private void OnFileLimitManual(object? sender, RoutedEventArgs e)
         => System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("xdg-open", FileLimitManual) { UseShellExecute = false });

--- a/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
+++ b/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
@@ -190,5 +190,16 @@ public partial class MixerSetupWindow : Window
         return await done.Task;
     }
 
+    private const string FileLimitManual =
+        "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#58-channels-or-mixes-vanish-after-adding-one";
+
+    private void OnFileLimitManual(object? sender, RoutedEventArgs e)
+        => System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("xdg-open", FileLimitManual) { UseShellExecute = false });
+
+    private async void OnRestartDaemon(object? sender, RoutedEventArgs e)
+    {
+        if (Vm is { } vm) await vm.DaemonRestart.RestartAsync();
+    }
+
     private void OnClose(object? sender, RoutedEventArgs e) => Close();
 }

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -524,6 +524,10 @@ public sealed class MainViewModel : ViewModelBase
     /// </summary>
     public bool RenamedSinceStart { get => _renamedSinceStart; private set => Set(ref _renamedSinceStart, value); }
 
+    private string _layoutWarning = "";
+    /// <summary>pipewire-pulse near its open-file limit, or empty; shown in the layout editor.</summary>
+    public string LayoutWarning { get => _layoutWarning; private set => Set(ref _layoutWarning, value); }
+
     // --- layout editing: the daemon answers after the new layout is saved ---
 
     public Task<string?> CreateChannel(string name) => Edit(_client.CreateChannelAsync(name));
@@ -943,9 +947,10 @@ public sealed class MainViewModel : ViewModelBase
 
     private void ApplyMixer(JsonNode? mixer)
     {
-        if (mixer is null) { HasMixer = false; RenamedSinceStart = false; return; }
+        if (mixer is null) { HasMixer = false; RenamedSinceStart = false; LayoutWarning = ""; return; }
         HasMixer = true;
         RenamedSinceStart = mixer["renamedSinceStart"]?.GetValue<bool>() ?? false;
+        LayoutWarning = mixer["layoutWarning"]?.GetValue<string>() ?? "";
         SoftLowCutHz = mixer["lowCutHz"]?.GetValue<int>() ?? 0;
         SoftClipGuardAvailable = mixer["softClipGuardAvailable"]?.GetValue<bool>() ?? false;
         SoftClipGuardError = mixer["softClipGuardError"]?.GetValue<string>();

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 using Avalonia.Threading;
 
 namespace OpenXLR.UI;
@@ -63,7 +64,7 @@ public sealed class MainViewModel : ViewModelBase
     // --- connection / device identity ---
 
     private bool _daemonConnected;
-    public bool DaemonConnected { get => _daemonConnected; private set { if (SetAndRaiseMismatch(ref _daemonConnected, value)) { Raise(nameof(StatusLine)); Raise(nameof(MixerPlaceholder)); } } }
+    public bool DaemonConnected { get => _daemonConnected; private set { if (SetAndRaiseMismatch(ref _daemonConnected, value)) { Raise(nameof(StatusLine)); Raise(nameof(MixerPlaceholder)); Raise(nameof(CanEditLayout)); } } }
 
     /// <summary>What the empty SUBMIXER tile says: the two reasons differ.</summary>
     public string MixerPlaceholder => !DaemonConnected
@@ -511,7 +512,48 @@ public sealed class MainViewModel : ViewModelBase
     public string OutputVolumeText => $"{_outputVolume * 100:0}%";
 
     private bool _hasMixer;
-    public bool HasMixer { get => _hasMixer; private set { if (Set(ref _hasMixer, value)) Raise(nameof(MixerPlaceholder)); } }
+    public bool HasMixer { get => _hasMixer; private set { if (Set(ref _hasMixer, value)) { Raise(nameof(MixerPlaceholder)); Raise(nameof(CanEditLayout)); } } }
+
+    /// <summary>The layout editor needs a live daemon with a built graph.</summary>
+    public bool CanEditLayout => DaemonConnected && HasMixer;
+
+    private bool _renamedSinceStart;
+    /// <summary>
+    /// A virtual microphone was renamed while the daemon runs. Other apps
+    /// keep listing the old device name until the daemon restarts.
+    /// </summary>
+    public bool RenamedSinceStart { get => _renamedSinceStart; private set => Set(ref _renamedSinceStart, value); }
+
+    // --- layout editing: the daemon answers after the new layout is saved ---
+
+    public Task<string?> CreateChannel(string name) => Edit(_client.CreateChannelAsync(name));
+    public Task<string?> RenameChannel(string id, string name) => Edit(_client.RenameChannelAsync(id, name));
+    public Task<string?> DeleteChannel(string id) => Edit(_client.DeleteChannelAsync(id));
+    public Task<string?> CreateMix(string name) => Edit(_client.CreateMixAsync(name));
+    public Task<string?> RenameMix(string id, string name) => Edit(_client.RenameMixAsync(id, name));
+    public Task<string?> DeleteMix(string id) => Edit(_client.DeleteMixAsync(id));
+
+    /// <summary>Move one editable channel or mix one step; the whole order is sent.</summary>
+    public Task<string?> MoveChannel(string id, int delta) => Reorder(id, delta, isMix: false);
+    public Task<string?> MoveMix(string id, int delta) => Reorder(id, delta, isMix: true);
+
+    private Task<string?> Reorder(string id, int delta, bool isMix)
+    {
+        List<string> channels = [.. Channels.Where(c => c.IsEditable).Select(c => c.Id)];
+        List<string> mixes = [.. Mixes.Where(m => m.IsEditable).Select(m => m.Id)];
+        List<string> list = isMix ? mixes : channels;
+        int from = list.IndexOf(id), to = from + delta;
+        if (from < 0 || to < 0 || to >= list.Count) return Task.FromResult<string?>(null);
+        (list[from], list[to]) = (list[to], list[from]);
+        return Edit(_client.SetLayoutOrderAsync(channels, mixes));
+    }
+
+    private async Task<string?> Edit(Task<string?> result)
+    {
+        string? error = await result;
+        if (error is not null) Status = error;
+        return error;
+    }
 
     private bool SetAndRaiseMismatch(ref bool field, bool value)
     {
@@ -862,16 +904,22 @@ public sealed class MainViewModel : ViewModelBase
                        s["active"]?.GetValue<bool>() ?? true,
                        s["running"]?.GetValue<bool>() ?? true));
         }
+        // Apps route to application channels only; "not managed" leaves them to the desktop.
+        List<ChannelChoice> choices = [.. Channels.Where(c => c.IsEditable).Select(c => new ChannelChoice(c.Id, c.Name)),
+            new ChannelChoice(AppStreamViewModel.Ignore, "Not managed")];
         // Update in place so an open dropdown is not closed by a state push.
         foreach (var f in fresh)
         {
             AppStreamViewModel? existing = Apps.FirstOrDefault(a =>
                 string.Equals(a.Identity, f.Identity, StringComparison.OrdinalIgnoreCase));
             if (existing is null)
-                Apps.Add(new AppStreamViewModel(_client, f.Identity, f.Label, [.. Channels.Select(c => c.Id), AppStreamViewModel.Ignore])
+                Apps.Add(new AppStreamViewModel(_client, f.Identity, f.Label, choices)
                     { ChannelId = f.Channel, Active = f.Active, Running = f.Running });
             else
+            {
+                existing.SyncChannels(choices);
                 existing.ApplyFromDaemon(f.Channel, f.Active, f.Running, f.Label);
+            }
         }
         for (int i = Apps.Count - 1; i >= 0; i--)
             if (!fresh.Any(f => string.Equals(f.Identity, Apps[i].Identity, StringComparison.OrdinalIgnoreCase))) Apps.RemoveAt(i);
@@ -895,8 +943,9 @@ public sealed class MainViewModel : ViewModelBase
 
     private void ApplyMixer(JsonNode? mixer)
     {
-        if (mixer is null) { HasMixer = false; return; }
+        if (mixer is null) { HasMixer = false; RenamedSinceStart = false; return; }
         HasMixer = true;
+        RenamedSinceStart = mixer["renamedSinceStart"]?.GetValue<bool>() ?? false;
         SoftLowCutHz = mixer["lowCutHz"]?.GetValue<int>() ?? 0;
         SoftClipGuardAvailable = mixer["softClipGuardAvailable"]?.GetValue<bool>() ?? false;
         SoftClipGuardError = mixer["softClipGuardError"]?.GetValue<string>();
@@ -927,10 +976,10 @@ public sealed class MainViewModel : ViewModelBase
 
         if (mixer["channels"] is JsonArray channels)
         {
+            string[] mixIds = [.. Mixes.Select(m => m.Id)];
             SyncList(Channels, channels, c => c["id"]!.GetValue<string>(),
-                (c, vm) => vm.ApplyFromDaemon(c),
-                c => new ChannelViewModel(_client, c["id"]!.GetValue<string>(), c["name"]!.GetValue<string>(),
-                    [.. Mixes.Select(m => m.Id)]));
+                (c, vm) => { vm.SyncSends(mixIds); vm.ApplyFromDaemon(c); },
+                c => new ChannelViewModel(_client, c["id"]!.GetValue<string>(), c["name"]!.GetValue<string>(), mixIds));
             // Send rows carry the mix's name, not its id.
             foreach (ChannelViewModel c in Channels)
                 foreach (SendViewModel send in c.Sends)
@@ -982,17 +1031,40 @@ public sealed class AppStreamViewModel : ViewModelBase
     private readonly DaemonClient _client;
     private bool _applying;
 
-    public AppStreamViewModel(DaemonClient client, string identity, string label, IReadOnlyList<string> channels)
+    public AppStreamViewModel(DaemonClient client, string identity, string label, IReadOnlyList<ChannelChoice> channels)
     {
         _client = client; Identity = identity; _label = label;
-        foreach (string c in channels) Channels.Add(c);
+        foreach (ChannelChoice c in channels) Channels.Add(c);
     }
 
     public string Identity { get; }
 
     private string _label;
     public string Label { get => _label; private set => Set(ref _label, value); }
-    public ObservableCollection<string> Channels { get; } = [];
+
+    /// <summary>The application channels by name, plus "not managed".</summary>
+    public ObservableCollection<ChannelChoice> Channels { get; } = [];
+
+    /// <summary>Replace the choices when the layout changed; the selection is re-pointed by id.</summary>
+    public void SyncChannels(IReadOnlyList<ChannelChoice> channels)
+    {
+        if (Channels.Select(c => (c.Id, c.Name)).SequenceEqual(channels.Select(c => (c.Id, c.Name)))) return;
+        _applying = true;
+        try
+        {
+            Channels.Clear();
+            foreach (ChannelChoice c in channels) Channels.Add(c);
+            Raise(nameof(SelectedChannel));
+        }
+        finally { _applying = false; }
+    }
+
+    /// <summary>The picker's selection, mapped onto <see cref="ChannelId"/>.</summary>
+    public ChannelChoice? SelectedChannel
+    {
+        get => Channels.FirstOrDefault(c => c.Id == _channelId);
+        set { if (value is not null) ChannelId = value.Id; }
+    }
 
     private bool _active = true;
     public bool Active
@@ -1015,7 +1087,14 @@ public sealed class AppStreamViewModel : ViewModelBase
     public string ChannelId
     {
         get => _channelId;
-        set { if (Set(ref _channelId, value) && !_applying && value.Length > 0) _ = _client.AssignAppAsync(Identity, value); }
+        set
+        {
+            if (Set(ref _channelId, value))
+            {
+                Raise(nameof(SelectedChannel));
+                if (!_applying && value.Length > 0) _ = _client.AssignAppAsync(Identity, value);
+            }
+        }
     }
 
     public void ApplyFromDaemon(string channelId, bool active, bool running, string? label = null)
@@ -1033,6 +1112,12 @@ public sealed class AppStreamViewModel : ViewModelBase
     public string StatusText => Active ? "playing" : Running ? "running" : "not running";
 
     public void Forget() => _ = _client.ForgetAppAsync(Identity);
+}
+
+/// <summary>An application channel as a picker entry: stable id, current name.</summary>
+public sealed record ChannelChoice(string Id, string Name)
+{
+    public override string ToString() => Name;
 }
 
 /// <summary>One selectable sink or source. Own nodes are OpenXLR's own.</summary>
@@ -1120,12 +1205,21 @@ public sealed class MixViewModel : ViewModelBase, IHasId
 
     public MixViewModel(DaemonClient client, string id, string name)
     {
-        _client = client; Id = id; Name = name;
+        _client = client; Id = id; _name = name;
         Inserts = new InsertsViewModel(client, $"mix:{id}", channels: 2, title: $"{name} mix");
     }
 
     public string Id { get; }
-    public string Name { get; }
+
+    private string _name;
+    /// <summary>Display name; the daemon renames virtual microphones live.</summary>
+    public string Name { get => _name; set => Set(ref _name, value); }
+
+    /// <summary>Editable: a virtual microphone. Monitors and Aux are structural.</summary>
+    public bool IsEditable => Kind == "virtualMic";
+
+    /// <summary>What a structural mix is, for the layout editor.</summary>
+    public string KindLabel => Kind switch { "monitor" => "monitor mix", "auxPort" => "USB Aux port", _ => "" };
 
     /// <summary>This mix's stereo plugin insert chain.</summary>
     public InsertsViewModel Inserts { get; }
@@ -1133,8 +1227,9 @@ public sealed class MixViewModel : ViewModelBase, IHasId
     private bool _visible = true;
     public bool Visible { get => _visible; set => Set(ref _visible, value); }
 
+    private string _kind = "monitor";
     /// <summary>"monitor", "virtualMic" or "auxPort", as the daemon reports it.</summary>
-    public string Kind { get; set; } = "monitor";
+    public string Kind { get => _kind; set { if (Set(ref _kind, value)) { Raise(nameof(IsEditable)); Raise(nameof(KindLabel)); } } }
 
     private double _volume = 1.0;
     public double Volume
@@ -1180,6 +1275,7 @@ public sealed class MixViewModel : ViewModelBase, IHasId
                 Volume = n["volume"]?.GetValue<double>() ?? 1.0;
             Muted = n["muted"]?.GetValue<bool>() ?? false;
             Kind = n["kind"]?.GetValue<string>() ?? Kind;
+            if (n["name"]?.GetValue<string>() is { Length: > 0 } name) Name = name;
         }
         finally { _applying = false; }
     }
@@ -1197,13 +1293,32 @@ public sealed class ChannelViewModel : ViewModelBase, IHasId
 {
     public ChannelViewModel(DaemonClient client, string id, string name, IReadOnlyList<string> mixIds)
     {
-        Id = id; Name = name;
+        _client = client; Id = id; _name = name;
         foreach (string mixId in mixIds) Sends.Add(new SendViewModel(client, id, mixId));
     }
 
+    private readonly DaemonClient _client;
     public string Id { get; }
-    public string Name { get; }
+
+    private string _name;
+    /// <summary>Display name; the daemon renames application channels live.</summary>
+    public string Name { get => _name; set => Set(ref _name, value); }
+
+    private bool _isHardware;
+    /// <summary>A hardware input (XLR 1, XLR 2, Aux In): structural, not editable.</summary>
+    public bool IsHardware { get => _isHardware; set { if (Set(ref _isHardware, value)) Raise(nameof(IsEditable)); } }
+    public bool IsEditable => !IsHardware;
+
     public ObservableCollection<SendViewModel> Sends { get; } = [];
+
+    /// <summary>Keep one send per mix as mixes come and go.</summary>
+    public void SyncSends(IReadOnlyList<string> mixIds)
+    {
+        for (int i = Sends.Count - 1; i >= 0; i--)
+            if (!mixIds.Contains(Sends[i].MixId)) Sends.RemoveAt(i);
+        foreach (string mixId in mixIds)
+            if (Sends.All(s => s.MixId != mixId)) Sends.Add(new SendViewModel(_client, Id, mixId));
+    }
 
     private bool _visible = true;
     public bool Visible { get => _visible; set => Set(ref _visible, value); }
@@ -1215,6 +1330,8 @@ public sealed class ChannelViewModel : ViewModelBase, IHasId
 
     public void ApplyFromDaemon(JsonNode n)
     {
+        if (n["name"]?.GetValue<string>() is { Length: > 0 } name) Name = name;
+        IsHardware = n["hardware"]?.GetValue<bool>() ?? false;
         var muted = new HashSet<string>();
         if (n["mutedIn"] is JsonArray arr)
             foreach (JsonNode? m in arr) if (m is not null) muted.Add(m.GetValue<string>());


### PR DESCRIPTION
Completes the editable layout on top of #33, #34 and #35: every operation the roadmap lists, from the window and the API, with the same contract throughout. A command is acknowledged only after the new layout is saved; a failed write restores the previous layout and answers with an error; no node that carries audio for an untouched channel or mix is rebuilt.

**Daemon**
- `renameChannel`, `deleteChannel`, `createMix`, `renameMix`, `deleteMix` join `createChannel` and `setLayoutOrder`. A new channel starts muted in every mix; a new mix receives nothing until a send is opened.
- The channel combines feed the mix sinks by name pattern (`slaves=~OpenXLR_mix_`), so a new virtual microphone grows its sends in every combine on its own and a removed one drops them. Verified on PipeWire 1.6.8.
- Renaming a channel reloads its sink under the new name and puts its streams back. Renaming a mix changes the name in OpenXLR only: reloading a capture device throws the apps recording from it onto another source (verified with pw-record), so the PipeWire description stays until the daemon restarts and the state carries `renamedSinceStart`.
- Any command may carry a `requestId`; it is answered with `commandResult {requestId, error}` after the state that reflects the outcome.
- pipewire-pulse inherits systemd's 1024 open-file soft limit. The default graph uses about 840 descriptors, a mix costs 118 and a channel 74, and past the limit the server drops combine modules at random (five channel sinks vanished in a test). The daemon now refuses an addition without headroom, the state warns at three quarters, and the packages install a drop-in under `pipewire-pulse.service.d` raising the limit to 65536 (deb, rpm, Nix module; the AUR PKGBUILD follows at release).

**Window**
- Edit layout in the SUBMIXER card: add, rename, move up and down, delete for application channels and virtual microphones, with the structural nodes listed but fixed. Every action waits for the daemon's answer.
- App pickers show channel names and follow the layout; a restart hint appears after a mix rename.

**Docs**: api.md, mixer-layout.md, manual 3.11 and 5.8, features, roadmap.

**Verification**: 209 tests. Live pass on this desk against the running daemon: create a channel with muted legs, route a playing stream to it, rename it and see the stream come back, create a mix and see every combine grow a muted leg, rename, reorder, the rejections, delete the mix and the channel with the stream landing on the first remaining channel, settings file clean, and the open-file guard refusing a mix that would not fit. The editor window compiles with compiled bindings but was not exercised by hand.
