### PR TITLE
Evaluation batch: RPM files list, fail-closed sends, helper ownership, results for every command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: dotnet restore src/OpenXLR.slnx --locked-mode
 
       - name: Build
-        run: dotnet build src/OpenXLR.slnx -c Release --no-restore
+        run: dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror
 
       - name: Test
         run: dotnet test src/OpenXLR.slnx -c Release --no-build
@@ -36,6 +36,8 @@ jobs:
         run: |
           node --check plugin/com.emaspa.openxlr.sdPlugin/plugin.mjs
           python3 -m json.tool plugin/com.emaspa.openxlr.sdPlugin/manifest.json >/dev/null
+          python3 -m json.tool docs/openapi-v1.json >/dev/null
+          node --test plugin/tests/
 
       - name: Lint shell scripts
         run: shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           node --check plugin/com.emaspa.openxlr.sdPlugin/plugin.mjs
           python3 -m json.tool plugin/com.emaspa.openxlr.sdPlugin/manifest.json >/dev/null
           python3 -m json.tool docs/openapi-v1.json >/dev/null
-          node --test plugin/tests/
+          node --test plugin/tests/*.test.mjs
 
       - name: Lint shell scripts
         run: shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: |
           dotnet restore src/OpenXLR.slnx --locked-mode
-          dotnet build src/OpenXLR.slnx -c Release --no-restore
+          dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror
           dotnet test src/OpenXLR.slnx -c Release --no-build
 
       - name: Build package

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run tests
         run: |
           dotnet restore src/OpenXLR.slnx --locked-mode
-          dotnet build src/OpenXLR.slnx -c Release --no-restore
+          dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror
           dotnet test src/OpenXLR.slnx -c Release --no-build
 
       - name: Build package

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,7 @@ Messages from the daemon, each a JSON object with a `type` field:
 Commands are single JSON objects with a `cmd` field. The layout commands
 (`createChannel` through `setLayoutOrder` below) succeed only after the
 new layout is written to `mixer.json`; a failed write restores the previous
-layout and answers with an error. Any command may carry a `requestId`; the
+layout and answers with an error. Any command may carry a `requestId` of up to 64 characters; the
 daemon then answers with a `commandResult {requestId, error}` message after
 the state that reflects the outcome (`error` is null on success) instead of
 a bare `error` message, so an editor can wait for the acknowledgement:

--- a/docs/openapi-v1.json
+++ b/docs/openapi-v1.json
@@ -1,31 +1,183 @@
 {
   "openapi": "3.0.3",
-  "info": {"title": "OpenXLR local API", "version": "1"},
-  "servers": [{"url": "http://127.0.0.1:37890"}],
-  "security": [{"localToken": []}],
+  "info": {
+    "title": "OpenXLR local API",
+    "version": "1"
+  },
+  "servers": [
+    {
+      "url": "http://127.0.0.1:37890"
+    }
+  ],
+  "security": [
+    {
+      "localToken": []
+    }
+  ],
   "paths": {
-    "/healthz": {"get": {"security": [], "responses": {"200": {"description": "Process alive, not hardware readiness"}}}},
-    "/api/v1": {"get": {"responses": {"200": {"description": "Endpoint discovery"}, "401": {"description": "Credential required"}}}},
-    "/api/v1/state": {"get": {"responses": {"200": {"description": "Combined state message"}, "401": {"description": "Credential required"}}}},
-    "/api/v1/plugins": {"get": {"responses": {"200": {"description": "v1 result containing plugins message"}, "401": {"description": "Credential required"}}}},
-    "/api/v1/commands": {"post": {
-      "description": "Execute the existing cmd protocol. Foreign browser origins are rejected. Maximum UTF-8 body size is 65536 bytes, including chunked requests.",
-      "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["cmd"], "properties": {"cmd": {"type": "string"}}, "additionalProperties": true}}}},
-      "responses": {
-        "200": {"description": "Executed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CommandResult"}}}},
-        "400": {"description": "Invalid or rejected command", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CommandResult"}}}},
-        "401": {"description": "Credential required"}, "403": {"description": "Foreign Origin"},
-        "408": {"description": "Body-read deadline"}, "413": {"description": "Body too large"},
-        "415": {"description": "UTF-8 application/json required"}, "429": {"description": "Budget exhausted or command in flight"}
+    "/healthz": {
+      "get": {
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Process alive, not hardware readiness"
+          }
+        }
       }
-    }},
-    "/api/v1/events": {"get": {"description": "Authenticated WebSocket upgrade; the existing state, meters and command protocol", "responses": {"101": {"description": "WebSocket connected"}, "400": {"description": "Upgrade required"}, "401": {"description": "Credential required"}}}}
+    },
+    "/api/v1": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Endpoint discovery"
+          },
+          "401": {
+            "description": "Credential required"
+          }
+        }
+      }
+    },
+    "/api/v1/state": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Combined state message"
+          },
+          "401": {
+            "description": "Credential required"
+          }
+        }
+      }
+    },
+    "/api/v1/plugins": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "v1 result containing plugins message"
+          },
+          "401": {
+            "description": "Credential required"
+          }
+        }
+      }
+    },
+    "/api/v1/commands": {
+      "post": {
+        "description": "Execute the existing cmd protocol. Foreign browser origins are rejected. Maximum UTF-8 body size is 65536 bytes, including chunked requests.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "cmd"
+                ],
+                "properties": {
+                  "cmd": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Executed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or rejected command",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Credential required"
+          },
+          "403": {
+            "description": "Foreign Origin"
+          },
+          "408": {
+            "description": "Body-read deadline"
+          },
+          "413": {
+            "description": "Body too large"
+          },
+          "415": {
+            "description": "UTF-8 application/json required"
+          },
+          "429": {
+            "description": "Budget exhausted or command in flight"
+          }
+        }
+      }
+    },
+    "/api/v1/events": {
+      "get": {
+        "description": "WebSocket upgrade with no Authorization header. The socket is authenticated by its first frame, {\"cmd\":\"auth\",\"token\":\"<token>\"}, within five seconds; then the existing state, meters and command protocol apply. The token is the same one the HTTP routes take as a bearer.",
+        "responses": {
+          "101": {
+            "description": "WebSocket connected"
+          },
+          "400": {
+            "description": "Upgrade required"
+          },
+          "401": {
+            "description": "Credential required"
+          }
+        },
+        "security": []
+      }
+    }
   },
   "components": {
-    "securitySchemes": {"localToken": {"type": "http", "scheme": "bearer", "description": "Existing per-session token from OpenXlrPaths.TokenPath"}},
-    "schemas": {"CommandResult": {"type": "object", "required": ["apiVersion", "ok", "messages"], "properties": {
-      "apiVersion": {"type": "string", "enum": ["1"]}, "ok": {"type": "boolean"},
-      "messages": {"type": "array", "items": {"type": "object", "additionalProperties": true}}
-    }}}
+    "securitySchemes": {
+      "localToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Existing per-session token from OpenXlrPaths.TokenPath"
+      }
+    },
+    "schemas": {
+      "CommandResult": {
+        "type": "object",
+        "required": [
+          "apiVersion",
+          "ok",
+          "messages"
+        ],
+        "properties": {
+          "apiVersion": {
+            "type": "string",
+            "enum": [
+              "1"
+            ]
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,9 +149,10 @@ host mechanism stable than two half-finished ones.
   every second; the daemon should subscribe to registry events (pw-mon,
   or libpipewire directly) and keep an incremental view, which is what
   finally brings its memory and CPU to what a control daemon should use.
-- [ ] Client authentication for the control API (a per-user secret), on
-  top of the origin check that exists, before any API is documented as
-  a public contract.
+- [x] Client authentication for the control API: a per-session token the
+  daemon writes at start, presented by every client, on top of the
+  origin check. Still open: binding the API to a Unix socket with peer
+  credentials instead of a loopback port, so no token file is needed.
 
 ## Next: distribution
 

--- a/packaging/rpm/openxlr.spec
+++ b/packaging/rpm/openxlr.spec
@@ -91,7 +91,6 @@ sed 's|^ExecStart=.*|ExecStart=%{_bindir}/openxlr-daemon|' \
     packaging/openxlr-daemon.service > openxlr-daemon.service
 install -Dm644 openxlr-daemon.service \
     %{buildroot}%{_userunitdir}/openxlr-daemon.service
-%{_userunitdir}/pipewire-pulse.service.d/openxlr.conf
 install -Dm644 packaging/pipewire-pulse-openxlr.conf \
     %{buildroot}%{_userunitdir}/pipewire-pulse.service.d/openxlr.conf
 
@@ -131,6 +130,7 @@ MSG
 %{_datadir}/wireplumber/wireplumber.conf.d/50-xlr-dock-capture-hold.conf
 %{_datadir}/wireplumber/wireplumber.conf.d/51-openxlr-pro-raw-names.conf
 %{_userunitdir}/openxlr-daemon.service
+%{_userunitdir}/pipewire-pulse.service.d/openxlr.conf
 %{_datadir}/applications/openxlr.desktop
 %{_datadir}/icons/hicolor/*/apps/openxlr.*
 %{_datadir}/openxlr/

