### PR TITLE
Cleanup: correlated client queries, OpenAPI shape check, catalog caps, monotonic deadlines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           node --check plugin/com.emaspa.openxlr.sdPlugin/plugin.mjs
           python3 -m json.tool plugin/com.emaspa.openxlr.sdPlugin/manifest.json >/dev/null
-          python3 -m json.tool docs/openapi-v1.json >/dev/null
+          python3 tools/check-openapi.py docs/openapi-v1.json
           node --test plugin/tests/*.test.mjs
 
       - name: Lint shell scripts

--- a/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
+++ b/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
@@ -110,6 +110,10 @@ public static class Lv2Catalog
     internal const int MaxControls = 512;
     internal const int MaxScalePoints = 256;
     internal const int MaxText = 200;
+    /// <summary>A plugin URI longer than this is not one the chain host will ever be asked for; the bundle is skipped.</summary>
+    internal const int MaxUri = 512;
+    /// <summary>Required features beyond this count are not read; no real plugin declares more than a handful.</summary>
+    internal const int MaxFeatures = 64;
     /// <summary>Rough serialized size the whole catalog may reach; the window reads at most 8 MiB per message.</summary>
     internal const int CatalogBudgetBytes = 6 * 1024 * 1024;
 
@@ -209,14 +213,15 @@ public static class Lv2Catalog
         }
         if (audioIns == 0 || audioOuts == 0 || inSym is null || outSym is null) return null;   // generators and analysers are not inserts
 
+        if (uri.Length > MaxUri) return null;
         var features = new List<string>();
         IntPtr req = Lilv.lilv_plugin_get_required_features(plugin);
         if (req != IntPtr.Zero)
         {
-            for (IntPtr fit = Lilv.lilv_nodes_begin(req); !Lilv.lilv_nodes_is_end(req, fit); fit = Lilv.lilv_nodes_next(req, fit))
+            for (IntPtr fit = Lilv.lilv_nodes_begin(req); !Lilv.lilv_nodes_is_end(req, fit) && features.Count < MaxFeatures; fit = Lilv.lilv_nodes_next(req, fit))
             {
                 string? f = Lilv.Str(Lilv.lilv_node_as_uri(Lilv.lilv_nodes_get(req, fit)));
-                if (f is not null) features.Add(f);
+                if (f is not null) features.Add(f.Length <= MaxUri ? f : f[..MaxUri]);
             }
             Lilv.lilv_nodes_free(req);
         }

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -621,8 +621,8 @@ public sealed class PipeWireAdapter
 
     private bool WaitForPorts(string node, string prefix, bool output, TimeSpan timeout, Process owner)
     {
-        DateTime end = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < end)
+        long end = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (Environment.TickCount64 < end)
         {
             if (owner.HasExited) return false;
             if (ListPorts(node, prefix, output).Count > 0) return true;
@@ -1181,8 +1181,8 @@ public sealed class PipeWireAdapter
 
     private bool WaitForNode(string nodeName, TimeSpan timeout)
     {
-        DateTime end = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < end)
+        long end = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (Environment.TickCount64 < end)
         {
             if (FindNodeId(nodeName) is not null) return true;
             Thread.Sleep(100);
@@ -1215,7 +1215,7 @@ public sealed class PipeWireAdapter
     // whole sweep. Staleness is bounded by the window below.
     private static readonly object DumpGate = new();
     private static byte[]? _dumpJson;
-    private static DateTime _dumpAt;
+    private static long _dumpAt;   // monotonic ms
     private static readonly TimeSpan DumpWindow = TimeSpan.FromMilliseconds(400);
 
     // Kept as UTF-8 bytes and parsed from them: the string form is twice
@@ -1224,9 +1224,9 @@ public sealed class PipeWireAdapter
     {
         lock (DumpGate)
         {
-            if (_dumpJson is not null && DateTime.UtcNow - _dumpAt < DumpWindow) return _dumpJson;
+            if (_dumpJson is not null && Environment.TickCount64 - _dumpAt < DumpWindow.TotalMilliseconds) return _dumpJson;
             _dumpJson = RunBytes("pw-dump");
-            _dumpAt = DateTime.UtcNow;
+            _dumpAt = Environment.TickCount64;
             return _dumpJson;
         }
     }

--- a/src/OpenXLR.Daemon/CommandBudget.cs
+++ b/src/OpenXLR.Daemon/CommandBudget.cs
@@ -10,23 +10,23 @@ public sealed class CommandBudget
 {
     private readonly int _capacity;
     private readonly double _refillPerSecond;
-    private readonly Func<DateTime> _clock;
+    private readonly Func<long> _clock;   // monotonic milliseconds
     private double _tokens;
-    private DateTime _last;
+    private long _last;
 
-    public CommandBudget(int capacity = 300, double refillPerSecond = 100, Func<DateTime>? clock = null)
+    public CommandBudget(int capacity = 300, double refillPerSecond = 100, Func<long>? clock = null)
     {
         _capacity = capacity;
         _refillPerSecond = refillPerSecond;
-        _clock = clock ?? (() => DateTime.UtcNow);
+        _clock = clock ?? (() => Environment.TickCount64);
         _tokens = capacity;
         _last = _clock();
     }
 
     public bool TryTake()
     {
-        DateTime now = _clock();
-        _tokens = Math.Min(_capacity, _tokens + (now - _last).TotalSeconds * _refillPerSecond);
+        long now = _clock();
+        _tokens = Math.Min(_capacity, _tokens + (now - _last) / 1000.0 * _refillPerSecond);
         _last = now;
         if (_tokens < 1) return false;
         _tokens -= 1;

--- a/src/OpenXLR.Daemon/DeviceManager.cs
+++ b/src/OpenXLR.Daemon/DeviceManager.cs
@@ -238,7 +238,7 @@ public sealed class DeviceManager : BackgroundService
     internal static TimeSpan HungReconnectDelay = TimeSpan.FromSeconds(10);
     /// <summary>After an ordinary open failure (permissions, a busy device): shorter, still not a tight loop.</summary>
     internal static TimeSpan OpenRetryDelay = TimeSpan.FromSeconds(2);
-    private DateTime _reconnectNotBefore = DateTime.MinValue;
+    private long _reconnectNotBefore;   // monotonic ms
     private string? _lastLoopError;
 
     /// <summary>
@@ -283,7 +283,7 @@ public sealed class DeviceManager : BackgroundService
                 _lastUsbFault, (int)HungReconnectDelay.TotalSeconds,
                 dev is null ? 0 : _hung.HungCount(dev.Info.ProductId), HungTransferPolicy.Limit);
         }
-        _reconnectNotBefore = DateTime.UtcNow + HungReconnectDelay;
+        _reconnectNotBefore = Environment.TickCount64 + (long)HungReconnectDelay.TotalMilliseconds;
         Drop();
     }
 
@@ -313,7 +313,7 @@ public sealed class DeviceManager : BackgroundService
                 }
             }
             if (_device is { Connected: true }) return;
-            if (DateTime.UtcNow < _reconnectNotBefore) return;
+            if (Environment.TickCount64 < _reconnectNotBefore) return;
             List<IAudioDevice> usable = [.. all.Where(d => !_hung.IsSetAside(d.Info.ProductId))];
             IAudioDevice? dev = _preferredPid is ushort pid
                 ? usable.FirstOrDefault(d => d.Info.ProductId == pid) ?? (usable.Count > 0 ? usable[0] : null)
@@ -327,7 +327,7 @@ public sealed class DeviceManager : BackgroundService
                 // cannot be opened (a udev rule not yet applied) ten times a
                 // second.
                 dev.Dispose();
-                if (ex is not UsbHungException) _reconnectNotBefore = DateTime.UtcNow + OpenRetryDelay;
+                if (ex is not UsbHungException) _reconnectNotBefore = Environment.TickCount64 + (long)OpenRetryDelay.TotalMilliseconds;
                 throw;
             }
             _device = dev;

--- a/src/OpenXLR.Daemon/Program.cs
+++ b/src/OpenXLR.Daemon/Program.cs
@@ -78,7 +78,7 @@ app.MapGet("/", () => Results.Text($"OpenXLR daemon. Control API: ws://127.0.0.1
 // kernel's ephemeral range, so any local program's outgoing connection can
 // hold it for a while (the packages reserve it via sysctl; source installs
 // may not). Wait for the port first, before anything touches PipeWire.
-DateTime deadline = DateTime.UtcNow.AddSeconds(60);
+long deadline = Environment.TickCount64 + 60_000;
 for (int attempt = 0; ; attempt++)
 {
     try
@@ -88,7 +88,7 @@ for (int attempt = 0; ; attempt++)
         probe.Stop();
         break;
     }
-    catch (SocketException) when (DateTime.UtcNow < deadline)
+    catch (SocketException) when (Environment.TickCount64 < deadline)
     {
         if (attempt % 10 == 0)
             app.Logger.LogWarning("port {Port} is in use by another local socket; waiting for it", ApiPort);

--- a/src/OpenXLR.Daemon/SocketGuard.cs
+++ b/src/OpenXLR.Daemon/SocketGuard.cs
@@ -31,7 +31,7 @@ internal static class SocketGuard
         WebSocket socket, byte[] buf, int maxBytes, TimeSpan messageDeadline, CancellationToken stopping)
     {
         using var ms = new MemoryStream();
-        DateTime? due = null;   // set by the first fragment of a multi-frame message
+        long? due = null;   // monotonic ms, set by the first fragment of a multi-frame message
         WebSocketReceiveResult res;
         do
         {
@@ -39,12 +39,12 @@ internal static class SocketGuard
             try
             {
                 recv = socket.ReceiveAsync(buf, stopping);
-                if (due is DateTime d)
+                if (due is long d)
                 {
                     // Cancelling a pending receive would abort the socket
                     // without a word to the peer, so race it with the clock
                     // and close properly when the clock wins.
-                    TimeSpan left = d - DateTime.UtcNow;
+                    TimeSpan left = TimeSpan.FromMilliseconds(d - Environment.TickCount64);
                     if (left <= TimeSpan.Zero || await Task.WhenAny(recv, Task.Delay(left, stopping)) != recv)
                     {
                         if (stopping.IsCancellationRequested)
@@ -82,7 +82,7 @@ internal static class SocketGuard
             ms.Write(buf, 0, res.Count);
             // The clock starts with the first fragment, so a quiet client
             // between commands is never on it.
-            if (due is null && !res.EndOfMessage) due = DateTime.UtcNow + messageDeadline;
+            if (due is null && !res.EndOfMessage) due = Environment.TickCount64 + (long)messageDeadline.TotalMilliseconds;
         } while (!res.EndOfMessage);
         return (Outcome.Message, ms.ToArray());
     }

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -324,8 +324,8 @@ public sealed class WebSocketHub
             }
             return;
         }
-        DateTime deadline = DateTime.UtcNow + TimeSpan.FromSeconds(60);
-        while (_mixer.SubmixerEnabled && !_mixer.Built && DateTime.UtcNow < deadline && !_stopping.IsCancellationRequested)
+        long deadline = Environment.TickCount64 + 60_000;
+        while (_mixer.SubmixerEnabled && !_mixer.Built && Environment.TickCount64 < deadline && !_stopping.IsCancellationRequested)
             await Task.Delay(250, _stopping).ContinueWith(_ => { }, TaskScheduler.Default);
         if (_stopping.IsCancellationRequested || ActiveDeviceId() != devId) { _devices.MarkRestored(); return; }
         string? err = ApplyNamedProfile(devId, name);

--- a/src/OpenXLR.Tests/CommandLimitsTests.cs
+++ b/src/OpenXLR.Tests/CommandLimitsTests.cs
@@ -74,11 +74,11 @@ public sealed class CommandLimitsTests
     [Fact]
     public void BudgetAllowsBurstsAndRefills()
     {
-        DateTime now = new(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc);
+        long now = 1_000_000;   // monotonic milliseconds
         var budget = new CommandBudget(capacity: 10, refillPerSecond: 5, clock: () => now);
         for (int i = 0; i < 10; i++) Assert.True(budget.TryTake());
         Assert.False(budget.TryTake());
-        now = now.AddSeconds(1);            // 5 tokens back
+        now += 1000;                        // 5 tokens back
         for (int i = 0; i < 5; i++) Assert.True(budget.TryTake());
         Assert.False(budget.TryTake());
     }

--- a/src/OpenXLR.Tests/DaemonClientTests.cs
+++ b/src/OpenXLR.Tests/DaemonClientTests.cs
@@ -16,6 +16,8 @@ public sealed class DaemonClientTests
             {
                 var command = await SocketTestServer.Receive(socket, stop);
                 if (command["cmd"]!.GetValue<string>() == "auth") continue;   // every connection opens with the token
+                // Like the daemon: the reply, then the commandResult for the requestId.
+                string requestId = command["requestId"]!.GetValue<string>();
                 if (command["cmd"]!.GetValue<string>() == "listPlugins")
                 {
                     Interlocked.Increment(ref requests);
@@ -24,6 +26,7 @@ public sealed class DaemonClientTests
                 }
                 else
                     await SocketTestServer.Send(socket, new { type = "diagnostics" }, stop);
+                await SocketTestServer.Send(socket, new { type = "commandResult", requestId }, stop);
             }
         });
         await using var client = new DaemonClient(server.Url);
@@ -43,6 +46,41 @@ public sealed class DaemonClientTests
         Assert.NotNull(await client.RequestDiagnosticsAsync(TimeSpan.FromSeconds(5)));
         Assert.Equal(1, requests);
         Assert.Equal(1, connections);
+    }
+
+    [Fact]
+    public async Task ALateReplyToATimedOutQueryNeverAnswersTheNextOne()
+    {
+        // The first catalog request is answered only after a second one was
+        // sent; the answers arrive in order, each followed by its
+        // commandResult, and the second caller must get the second answer.
+        var release = Completion();
+        var answers = new System.Collections.Concurrent.ConcurrentQueue<(string Id, string Name)>();
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                var command = await SocketTestServer.Receive(socket, stop);
+                if (command["cmd"]!.GetValue<string>() == "auth") continue;
+                answers.Enqueue((command["requestId"]!.GetValue<string>(), answers.Count == 0 ? "OLD" : "NEW"));
+                if (answers.Count < 2) { await release.Task.WaitAsync(stop); continue; }
+                while (answers.TryDequeue(out var a))
+                {
+                    await SocketTestServer.Send(socket, new { type = "plugins", plugins = new[] { new { name = a.Name } } }, stop);
+                    await SocketTestServer.Send(socket, new { type = "commandResult", requestId = a.Id }, stop);
+                }
+            }
+        });
+        await using var client = new DaemonClient(server.Url);
+        var connected = Completion();
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(await client.RequestPluginsAsync(TimeSpan.FromMilliseconds(200)));   // gives up; its reply is still owed
+        Task<System.Text.Json.Nodes.JsonNode?> second = client.RequestPluginsAsync(TimeSpan.FromSeconds(5));
+        release.SetResult();
+        Assert.Equal("NEW", (await second)![0]!["name"]!.GetValue<string>());
     }
 
     [Fact]

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -26,7 +26,12 @@ public sealed class DaemonClient : IAsyncDisposable
     private Task? _runTask;
     private Task? _disposeTask;
     private bool _disposed;
+    // Queries in flight by reply type (so concurrent callers share one
+    // request) and by requestId (so the daemon's commandResult, which follows
+    // the reply on the socket, completes exactly the query it belongs to).
     private readonly Dictionary<string, PendingQuery> _queries = new();
+    private readonly Dictionary<string, PendingQuery> _queriesById = new();
+    private readonly Dictionary<string, JsonNode?> _lastReply = new();
     // Layout edits wait for the daemon's commandResult with their requestId.
     private readonly Dictionary<string, TaskCompletionSource<string?>> _edits = new();
     private const int MaxMessageBytes = 8 * 1024 * 1024;
@@ -34,6 +39,8 @@ public sealed class DaemonClient : IAsyncDisposable
     private sealed class PendingQuery
     {
         public readonly TaskCompletionSource<JsonNode?> Reply = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly string Id = Guid.NewGuid().ToString("N");
+        public required string Type;
         public int Callers;
     }
 
@@ -61,12 +68,12 @@ public sealed class DaemonClient : IAsyncDisposable
         {
             if (_disposed) return null;
             send = !_queries.TryGetValue(type, out query!);
-            if (send) _queries[type] = query = new();
+            if (send) { query = new PendingQuery { Type = type }; _queries[type] = query; _queriesById[query.Id] = query; }
             query.Callers++;
         }
         try
         {
-            if (send && !await SendAsync(new { cmd = command }, reportErrors: false))
+            if (send && !await SendAsync(new { cmd = command, requestId = query.Id }, reportErrors: false))
                 query.Reply.TrySetResult(null);
             return await query.Reply.Task.WaitAsync(timeout);
         }
@@ -76,17 +83,31 @@ public sealed class DaemonClient : IAsyncDisposable
             lock (_lifecycle)
             {
                 // One impatient caller must not remove the reply slot still
-                // used by other windows waiting for the same catalog.
+                // used by other windows waiting for the same catalog. Once
+                // nobody waits, a new call sends a fresh request; the old
+                // one's late reply is consumed by its own commandResult.
                 if (--query.Callers == 0 && _queries.TryGetValue(type, out var current)
                     && ReferenceEquals(current, query)) _queries.Remove(type);
             }
         }
     }
 
-    private void CompleteQuery(string type, JsonNode? reply)
+    /// <summary>A reply message: the commandResult that follows it says which query it answers.</summary>
+    private void StoreReply(string type, JsonNode? reply)
+    {
+        lock (_lifecycle) _lastReply[type] = reply;
+    }
+
+    /// <summary>The daemon's commandResult for one of our queries: complete exactly that one.</summary>
+    private void CompleteQuery(string requestId)
     {
         lock (_lifecycle)
-            if (_queries.TryGetValue(type, out var query)) query.Reply.TrySetResult(reply);
+        {
+            if (!_queriesById.Remove(requestId, out PendingQuery? query)) return;
+            _lastReply.Remove(query.Type, out JsonNode? reply);
+            query.Reply.TrySetResult(reply);
+            if (_queries.TryGetValue(query.Type, out var current) && ReferenceEquals(current, query)) _queries.Remove(query.Type);
+        }
     }
 
     /// <summary>Raised when an error message arrives from the daemon.</summary>
@@ -144,8 +165,10 @@ public sealed class DaemonClient : IAsyncDisposable
                 _socket = null;
                 lock (_lifecycle)
                 {
-                    foreach (var query in _queries.Values) query.Reply.TrySetResult(null);
+                    foreach (var query in _queriesById.Values) query.Reply.TrySetResult(null);
                     _queries.Clear();
+                    _queriesById.Clear();
+                    _lastReply.Clear();
                     foreach (var edit in _edits.Values) edit.TrySetResult("Connection lost. Check the layout before retrying.");
                     _edits.Clear();
                 }
@@ -186,10 +209,11 @@ public sealed class DaemonClient : IAsyncDisposable
             string? type = node["type"]?.GetValue<string>();
             if (type == "error") ErrorReceived?.Invoke(node["message"]?.GetValue<string>() ?? "unknown error");
             else if (type == "state") { LastStateJson = text; StateReceived?.Invoke(node); }
-            else if (type == "diagnostics") CompleteQuery(type, node);
-            else if (type == "plugins") CompleteQuery(type, node["plugins"]);
+            else if (type == "diagnostics") StoreReply(type, node);
+            else if (type == "plugins") StoreReply(type, node["plugins"]);
             else if (type == "commandResult" && node["requestId"]?.GetValue<string>() is string requestId)
             {
+                CompleteQuery(requestId);
                 TaskCompletionSource<string?>? edit;
                 lock (_lifecycle) _edits.TryGetValue(requestId, out edit);
                 edit?.TrySetResult(node["error"]?.GetValue<string>());

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -1421,14 +1421,14 @@ public sealed class SendViewModel : ViewModelBase
 /// </summary>
 internal static class SliderSync
 {
-    private static readonly System.Collections.Generic.Dictionary<string, DateTime> Touched = [];
+    private static readonly System.Collections.Generic.Dictionary<string, long> Touched = [];   // monotonic ms
     private static readonly System.Collections.Generic.Dictionary<string, Action> Pending = [];
     private static DispatcherTimer? _timer;
 
-    public static void Touch(string key) => Touched[key] = DateTime.UtcNow;
+    public static void Touch(string key) => Touched[key] = Environment.TickCount64;
 
     public static bool RecentlyTouched(string key)
-        => Touched.TryGetValue(key, out DateTime t) && DateTime.UtcNow - t < TimeSpan.FromMilliseconds(800);
+        => Touched.TryGetValue(key, out long t) && Environment.TickCount64 - t < 800;
 
     public static void Send(string key, Action send)
     {

--- a/tools/check-openapi.py
+++ b/tools/check-openapi.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Structural check of docs/openapi-v1.json with the standard library only.
+
+Not a full validator: it checks the shape a client generator relies on
+(version, info, servers, every path's methods with responses, every $ref
+resolving to a component, every security requirement naming a declared
+scheme) and fails loudly on drift.
+"""
+import json
+import re
+import sys
+
+path = sys.argv[1] if len(sys.argv) > 1 else "docs/openapi-v1.json"
+doc = json.load(open(path))
+errors = []
+METHODS = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+
+
+def ref_ok(ref):
+    m = re.fullmatch(r"#/components/([A-Za-z]+)/([A-Za-z0-9_.-]+)", ref)
+    return bool(m) and m.group(2) in doc.get("components", {}).get(m.group(1), {})
+
+
+def walk(node, where):
+    if isinstance(node, dict):
+        if "$ref" in node and not ref_ok(node["$ref"]):
+            errors.append(f"{where}: unresolved $ref {node['$ref']}")
+        for k, v in node.items():
+            walk(v, f"{where}/{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            walk(v, f"{where}[{i}]")
+
+
+if not str(doc.get("openapi", "")).startswith("3."):
+    errors.append("openapi version must be 3.x")
+for key in ("title", "version"):
+    if not doc.get("info", {}).get(key):
+        errors.append(f"info.{key} missing")
+if not doc.get("servers"):
+    errors.append("servers missing")
+schemes = doc.get("components", {}).get("securitySchemes", {})
+for req in doc.get("security", []):
+    for name in req:
+        if name not in schemes:
+            errors.append(f"global security names undeclared scheme {name}")
+paths = doc.get("paths", {})
+if not paths:
+    errors.append("no paths")
+for p, item in paths.items():
+    if not p.startswith("/"):
+        errors.append(f"path {p} must start with /")
+    ops = {k: v for k, v in item.items() if k in METHODS}
+    if not ops:
+        errors.append(f"{p}: no operations")
+    for method, op in ops.items():
+        responses = op.get("responses", {})
+        if not responses:
+            errors.append(f"{method.upper()} {p}: no responses")
+        for code in responses:
+            if not re.fullmatch(r"[1-5]XX|[1-5][0-9][0-9]|default", str(code)):
+                errors.append(f"{method.upper()} {p}: bad response code {code}")
+        for req in op.get("security", []):
+            for name in req:
+                if name not in schemes:
+                    errors.append(f"{method.upper()} {p}: security names undeclared scheme {name}")
+walk(doc, "")
+for e in errors:
+    print(f"openapi: {e}", file=sys.stderr)
+print(f"openapi: {len(paths)} paths, {sum(len([k for k in i if k in METHODS]) for i in paths.values())} operations, "
+      f"{len(schemes)} security schemes, {'ok' if not errors else str(len(errors)) + ' problems'}")
+sys.exit(1 if errors else 0)


### PR DESCRIPTION
The window's daemon client sends its catalog and diagnostics queries
with a requestId and completes each one from the commandResult that
follows its reply, so a late answer to a query that timed out can no
longer satisfy the next query of the same type; concurrent callers still
share one request. CI checks the OpenAPI document's shape with a
standard-library script instead of parsing it as JSON. The LV2 catalog
skips a plugin whose URI exceeds 512 characters and reads at most 64
required features. Deadlines in the socket guard, the command budget,
the PipeWire waits, the port and profile waits, the device reconnect
hold-off and the slider echo window use the monotonic tick count instead
of wall-clock time.

Verified: 211 tests including a new one where a late reply to a timed-out catalog query arrives before the next query's reply, the OpenAPI check passes on the current document, and on this desk the daemon answers listPlugins and getDiagnostics in reply-then-result order.