### PR TITLE
Daemon: rebuild the graph after a pipewire-pulse restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,29 +245,28 @@ work.
 
 Code:
 
-- [Carina Schoppe](https://github.com/CarinaSchoppe): routing and device
-  control hardening, transactional graph changes, the bounded WebSocket
-  send queue, diagnostics redaction, systemd sandboxing, the xUnit test
-  project and the CI workflow ([#4](https://github.com/emaspa/openxlr/pull/4));
-  verified stream moves ([#12](https://github.com/emaspa/openxlr/pull/12)),
-  multi-batch `pw-dump` parsing ([#13](https://github.com/emaspa/openxlr/pull/13)),
-  the hardened window daemon client ([#14](https://github.com/emaspa/openxlr/pull/14)),
-  coalesced state broadcasts ([#15](https://github.com/emaspa/openxlr/pull/15)),
-  the Restart daemon button ([#16](https://github.com/emaspa/openxlr/pull/16))
-  and the API document fix ([#17](https://github.com/emaspa/openxlr/pull/17));
-  the progress-gated systemd watchdog ([#18](https://github.com/emaspa/openxlr/pull/18))
-  and the opt-in update notice ([#23](https://github.com/emaspa/openxlr/pull/23));
-  the versioned HTTP API on the session token ([#24](https://github.com/emaspa/openxlr/pull/24),
-  [#32](https://github.com/emaspa/openxlr/pull/32))
-  and the OpenDeck choices generated from daemon state ([#25](https://github.com/emaspa/openxlr/pull/25));
-  the saved mixer layout ([#33](https://github.com/emaspa/openxlr/pull/33)),
-  live application-channel creation ([#34](https://github.com/emaspa/openxlr/pull/34))
-  and the saved channel and mix order ([#35](https://github.com/emaspa/openxlr/pull/35)),
-  the first pieces of the editable layout;
-  the native LV2 plugin editors ([#19](https://github.com/emaspa/openxlr/pull/19))
-  and the editable mixer layout ([#22](https://github.com/emaspa/openxlr/pull/22))
-  in review, split out of her larger proposal
-  ([#10](https://github.com/emaspa/openxlr/pull/10)).
+- [Carina Schoppe](https://github.com/CarinaSchoppe) laid much of the
+  daemon's hardening: routing and device control that fail safely,
+  transactional graph changes, the bounded WebSocket send queue,
+  diagnostics redaction, systemd sandboxing, the xUnit test project and
+  the CI workflow ([#4](https://github.com/emaspa/openxlr/pull/4)), then
+  verified stream moves, multi-batch `pw-dump` parsing, the hardened
+  window client, coalesced state broadcasts and the Restart daemon button
+  ([#12](https://github.com/emaspa/openxlr/pull/12) to
+  [#16](https://github.com/emaspa/openxlr/pull/16)), the progress-gated
+  systemd watchdog ([#18](https://github.com/emaspa/openxlr/pull/18)) and
+  the opt-in update notice ([#23](https://github.com/emaspa/openxlr/pull/23)).
+  She built the versioned HTTP API on the session token
+  ([#24](https://github.com/emaspa/openxlr/pull/24),
+  [#32](https://github.com/emaspa/openxlr/pull/32)), the OpenDeck choices
+  generated from daemon state ([#25](https://github.com/emaspa/openxlr/pull/25)),
+  and the first pieces of the editable layout: the saved layout format,
+  live channel creation and the saved order
+  ([#33](https://github.com/emaspa/openxlr/pull/33) to
+  [#35](https://github.com/emaspa/openxlr/pull/35)), all split out of her
+  larger proposal ([#10](https://github.com/emaspa/openxlr/pull/10)). Her
+  native LV2 plugin editors ([#19](https://github.com/emaspa/openxlr/pull/19))
+  are in review.
 - [Michael Brooks](https://github.com/Michael-Brooks): the stream-sweep
   starvation fix ([#7](https://github.com/emaspa/openxlr/pull/7)) and the
   diagnosis that led to it.

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,6 +9,7 @@ Start the mixer:   openxlr   (or from your application menu)
 The package raises pipewire-pulse's open-file limit (a drop-in under
 /usr/lib/systemd/user/pipewire-pulse.service.d); it applies at your next
 login, or now with:  systemctl --user daemon-reload; systemctl --user restart pipewire-pulse
+(the daemon rebuilds its graph by itself after that restart)
 Stream Deck via OpenDeck:
   cp -r /usr/share/openxlr/com.emaspa.openxlr.sdPlugin ~/.config/opendeck/plugins/
 MSG

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -470,8 +470,10 @@ systemctl --user daemon-reload
 systemctl --user restart pipewire-pulse
 ```
 
-Restarting pipewire-pulse reconnects every PulseAudio client for a moment.
-Check with `systemctl --user show pipewire-pulse -p LimitNOFILESoft`.
+Restarting pipewire-pulse reconnects every PulseAudio client for a moment
+and takes OpenXLR's nodes with it; the daemon notices within two seconds
+and restarts itself to rebuild the graph from the saved layout. Check the
+limit afterwards with `systemctl --user show pipewire-pulse -p LimitNOFILESoft`.
 A source checkout without the package can put the same two lines into
 `~/.config/systemd/user/pipewire-pulse.service.d/openxlr.conf` by hand.
 

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -1707,6 +1707,35 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         lock (_gate) TearDownLocked();
     }
 
+    /// <summary>
+    /// Whether the built graph is still published: false once pipewire-pulse
+    /// restarted underneath the daemon and took every module with it. Null
+    /// when the question cannot be answered right now.
+    /// </summary>
+    public bool? GraphPresent()
+    {
+        lock (_gate)
+        {
+            if (!_built) return null;
+            MixDefinition? probe = _config.Mixes.FirstOrDefault();
+            return probe is null ? null : _pw.SinkExists(probe.SinkName);
+        }
+    }
+
+    /// <summary>
+    /// Forget a graph that is already gone. The holder processes are stopped
+    /// and the bookkeeping cleared, but no module is unloaded: their ids now
+    /// belong to whatever loaded after the restart.
+    /// </summary>
+    public void ForgetGraph()
+    {
+        lock (_gate)
+        {
+            _pw.ForgetModules();
+            TearDownLocked();
+        }
+    }
+
     public void Dispose()
     {
         TearDown();

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -300,6 +300,21 @@ public sealed class PipeWireAdapter
         return null;
     }
 
+    /// <summary>Whether a sink of this name is published right now (null when pactl is unavailable).</summary>
+    public bool? SinkExists(string sinkName)
+    {
+        string? sinks = TryRun("pactl", "list", "sinks", "short");
+        if (sinks is null) return null;
+        return sinks.Split('\n').Any(line => line.Split('\t') is { Length: >= 2 } columns && columns[1] == sinkName);
+    }
+
+    /// <summary>
+    /// Drop the module bookkeeping without unloading anything: after a
+    /// pipewire-pulse restart the modules are gone and their ids are being
+    /// handed to other clients, so unloading them would hit someone else.
+    /// </summary>
+    public void ForgetModules() => _modules.Clear();
+
     /// <summary>Like <see cref="FindCombineLegs"/>, but null when pactl fails or stalls.</summary>
     public IReadOnlyDictionary<string, int>? TryFindCombineLegs(uint combineModule)
     {

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -40,12 +40,41 @@ public sealed class MixerService : IHostedService, IDisposable
     private int _sweepRunning;
     private string? _lastSweepError;
 
-    public MixerService(ILogger<MixerService> log, IConfiguration config, DeviceManager devices)
+    private readonly IHostApplicationLifetime? _lifetime;
+    private int _graphMissing;
+
+    public MixerService(ILogger<MixerService> log, IConfiguration config, DeviceManager devices,
+        IHostApplicationLifetime? lifetime = null)
     {
         _log = log;
         _config = config;
         _devices = devices;
+        _lifetime = lifetime;
         _mixer = new(new PipeWireAdapter(_progress.Mark));
+    }
+
+    /// <summary>
+    /// pipewire-pulse restarted underneath the daemon: every module it hosted
+    /// is gone and the module ids are being reused by other clients. Nothing
+    /// can be unloaded or healed piecemeal, so the graph is forgotten and the
+    /// daemon asks to be started afresh; systemd brings it back in seconds
+    /// with the saved layout. Two consecutive sightings, so a momentary pactl
+    /// hiccup does not trigger it.
+    /// </summary>
+    private bool GraphLost()
+    {
+        if (_mixer.GraphPresent() is not false) { _graphMissing = 0; return false; }
+        if (++_graphMissing < 2) return false;
+        _log.LogWarning("the submixer graph is gone (pipewire-pulse restarted?); restarting the daemon to rebuild it");
+        lock (_saveGate)
+        {
+            if (_saveDirty && _mixer.ExportSettings().Save() is string err) _log.LogWarning("settings not saved before the restart: {err}", err);
+            _saveDirty = false;
+        }
+        _mixer.ForgetGraph();
+        RestartRequest.Ask(RestartRequest.TemporaryFailure);
+        _lifetime?.StopApplication();
+        return true;
     }
 
     /// <summary>
@@ -180,6 +209,7 @@ public sealed class MixerService : IHostedService, IDisposable
                 if (Interlocked.CompareExchange(ref _sweepRunning, 1, 0) != 0) return;
                 try
                 {
+                    if (GraphLost()) return;
                     // Channel feeds follow the actively driven interface; the
                     // node name contains the model with underscores for spaces.
                     _mixer.SetInputDeviceHint(

--- a/src/OpenXLR.Daemon/Program.cs
+++ b/src/OpenXLR.Daemon/Program.cs
@@ -111,4 +111,4 @@ catch (IOException ex) when (ex.InnerException is AddressInUseException)
     app.Logger.LogError("port {Port} was taken between probe and bind; exiting for systemd to retry", ApiPort);
     return 75;
 }
-return 0;
+return RestartRequest.ExitCode;   // 0, or a service asked to be started afresh

--- a/src/OpenXLR.Daemon/RestartRequest.cs
+++ b/src/OpenXLR.Daemon/RestartRequest.cs
@@ -1,0 +1,18 @@
+namespace OpenXLR.Daemon;
+
+/// <summary>
+/// A service that wants the whole daemon started afresh (the audio server
+/// restarted underneath it) records the exit code here and stops the host;
+/// Program returns it so systemd's Restart=on-failure brings the daemon back.
+/// </summary>
+internal static class RestartRequest
+{
+    /// <summary>EX_TEMPFAIL: a clean exit that systemd retries.</summary>
+    public const int TemporaryFailure = 75;
+
+    private static int _exitCode;
+
+    public static int ExitCode => Volatile.Read(ref _exitCode);
+
+    public static void Ask(int exitCode) => Volatile.Write(ref _exitCode, exitCode);
+}

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -524,12 +524,15 @@
     <!-- mixer -->
     <Border Classes="card">
       <Expander Name="SubmixerTile" Classes="tile" Theme="{StaticResource TileExpanderTheme}" IsExpanded="True">
-        <Expander.Header><TextBlock Text="SUBMIXER" Classes="h"/></Expander.Header>
+        <Expander.Header>
+          <StackPanel Orientation="Horizontal" Spacing="10">
+            <TextBlock Text="SUBMIXER" Classes="h" VerticalAlignment="Center"/>
+            <Button Content="Edit layout…" Padding="8,1" FontSize="11" MinHeight="0" VerticalAlignment="Center"
+                    IsVisible="{Binding HasMixer}" IsEnabled="{Binding CanEditLayout}" Click="OnEditLayout"
+                    ToolTip.Tip="Add, rename, reorder and remove application channels and virtual microphones while audio plays"/>
+          </StackPanel>
+        </Expander.Header>
       <DockPanel>
-        <Button DockPanel.Dock="Top" Content="Edit layout…" Padding="12,4" Margin="0,0,0,8"
-                HorizontalAlignment="Right" IsVisible="{Binding HasMixer}" IsEnabled="{Binding CanEditLayout}"
-                Click="OnEditLayout"
-                ToolTip.Tip="Add, rename, reorder and remove application channels and virtual microphones while audio plays"/>
         <TextBlock DockPanel.Dock="Top" Text="{Binding MixerPlaceholder}" TextWrapping="Wrap"
                    Foreground="#6b7285" IsVisible="{Binding !HasMixer}"/>
 


### PR DESCRIPTION
A pipewire-pulse restart takes every OpenXLR module with it, and the ids are reused by other clients, so nothing can be unloaded or healed in place. The sweep now spots the missing graph on two consecutive checks, saves pending settings, forgets the graph without unloading anything, and exits with 75 so systemd starts the daemon afresh with the saved layout. The manual's open-file section and the Debian post-install note say so.

Verified on this desk: after `systemctl --user restart pipewire-pulse` the daemon logged the loss two seconds later, systemd restarted it, and all nine channel sinks and five mix sinks were back within six seconds. 209 tests.