--- a/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/dial.html
+++ b/plugin/com.emaspa.openxlr.sdPlugin/propertyInspector/dial.html
@@ -53,7 +53,7 @@
       ws = new WebSocket("ws://localhost:" + inPort);
       ws.onopen = () => {
         ws.send(JSON.stringify({ event: inRegisterEvent, uuid: piUuid }));
-        const g = settings.cycleGesture ?? "tap";
+        const g = ["tap", "push"].includes(settings.cycleGesture) ? settings.cycleGesture : "tap";
         document.querySelector('input[name="gesture"][value="' + g + '"]').checked = true;
         for (const r of document.querySelectorAll('input[name="gesture"]'))
           r.addEventListener("change", () => {

--- a/src/OpenXLR.Core/Devices/IAudioDevice.cs
+++ b/src/OpenXLR.Core/Devices/IAudioDevice.cs
@@ -8,7 +8,7 @@ namespace OpenXLR.Core.Devices;
 /// <see cref="Capabilities"/> tells clients which fields a given device honours,
 /// so setters for unsupported controls are simply no-ops.
 /// </summary>
-public interface IAudioDevice
+public interface IAudioDevice : IDisposable
 {
     /// <summary>Stable identity of the device model (for UI labels, logs, plugin routing).</summary>
     DeviceInfo Info { get; }

--- a/src/OpenXLR.Core/Devices/WaveXlrMk1Device.cs
+++ b/src/OpenXLR.Core/Devices/WaveXlrMk1Device.cs
@@ -66,6 +66,9 @@ public abstract class Mk1ClassProtocolDevice : IAudioDevice
 
     public bool Connected => _usb.IsOpen;
 
+    /// <summary>Release the USB transport and its helper process.</summary>
+    public void Dispose() => _usb.Dispose();
+
     public void Connect()
     {
         if (!_usb.Open(VendorId, Info.ProductId))

--- a/src/OpenXLR.Core/Devices/WaveXlrMk2Device.cs
+++ b/src/OpenXLR.Core/Devices/WaveXlrMk2Device.cs
@@ -99,6 +99,9 @@ public class WaveXlrMk2Device : IAudioDevice
 
     public bool Connected => _usb.IsOpen;
 
+    /// <summary>Release the USB transport and its helper process.</summary>
+    public void Dispose() => _usb.Dispose();
+
     public void Connect()
     {
         if (!_usb.Open(VendorId, Info.ProductId))

--- a/src/OpenXLR.Core/Devices/XlrDockDevice.cs
+++ b/src/OpenXLR.Core/Devices/XlrDockDevice.cs
@@ -73,6 +73,9 @@ public sealed class XlrDockDevice : IAudioDevice
 
     public bool Connected => _card >= 0;
 
+    /// <summary>Release the USB transport and its helper process.</summary>
+    public void Dispose() => _usb.Dispose();
+
     public void Connect()
     {
         foreach (string dir in Directory.EnumerateDirectories("/proc/asound").OrderBy(d => d))

--- a/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
@@ -75,7 +75,8 @@ public sealed partial class Mixer
                     _levels[cell] = 1.0;
                     _muted.Add(cell);
                 }
-                WaitForLegsLocked([module], _config.Mixes.Select(m => m.SinkName));
+                if (!WaitForLegsLocked([module], _config.Mixes.Select(m => m.SinkName)))
+                    throw new InvalidOperationException("the channel's sends did not come up within 3 s; nothing was changed");
                 foreach (MixDefinition mix in _config.Mixes) ApplyCellLocked(id, mix.Id);
                 PersistLocked(persist);
             }
@@ -214,7 +215,8 @@ public sealed partial class Mixer
                     _levels[cell] = 1.0;
                     _muted.Add(cell);
                 }
-                WaitForLegsLocked([.. _combineModules.Values], [mix.SinkName]);
+                if (!WaitForLegsLocked([.. _combineModules.Values], [mix.SinkName]))
+                    throw new InvalidOperationException("not every channel grew a send into the new mix within 3 s; nothing was changed");
                 foreach (ChannelDefinition ch in _config.Channels) ApplyCellLocked(ch.Id, id);
                 _postModules[id] = _pw.CreateNullSink(mix.PostSinkName, $"OpenXLR {name} (post)");
                 _virtualMicModules[id] = _pw.CreateVirtualMic(mix.VirtualMicName, $"{mix.PostSinkName}.monitor", $"OpenXLR {name}");
@@ -376,7 +378,7 @@ public sealed partial class Mixer
     private void FinishReloadLocked(ChannelDefinition channel, uint module, IEnumerable<int> streamSerials)
     {
         _combineModules[channel.Id] = module;
-        WaitForLegsLocked([module], _config.Mixes.Select(m => m.SinkName));
+        bool complete = WaitForLegsLocked([module], _config.Mixes.Select(m => m.SinkName));
         foreach (MixDefinition mix in _config.Mixes) ApplyCellLocked(channel.Id, mix.Id);
         foreach (int serial in streamSerials)
         {
@@ -384,25 +386,32 @@ public sealed partial class Mixer
             catch (InvalidOperationException) { /* the stream ended meanwhile */ }
         }
         _meters.Add($"ch:{channel.Id}", channel.SinkName);
+        if (!complete)
+            throw new InvalidOperationException(
+                "the name was saved, but not every send of the reloaded channel came up within 3 s; check its sends, or restart the daemon");
     }
 
     /// <summary>
     /// A combine loaded with a name pattern grows its legs as the registry
     /// scan reports the matching sinks, a moment after the load returns. Wait
-    /// for the named ones, then refresh the leg table.
+    /// for the named ones, then refresh the leg table. False when the
+    /// deadline passed with a leg still missing: a leg that appears later
+    /// would carry PipeWire's defaults (full level, unmuted) instead of the
+    /// stored fader, so callers treat that as a failed edit.
     /// </summary>
-    private void WaitForLegsLocked(IReadOnlyList<uint> modules, IEnumerable<string> sinkNames)
+    private bool WaitForLegsLocked(IReadOnlyList<uint> modules, IEnumerable<string> sinkNames)
     {
         var wanted = sinkNames.ToHashSet(StringComparer.Ordinal);
         var pending = modules.ToHashSet();
-        var deadline = DateTime.UtcNow + LegTimeout;
-        while (pending.Count > 0 && DateTime.UtcNow < deadline)
+        long deadline = Environment.TickCount64 + (long)LegTimeout.TotalMilliseconds;
+        while (pending.Count > 0 && Environment.TickCount64 < deadline)
         {
             foreach (uint module in pending.ToList())
                 if (_pw.TryFindCombineLegs(module) is { } legs && wanted.All(legs.ContainsKey)) pending.Remove(module);
             if (pending.Count > 0) Thread.Sleep(100);
         }
         DiscoverLegsLocked();
+        return pending.Count == 0;
     }
 
     /// <summary>The fader state of removed cells, so a failed save can put them back.</summary>

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -277,27 +277,45 @@ public sealed class PipeWireAdapter
     {
         try
         {
+            // Our own session's server: the one running as our user. On a
+            // shared machine another user's pipewire-pulse is not ours to
+            // read, and would answer for the wrong session if it were.
+            string? uid = ProcUid("/proc/self");
+            if (uid is null) return null;
             foreach (string dir in Directory.EnumerateDirectories("/proc"))
             {
-                string name = Path.GetFileName(dir);
-                if (!name.All(char.IsAsciiDigit)) continue;
-                string comm;
-                try { comm = File.ReadAllText(Path.Combine(dir, "comm")).Trim(); }
-                catch (Exception) { continue; }
-                if (comm != "pipewire-pulse") continue;
-                int? limit = File.ReadLines(Path.Combine(dir, "limits"))
-                    .Where(line => line.StartsWith("Max open files", StringComparison.Ordinal))
-                    .Select(line => line[14..].Split(' ', StringSplitOptions.RemoveEmptyEntries))
-                    .Where(columns => columns.Length >= 1 && int.TryParse(columns[0], out _))
-                    .Select(columns => (int?)int.Parse(columns[0]))
-                    .FirstOrDefault();
-                if (limit is null) return null;
-                int used = Directory.EnumerateFileSystemEntries(Path.Combine(dir, "fd")).Count();
-                return (used, limit.Value);
+                if (!Path.GetFileName(dir).All(char.IsAsciiDigit)) continue;
+                try
+                {
+                    if (File.ReadAllText(Path.Combine(dir, "comm")).Trim() != "pipewire-pulse" || ProcUid(dir) != uid) continue;
+                    int? limit = File.ReadLines(Path.Combine(dir, "limits"))
+                        .Where(line => line.StartsWith("Max open files", StringComparison.Ordinal))
+                        .Select(line => line[14..].Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                        .Where(columns => columns.Length >= 1 && int.TryParse(columns[0], out _))
+                        .Select(columns => (int?)int.Parse(columns[0]))
+                        .FirstOrDefault();
+                    if (limit is null) continue;
+                    int used = Directory.EnumerateFileSystemEntries(Path.Combine(dir, "fd")).Count();
+                    return (used, limit.Value);
+                }
+                catch (Exception) { /* gone meanwhile, or not readable: keep looking */ }
             }
         }
-        catch (Exception) { /* no /proc, or not ours to read */ }
+        catch (Exception) { /* no /proc */ }
         return null;
+    }
+
+    /// <summary>The real uid of a /proc entry, from its status file.</summary>
+    private static string? ProcUid(string procDir)
+    {
+        try
+        {
+            return File.ReadLines(Path.Combine(procDir, "status"))
+                .Where(line => line.StartsWith("Uid:", StringComparison.Ordinal))
+                .Select(line => line[4..].Split((char[])['\t', ' '], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
+                .FirstOrDefault();
+        }
+        catch (Exception) { return null; }
     }
 
     /// <summary>Whether a sink of this name is published right now (null when pactl is unavailable).</summary>

--- a/src/OpenXLR.Core/Usb/HelperUsbTransport.cs
+++ b/src/OpenXLR.Core/Usb/HelperUsbTransport.cs
@@ -44,6 +44,10 @@ public sealed class HelperUsbTransport : IUsbTransport
             byte[] reply = Exchange(UsbHelperProtocol.Open(vendorId, productId), OpenDeadline,
                 () => new InvalidOperationException("the USB helper did not answer an open request in time"));
             _open = BinaryPrimitives.ReadInt32LittleEndian(reply) == 0;
+            // A helper with nothing open is a process for nothing; the device
+            // loop retries every few seconds and each retry would otherwise
+            // leave one more behind.
+            if (!_open) Kill();
             return _open;
         }
     }
@@ -138,6 +142,9 @@ public sealed class HelperUsbTransport : IUsbTransport
         }
         return reply;
     }
+
+    /// <summary>For tests: whether a helper process is alive right now.</summary>
+    internal bool HelperAlive { get { lock (_gate) return _helper is { HasExited: false }; } }
 
     private void Kill()
     {

--- a/src/OpenXLR.Daemon/ApiToken.cs
+++ b/src/OpenXLR.Daemon/ApiToken.cs
@@ -19,14 +19,17 @@ public static class ApiToken
     public static string? Current => _current;
 
     /// <summary>
-    /// Remove any token an earlier run left behind and publish a fresh one
-    /// only once the host is listening, so no client ever hands a token
-    /// that will be valid on this daemon to whoever squats the port before
-    /// it binds, and a second instance that never binds never publishes.
+    /// Publish a fresh token only once the host is listening, so no client
+    /// ever hands a token that will be valid on this daemon to whoever
+    /// squats the port before it binds, and a second instance that never
+    /// binds never publishes. The file an earlier run left behind is
+    /// replaced atomically at that moment and not touched before: while a
+    /// second instance waits for the port, the running daemon's clients
+    /// keep reconnecting with the token that is still theirs.
     /// </summary>
     public static void PublishWhenListening(IHostApplicationLifetime lifetime, ILogger log)
     {
-        Clear();
+        _current = null;
         lifetime.ApplicationStarted.Register(() =>
         {
             try { log.LogInformation("control API token written to {path}", Initialize()); }

--- a/src/OpenXLR.Daemon/DefaultDefense.cs
+++ b/src/OpenXLR.Daemon/DefaultDefense.cs
@@ -26,13 +26,17 @@ internal static class DefaultDefense
                 try { await Task.Delay(delayMs, stop); }
                 catch (OperationCanceledException) { return; }
                 if (stop.IsCancellationRequested) return;
+                // Each helper call can take seconds; check between them so a
+                // stop that arrives mid-pass never lets a later write land.
+                string Guarded(string[] args) { stop.ThrowIfCancellationRequested(); return run(args); }
                 try
                 {
-                    if (wantSink is { Length: > 0 } && run(["get-default-sink"]) != wantSink)
-                        run(["set-default-sink", wantSink]);
-                    if (wantSource is { Length: > 0 } && run(["get-default-source"]) != wantSource)
-                        run(["set-default-source", wantSource]);
+                    if (wantSink is { Length: > 0 } && Guarded(["get-default-sink"]) != wantSink)
+                        Guarded(["set-default-sink", wantSink]);
+                    if (wantSource is { Length: > 0 } && Guarded(["get-default-source"]) != wantSource)
+                        Guarded(["set-default-source", wantSource]);
                 }
+                catch (OperationCanceledException) { return; }
                 catch (Exception ex) { onError?.Invoke(ex.Message); }
             }
         }, CancellationToken.None);

--- a/src/OpenXLR.Daemon/DeviceManager.cs
+++ b/src/OpenXLR.Daemon/DeviceManager.cs
@@ -222,7 +222,11 @@ public sealed class DeviceManager : BackgroundService
         }
         catch (Exception ex)
         {
-            _log.LogWarning("device loop: {msg}", ex.Message);
+            // Once per distinct message at warning; the retries that follow
+            // every few seconds go to debug.
+            if (ex.Message != _lastLoopError) _log.LogWarning("device loop: {msg}", ex.Message);
+            else _log.LogDebug("device loop: {msg}", ex.Message);
+            _lastLoopError = ex.Message;
             Drop();
         }
         Progress.Mark(); // a completed failed poll is responsive too
@@ -232,7 +236,10 @@ public sealed class DeviceManager : BackgroundService
     // a device that hangs at once again is not worth a tight loop, so wait
     // before retrying. Tests shorten it.
     internal static TimeSpan HungReconnectDelay = TimeSpan.FromSeconds(10);
+    /// <summary>After an ordinary open failure (permissions, a busy device): shorter, still not a tight loop.</summary>
+    internal static TimeSpan OpenRetryDelay = TimeSpan.FromSeconds(2);
     private DateTime _reconnectNotBefore = DateTime.MinValue;
+    private string? _lastLoopError;
 
     /// <summary>
     /// The last transfer that never returned, kept for the diagnostics
@@ -312,10 +319,21 @@ public sealed class DeviceManager : BackgroundService
                 ? usable.FirstOrDefault(d => d.Info.ProductId == pid) ?? (usable.Count > 0 ? usable[0] : null)
                 : usable.Count > 0 ? usable[0] : null;
             if (dev is null) return;                    // nothing usable attached; try again next tick
-            dev.Connect();
+            try { dev.Connect(); }
+            catch (Exception ex)
+            {
+                // The candidate owns a transport, and a helper process once it
+                // tried to open: release it, and do not hammer a device that
+                // cannot be opened (a udev rule not yet applied) ten times a
+                // second.
+                dev.Dispose();
+                if (ex is not UsbHungException) _reconnectNotBefore = DateTime.UtcNow + OpenRetryDelay;
+                throw;
+            }
             _device = dev;
             _last = null;
             _log.LogInformation("connected {dev}", dev.Info.DisplayName);
+            _lastLoopError = null;
             // The UCM split profile that hides the raw multichannel nodes exists
             // for the Wave XLR Pro only; on the other devices the check would
             // poll wpctl for two minutes and then warn about a profile that
@@ -820,6 +838,7 @@ public sealed class DeviceManager : BackgroundService
         lock (_gate)
         {
             try { _device?.Disconnect(); } catch { /* ignore */ }
+            try { _device?.Dispose(); } catch { /* the helper is gone either way */ }
             bool was = _device is not null;
             _device = null;
             _last = null;

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -305,7 +305,7 @@ public sealed class MixerService : IHostedService, IDisposable
         _meterPush = null;
         // No default-device write may land after the graph is gone.
         _stopping.Cancel();
-        try { await _defaultDefense.WaitAsync(TimeSpan.FromSeconds(3), ct); }
+        try { await _defaultDefense.WaitAsync(TimeSpan.FromSeconds(4), ct); }   // one in-flight pactl call at most, 3 s
         catch (Exception ex) when (ex is TimeoutException or OperationCanceledException) { _log.LogWarning("default defense did not stop in time"); }
         if (_mixer.Built)
         {

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -73,6 +73,9 @@ public sealed class WebSocketHub
             Detected = [.. _devices.Detected().Select(d => new DetectedDevice(d.UsbId, d.Name, d.Active))],
         };
 
+    /// <summary>A correlation id longer than this is refused rather than echoed.</summary>
+    internal const int MaxRequestId = 64;
+
     /// <summary>A client has this long to present the token before it is dropped.</summary>
     private static readonly TimeSpan AuthDeadline = TimeSpan.FromSeconds(5);
 
@@ -167,6 +170,18 @@ public sealed class WebSocketHub
         catch (JsonException ex) { await reply(new ErrorMessage($"bad json: {ex.Message}")); return; }
         if (cmd is null) { await reply(new ErrorMessage("command must be an object")); return; }
 
+        if (cmd.RequestId is { Length: > MaxRequestId })
+        {
+            await reply(new ErrorMessage($"requestId: at most {MaxRequestId} characters"));
+            return;
+        }
+
+        // Every command ends here with one outcome. A requestId gets the
+        // state that reflects it and then a commandResult, success or not;
+        // without one, a failure is an error message, followed by the state
+        // for the optimistic mixer controls so a rejected change snaps back.
+        string? error = null;
+        bool stateOnError = false;
         switch (cmd.Cmd)
         {
             case "auth":
@@ -183,9 +198,7 @@ public sealed class WebSocketHub
                 await reply(new PluginsMessage(plugins));
                 break;
             case "set":
-                if (cmd.Control is null) { await reply(new ErrorMessage("set: missing 'control'")); break; }
-                string? err = _devices.Apply(cmd.Control, cmd.Value);  // broadcasts on success
-                if (err is not null) await reply(new ErrorMessage(err));
+                error = cmd.Control is null ? "set: missing 'control'" : _devices.Apply(cmd.Control, cmd.Value);  // broadcasts on success
                 break;
             case "createChannel":
             case "renameChannel":
@@ -212,49 +225,39 @@ public sealed class WebSocketHub
             case "setInserts":
             case "setInsertBypass":
             case "setInsertParam":
-                string? mixErr = _mixer.Apply(cmd);                     // broadcasts on success
-                if (cmd.RequestId is not null)
-                {
-                    // The state first, so a waiting editor re-enables its
-                    // controls against the layout the result refers to.
-                    await reply(Snapshot());
-                    await reply(new CommandResultMessage(cmd.RequestId, mixErr));
-                    break;
-                }
-                if (mixErr is not null)
-                {
-                    await reply(new ErrorMessage(mixErr));
-                    // Controls are optimistic in both clients. Follow an error
-                    // with authoritative state so a rejected ClipGuard/plugin
-                    // change snaps back instead of looking enabled forever.
-                    await reply(Snapshot());
-                }
+                error = _mixer.Apply(cmd);                     // broadcasts on success
+                stateOnError = true;
                 break;
             case "setActiveDevice":
-                if (cmd.Device is null) { await reply(new ErrorMessage("setActiveDevice: missing 'device'")); break; }
-                string? devSelErr = _devices.SetActiveDevice(cmd.Device);
-                if (devSelErr is not null) await reply(new ErrorMessage(devSelErr));
+                error = cmd.Device is null ? "setActiveDevice: missing 'device'" : _devices.SetActiveDevice(cmd.Device);
                 break;
             case "saveProfile":
             case "loadProfile":
             case "deleteProfile":
-                string? profErr = HandleProfile(cmd);
-                if (profErr is not null) await reply(new ErrorMessage(profErr));
-                else Broadcast(Snapshot());   // list (and loaded state) changed
+                error = HandleProfile(cmd);
+                if (error is null) Broadcast(Snapshot());   // list (and loaded state) changed
                 break;
             case "setRecallOnConnect":
-                string? recallErr = HandleRecallOnConnect(cmd);
-                if (recallErr is not null) await reply(new ErrorMessage(recallErr));
-                else Broadcast(Snapshot());
+                error = HandleRecallOnConnect(cmd);
+                if (error is null) Broadcast(Snapshot());
                 break;
             case "resetDevice":
-                string? resetErr = _devices.ResetToDefaults();   // the state change broadcasts itself
-                if (resetErr is not null) await reply(new ErrorMessage(resetErr));
-                else _log.LogInformation("reset {dev} to its firmware defaults", ActiveDeviceId());
+                error = _devices.ResetToDefaults();   // the state change broadcasts itself
+                if (error is null) _log.LogInformation("reset {dev} to its firmware defaults", ActiveDeviceId());
                 break;
             default:
-                await reply(new ErrorMessage($"unknown cmd '{cmd.Cmd}'"));
+                error = $"unknown cmd '{cmd.Cmd}'";
                 break;
+        }
+        if (cmd.RequestId is not null)
+        {
+            await reply(Snapshot());
+            await reply(new CommandResultMessage(cmd.RequestId, error));
+        }
+        else if (error is not null)
+        {
+            await reply(new ErrorMessage(error));
+            if (stateOnError) await reply(Snapshot());
         }
     }
 

--- a/src/OpenXLR.Tests/ApiTokenTests.cs
+++ b/src/OpenXLR.Tests/ApiTokenTests.cs
@@ -50,7 +50,7 @@ public sealed class ApiTokenTests
     }
 
     [Fact]
-    public async Task TheTokenIsPublishedOnlyOnceTheHostListensAndAStaleOneIsRemovedFirst()
+    public async Task TheTokenIsPublishedOnlyOnceTheHostListensAndTheOldOneStaysUntilThen()
     {
         string dir = Path.Combine(Path.GetTempPath(), "openxlr-test-" + Guid.NewGuid().ToString("N"));
         string? prev = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
@@ -64,10 +64,12 @@ public sealed class ApiTokenTests
             builder.Logging.ClearProviders();
             await using var app = builder.Build();
             ApiToken.PublishWhenListening(app.Lifetime, app.Logger);
-            Assert.False(File.Exists(path));            // the stale token is gone before anything listens
+            // Another daemon may own that token and the port right now: it
+            // stays valid for its clients until this host really listens.
+            Assert.Equal("stale-token-from-an-earlier-run", OpenXlrPaths.ReadToken());
             Assert.Null(ApiToken.Current);
             await app.StartAsync();
-            Assert.True(File.Exists(path));             // and the new one exists only now
+            Assert.NotEqual("stale-token-from-an-earlier-run", OpenXlrPaths.ReadToken());   // replaced only now
             Assert.Equal(ApiToken.Current, OpenXlrPaths.ReadToken());
             await app.StopAsync();
         }

--- a/src/OpenXLR.Tests/DeviceManagerHangTests.cs
+++ b/src/OpenXLR.Tests/DeviceManagerHangTests.cs
@@ -15,6 +15,8 @@ public sealed class DeviceManagerHangTests
     private sealed class FlakyDevice : IAudioDevice
     {
         public bool Hanging;
+        public int Disposals;
+        public void Dispose() => Disposals++;
         public int Connects, Hangs;
         public DeviceInfo Info { get; } = new("Elgato", "Wave XLR", 0x0fd9, 0x007d);
         public DeviceCapabilities Capabilities { get; } = new() { Gain = true, Mute = true, HpVolume = true };

--- a/src/OpenXLR.Tests/LiveLayoutEditingTests.cs
+++ b/src/OpenXLR.Tests/LiveLayoutEditingTests.cs
@@ -142,5 +142,18 @@ public sealed class LiveLayoutEditingTests
         ApiCommandResult plain = await hub.ExecuteForApiAsync("""{"cmd":"createMix","name":"Podcast"}""");
         Assert.False(plain.Ok);
         Assert.Contains(plain.Messages, m => m is ErrorMessage);
+
+        // The contract holds for every command, not only the mixer's, and for a read.
+        ApiCommandResult device = await hub.ExecuteForApiAsync("""{"cmd":"set","requestId":"r2"}""");
+        var deviceResult = Assert.IsType<CommandResultMessage>(device.Messages[^1]);
+        Assert.Equal("r2", deviceResult.RequestId);
+        Assert.Contains("missing 'control'", deviceResult.Error);
+        ApiCommandResult unknown = await hub.ExecuteForApiAsync("""{"cmd":"nothing","requestId":"r3"}""");
+        Assert.Contains("unknown cmd", Assert.IsType<CommandResultMessage>(unknown.Messages[^1]).Error);
+        ApiCommandResult read = await hub.ExecuteForApiAsync("""{"cmd":"getState","requestId":"r4"}""");
+        Assert.True(read.Ok);
+        Assert.Null(Assert.IsType<CommandResultMessage>(read.Messages[^1]).Error);
+        ApiCommandResult tooLong = await hub.ExecuteForApiAsync("{\"cmd\":\"getState\",\"requestId\":\"" + new string('x', 65) + "\"}");
+        Assert.Contains(tooLong.Messages, m => m is ErrorMessage);
     }
 }

--- a/src/OpenXLR.Tests/Lv2BundleTests.cs
+++ b/src/OpenXLR.Tests/Lv2BundleTests.cs
@@ -42,7 +42,7 @@ public sealed class Lv2BundleTests
             File.WriteAllText(Path.Combine(monster, "monster.ttl"), Bundle("monster", "urn:openxlr:test:monster", Lv2Catalog.MaxPorts + 10));
             // lilv is told the path directly: native code never sees a .NET environment change.
             IReadOnlyList<PluginInfo> found = Lv2Catalog.ScanNow(dir);
-            Assert.Equal(1, found.Count);   // only this directory was scanned
+            Assert.Single(found);   // only this directory was scanned
             Assert.Contains(found, p => p.Plugin == "urn:openxlr:test:good" && p.Params.Count == 3 && p.AudioIns == 1 && p.AudioOuts == 1);
             Assert.DoesNotContain(found, p => p.Plugin == "urn:openxlr:test:monster");
         }

--- a/src/OpenXLR.Tests/UsbHelperTests.cs
+++ b/src/OpenXLR.Tests/UsbHelperTests.cs
@@ -76,6 +76,34 @@ public sealed class UsbHelperTests
     }
 
     [Fact]
+    public void AHelperThatCannotOpenTheDeviceIsNotLeftRunning()
+    {
+        // A helper that answers every open with "not opened", as libusb does
+        // without permission on the device. The device loop retries; each
+        // retry must not leave one more process behind.
+        const string script = """
+            import sys, struct
+            def rd(n):
+                b = b''
+                while len(b) < n:
+                    c = sys.stdin.buffer.read(n - len(b))
+                    if not c: sys.exit(0)
+                    b += c
+                return b
+            while True:
+                n = struct.unpack('<I', rd(4))[0]; rd(n)
+                sys.stdout.buffer.write(struct.pack('<I', 4) + struct.pack('<i', 1)); sys.stdout.buffer.flush()
+            """;
+        using var usb = new HelperUsbTransport("python3", ["-c", script]);
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            Assert.False(usb.Open(0x0fd9, 0x00b4));
+            Assert.False(usb.IsOpen);
+            Assert.False(usb.HelperAlive);
+        }
+    }
+
+    [Fact]
     public void AHelperThatStopsAnsweringIsKilledAndTheTransferReportsAHang()
     {
         // A helper that answers the open, then never again: it swallows the

--- a/src/OpenXLR.UI/AboutWindow.axaml.cs
+++ b/src/OpenXLR.UI/AboutWindow.axaml.cs
@@ -13,8 +13,7 @@ public partial class AboutWindow : Window
         VersionText.Text = $"v{AppVersion.Current}";
     }
 
-    private static void OpenUrl(string url)
-        => Process.Start(new ProcessStartInfo("xdg-open", url) { UseShellExecute = false });
+    private static void OpenUrl(string url) => ExternalLink.Open(url);
 
     private void OnRepo(object? sender, RoutedEventArgs e) => OpenUrl("https://github.com/emaspa/openxlr");
     private void OnCredits(object? sender, RoutedEventArgs e) => OpenUrl("https://github.com/emaspa/openxlr#credits");

--- a/src/OpenXLR.UI/ExternalLink.cs
+++ b/src/OpenXLR.UI/ExternalLink.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics;
+
+namespace OpenXLR.UI;
+
+/// <summary>
+/// The one way the window hands a link to the desktop: https to a host we
+/// name, through xdg-open, never through a shell. Anything else is refused.
+/// </summary>
+internal static class ExternalLink
+{
+    private static readonly string[] Hosts = ["github.com", "www.reddit.com", "discord.gg", "buymeacoffee.com"];
+
+    public static bool Open(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) || uri.Scheme != "https" || Array.IndexOf(Hosts, uri.Host) < 0)
+            return false;
+        try
+        {
+            Process.Start(new ProcessStartInfo("xdg-open", uri.ToString()) { UseShellExecute = false });
+            return true;
+        }
+        catch (Exception) { return false; }
+    }
+}

--- a/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
+++ b/src/OpenXLR.UI/MixerSetupWindow.axaml.cs
@@ -193,8 +193,7 @@ public partial class MixerSetupWindow : Window
     private const string FileLimitManual =
         "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#open-files";
 
-    private void OnFileLimitManual(object? sender, RoutedEventArgs e)
-        => System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("xdg-open", FileLimitManual) { UseShellExecute = false });
+    private void OnFileLimitManual(object? sender, RoutedEventArgs e) => ExternalLink.Open(FileLimitManual);
 
     private async void OnRestartDaemon(object? sender, RoutedEventArgs e)
     {

--- a/src/OpenXLR.UI/UpdatesWindow.axaml.cs
+++ b/src/OpenXLR.UI/UpdatesWindow.axaml.cs
@@ -16,16 +16,7 @@ public partial class UpdatesWindow : Window
 
     private void OnOpen(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not UpdatesViewModel { Url: { } url }) return;
-        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
-            uri.Scheme != "https" || uri.Host != "github.com") return;
-        try
-        {
-            var start = new ProcessStartInfo("xdg-open") { UseShellExecute = false };
-            start.ArgumentList.Add(url);
-            Process.Start(start)?.Dispose();
-        }
-        catch (Exception) { /* opening a browser is best effort */ }
+        if (DataContext is UpdatesViewModel { Url: { } url }) ExternalLink.Open(url);
     }
 
     private void OnClose(object? sender, RoutedEventArgs e) => Close();


### PR DESCRIPTION
The rpm recipe carried the drop-in's path inside %install instead of
%files; it is a %files entry now. A layout edit fails and rolls back
when a combine leg has not appeared within the wait, since a late leg
would carry PipeWire's defaults instead of the stored fader. A USB
helper that could not open its device is killed at once, a failed
candidate device is disposed, an ordinary open failure waits two
seconds before the next try and is logged once, and a dropped device
releases its transport. Every command answers a requestId with a
commandResult after the state, the id is bounded, and the OpenAPI
document says the events route authenticates on its first frame. The
token file is left alone until this host listens, so a second instance
waiting for the port no longer locks the running daemon's clients out.
The default-device defense checks for a stop between helper calls. CI
builds with warnings as errors and runs the plugin tests; the one
analyzer warning is fixed. pipewire-pulse's open files are read from the
server running as this user only. The window opens links through one
checked helper, the dial inspector validates the gesture value, and the
roadmap's authentication item reflects the token that exists.

Verified: 210 tests, plugin tests, build with warnings as errors, expanded spec puts the drop-in in %files, and on this desk the daemon restarted with one helper process, a requestId on getState, set and saveProfile answered with commandResult, and no device-loop noise.