### PR TITLE
Report remainders and the pre-release docs pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Locked restore enforced on every packaging path
         run: tools/check-locked-restore.sh
 
+      - name: RPM recipe claims every file it installs
+        run: tools/check-spec.py packaging/rpm/openxlr.spec
+
       - name: Validate packaged service inputs
         run: |
           test -f packaging/openxlr-daemon.service

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -42,6 +42,16 @@ jobs:
       - name: Lint package
         run: lintian --fail-on error dist/openxlr_*.deb
 
+      - name: Package contents
+        run: |
+          dpkg -c dist/openxlr_*.deb > contents.txt
+          for f in usr/lib/systemd/user/openxlr-daemon.service \
+                   usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf \
+                   usr/lib/udev/rules.d/70-openxlr.rules \
+                   usr/bin/openxlr usr/bin/openxlr-daemon; do
+            grep -q " ./$f\$" contents.txt || { echo "missing from the package: $f"; exit 1; }
+          done
+
       - name: Checksums
         run: cd dist && sha256sum openxlr_*.deb > SHA256SUMS-deb.txt && cat SHA256SUMS-deb.txt
 

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -57,6 +57,7 @@ jobs:
           test -f /usr/lib/udev/rules.d/70-openxlr.rules
           test -f /usr/share/wireplumber/wireplumber.conf.d/50-xlr-dock-capture-hold.conf
           test -f /usr/lib/systemd/user/openxlr-daemon.service
+          test -f /usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf
 
       - name: Checksums
         run: cd dist && sha256sum openxlr-*.rpm > SHA256SUMS-rpm.txt && cat SHA256SUMS-rpm.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,20 @@ read before touching the tree.
 
 ```sh
 dotnet restore src/OpenXLR.slnx --locked-mode
-dotnet build src/OpenXLR.slnx -c Release --no-restore
+dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror
 dotnet test src/OpenXLR.slnx -c Release --no-build
 node --check plugin/com.emaspa.openxlr.sdPlugin/plugin.mjs
-node --test plugin/tests/
+node --test plugin/tests/*.test.mjs
+python3 -m json.tool plugin/com.emaspa.openxlr.sdPlugin/manifest.json >/dev/null
+shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh
 tools/check-version.sh
+tools/check-locked-restore.sh
+tools/check-openapi.py docs/openapi-v1.json
+tools/check-spec.py packaging/rpm/openxlr.spec
 ```
 
-A build counts as clean only with `0 Error(s)` and no new warnings.
+CI runs exactly these; the build treats warnings as errors, so a build
+counts as clean only with `0 Error(s)` and `0 Warning(s)`.
 After a package change, regenerate the lock files with a plain
 `dotnet restore src/OpenXLR.slnx` and the Nix dependency list with
 `nix build .#openxlr.passthru.fetch-deps -o /tmp/fd && /tmp/fd packaging/nix/deps.json`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,15 +29,21 @@ prerequisites and the build. The checks CI runs:
 
 ```sh
 dotnet restore src/OpenXLR.slnx --locked-mode   # the committed lock files must match
-dotnet build src/OpenXLR.slnx -c Release --no-restore
+dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror
 dotnet test src/OpenXLR.slnx -c Release --no-build
 node --check plugin/com.emaspa.openxlr.sdPlugin/plugin.mjs
-node --test plugin/tests/
+node --test plugin/tests/*.test.mjs
+python3 -m json.tool plugin/com.emaspa.openxlr.sdPlugin/manifest.json >/dev/null
+shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh
 tools/check-version.sh                          # the five version locations agree
+tools/check-locked-restore.sh                   # every packaging path restores locked
+tools/check-openapi.py docs/openapi-v1.json     # the HTTP API document keeps its shape
+tools/check-spec.py packaging/rpm/openxlr.spec  # every installed file is in %files
 ```
 
-If you add or change a NuGet package, regenerate the lock files
-(`dotnet restore src/OpenXLR.slnx -r linux-x64`, then a plain restore)
+If you add or change a NuGet package, regenerate the lock files with a
+plain `dotnet restore src/OpenXLR.slnx` (the linux-x64 graph is part of
+the projects' runtime identifiers, so one restore covers it)
 and the Nix dependency list
 (`nix build .#openxlr.passthru.fetch-deps -o /tmp/fd && /tmp/fd packaging/nix/deps.json`)
 and commit both. Do not bump the version: releases do that in one

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Collect diagnostics).
 - **Submixer** built from PipeWire nodes (null sinks, remap sources,
   filter chains), no kernel modules. Channels for the hardware inputs
   and for application groups; mixes for what you hear (Monitor A and
-  Monitor B, each output choosing which of the two it follows), for
+  Monitor B, each output choosing one of the two or both summed), for
   virtual microphones other apps record from, and for the USB Aux port.
   The default layout is Game, Music, Browser, System, Voice Chat and
   SFX with Stream and Chat microphones; channels and microphones can be

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,9 @@ Token. The first message on every connection must be
 `{"cmd":"auth","token":"<token>"}`, where the token is the content of
 `$XDG_RUNTIME_DIR/openxlr/token` (or `~/.config/openxlr/token` in a
 session without a runtime directory), a file only your user can read
-that the daemon rewrites at every start. Nothing is sent before it;
+that the daemon replaces the moment it is listening (never earlier, so
+a second instance waiting for the port leaves the running daemon's
+clients alone). Nothing is sent before it;
 anything else as a first message, or nothing within 5 s, closes the
 socket with code 1008 and the reason `unauthorized` or `authentication
 timeout`. Another local user cannot read the file, so the loopback
@@ -33,7 +35,12 @@ non-finite numbers, and over-long strings or lists all come back as an
 `error` message instead of being silently ignored. A client may send
 bursts of up to 300 commands and a sustained 100 per second; beyond
 that it is disconnected with close code 1008. At most 32 clients can be
-connected at once.
+connected at once. The plugin catalog is bounded too: a plugin with a
+URI over 512 characters, more than 4096 ports, or one that would push
+the catalog past 6 MiB is left out of `plugins` altogether, and at most
+512 controls, 256 scale points and 64 required features are read per
+plugin; a plugin that is listed with `supported: false` is a different
+case, one the chain host cannot run.
 
 Messages from the daemon, each a JSON object with a `type` field:
 
@@ -60,10 +67,10 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setLowCutHz` | `value` | software low cut: 0, 80, or 120 |
 | `setSoftClipGuard` | `value` | software ClipGuard (post-ADC limiter at -3 dB); enabling is rejected if `swh-plugins` is unavailable, without replacing or disconnecting the live microphone route |
 | `setLevel` | `channel`, `mix`, `value` | one send fader |
-| `createChannel` | `name` | add an application channel, muted in every mix, without touching existing nodes; its generated stable id is in the next state |
+| `createChannel` | `name` | add an application channel, muted in every mix, without touching existing nodes; its generated stable id is in the next state. Undone with an error when its sends have not appeared within 3 s |
 | `renameChannel` | `channel`, `name` | rename an application channel; its playback device is reloaded under the new name and the streams on it are put back (a short gap on that channel only) |
 | `deleteChannel` | `channel` | remove an application channel; apps and remembered assignments on it move to the first remaining application channel. The last application channel cannot be removed |
-| `createMix` | `name` | add a virtual microphone; every channel gets a muted send into it before the capture device is published |
+| `createMix` | `name` | add a virtual microphone; every channel gets a muted send into it before the capture device is published. Undone with an error when a channel's send has not appeared within 3 s |
 | `renameMix` | `mix`, `name` | rename a virtual microphone in OpenXLR; the PipeWire device keeps its old description until the daemon restarts (reloading it would throw recording apps off), and the mixer state's `renamedSinceStart` says so |
 | `deleteMix` | `mix` | remove a virtual microphone with its sends, inserts and capture device |
 | `setLayoutOrder` | `channels[]`, `mixes[]` | complete ordered lists of application-channel and virtual-microphone ids; structural nodes stay fixed |
@@ -112,6 +119,9 @@ All under `~/.config/openxlr/` (or `$XDG_CONFIG_HOME/openxlr/`):
 - `$XDG_RUNTIME_DIR/openxlr/token` (or `token` here without a runtime
   directory): the control API token for this daemon run, 0600, see the
   top of this page
+- `$XDG_RUNTIME_DIR/openxlr/daemon.lock`: held by the running daemon for
+  the life of the process; a second daemon for the same user finds it
+  held and exits with code 75 at once
 - `daemon.json`: the daemon's own preferences, read once at start.
   `submixer` (true/false/absent) turns the submixer on or off; absent
   means the unit's environment decides (`OPENXLR_BUILD_MIXER`). Written

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@
 
   ~/.config/openxlr: mixer.json, profiles/, devices/, gainlock.json (daemon); daemon.json, ui.json (UI)
   $XDG_RUNTIME_DIR/openxlr/token: the control API token, one per daemon run
+  $XDG_RUNTIME_DIR/openxlr/daemon.lock: held by the running daemon, one instance per user
 ```
 
 - `OpenXLR.Daemon` owns the device and the graph: it opens the
@@ -125,7 +126,11 @@ stdout. Every transfer runs under a watchdog (the libusb timeout plus
 operating system reclaims the stuck thread and the device handle, the
 device is dropped and reconnected through a fresh helper, and the
 daemon keeps serving. After three hangs of one device without a replug
-the daemon sets it aside instead of retrying.
+the daemon sets it aside instead of retrying. A helper whose device
+could not be opened at all (no permission yet, a busy interface) is
+killed at once, and the next attempt waits two seconds, so a device the
+udev rule has not reached yet never turns into a stream of helper
+processes.
 
 ## Repository layout
 
@@ -133,7 +138,9 @@ the daemon sets it aside instead of retrying.
 src/            .NET solution: Core (device + mixer), Daemon, UI, Probe, Tests
 plugin/         the OpenDeck (Stream Deck) plugin
 docs/           this documentation, protocol write-up, capture guides
-tools/          proprobe.py, a standalone Python probe for the vendor protocol
+tools/          proprobe.py, a standalone Python probe for the vendor protocol,
+                and the CI checks (versions, locked restores, the OpenAPI
+                document's shape, the rpm recipe's %files)
 packaging/      systemd unit, the pipewire-pulse open-file drop-in, udev rule,
                 WirePlumber rules, UCM profile, rpm and nix packaging, OpenDeck patches
 debian/         Debian/Ubuntu packaging

--- a/docs/features.md
+++ b/docs/features.md
@@ -185,8 +185,8 @@ Keys render a button with an icon and a status LED: red for a mute,
 green for an engaged feature or the active monitor output. Every
 hardware switch and mute is a key target, plus the software low cut
 (its frequency shown on the LED, cycling Off, 80, 120), ClipGuard, gain
-lock, switching the monitor output to a specific device, and flipping
-an output between Monitor A and Monitor B. Each key
+lock, switching the monitor output to a specific device, and cycling
+an output's feed through Monitor A, Monitor B and Monitor A+B. Each key
 can pick its icon, and a typed title replaces the built-in label.
 
 ![Keys](plugin-keys.png)

--- a/docs/hardware-support.md
+++ b/docs/hardware-support.md
@@ -1,8 +1,8 @@
 # Hardware support
 
 The state of every device OpenXLR supports, control by control. The
-last two rows need owners; the section at the bottom explains how to
-help.
+Wave XLR row still needs an owner; the section at the bottom explains
+how to help.
 
 | Device | USB id | Status |
 |---|---|---|

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -4,7 +4,8 @@ The daemon listens on `127.0.0.1:37890`. HTTP requests use the same per-session
 token as the existing WebSocket clients, presented as `Authorization: Bearer
 <token>`. Read it from `$XDG_RUNTIME_DIR/openxlr/token`, or from
 `$XDG_CONFIG_HOME/openxlr/token` (`~/.config/openxlr/token`) when the runtime
-directory is unset. The daemon creates the private token file at startup.
+directory is unset. The daemon writes the private token file once it is
+listening, and not before.
 There is no second credential or change to the existing UI/OpenDeck login.
 
 Foreign browser Origins are refused even with a valid token. JSON commands
@@ -35,11 +36,13 @@ This reports execution, not a new durability guarantee: saving follows each
 existing command's behavior. Never automatically retry a mutation after losing
 the connection; it may already have executed.
 
-Error status codes: 401 missing/wrong token, 403 foreign Origin, 408 body-read
-deadline, 413 body over 64 KiB, 415 wrong Content-Type, 429 budget exhausted or
-another HTTP mutation in flight. Chunked bodies have the same 64 KiB cap and
+Error status codes: 400 a body that is not valid UTF-8, or a plain request
+on the events route without a WebSocket upgrade; 401 missing/wrong token;
+403 foreign Origin; 408 body-read deadline; 413 body over 64 KiB; 415 wrong
+Content-Type; 429 budget exhausted or another HTTP mutation in flight. Chunked bodies have the same 64 KiB cap and
 five-second deadline. One HTTP command runs at a time, with no waiting queue.
 All authenticated HTTP responses use `Cache-Control: no-store`.
 
 The [OpenAPI document](openapi-v1.json) describes the HTTP endpoints. Restarting
-the daemon rotates its existing per-session token; clients must reread it.
+the daemon rotates its per-session token once the new instance listens;
+clients must reread it.

--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -129,9 +129,21 @@ persistent failure, use `systemctl --user reset-failed openxlr-daemon` followed
 by `systemctl --user start openxlr-daemon`. Manual launches without
 `NOTIFY_SOCKET` do not enable the watchdog.
 
-OpenXLR does not install a file-descriptor-limit override for pipewire-pulse.
-If its journal reports exhausted descriptors, inspect that service's limits
-and configure a user override explicitly for your environment.
+The packages raise pipewire-pulse's open-file limit with a systemd
+drop-in; a source install has to create it itself, or the daemon refuses
+to grow the mixer layout once the server nears systemd's default of 1024
+open files:
+
+```sh
+mkdir -p ~/.config/systemd/user/pipewire-pulse.service.d
+cp packaging/pipewire-pulse-openxlr.conf ~/.config/systemd/user/pipewire-pulse.service.d/openxlr.conf
+systemctl --user daemon-reload
+systemctl --user restart pipewire-pulse
+```
+
+The restart takes OpenXLR's nodes with it; the daemon notices and
+restarts itself to rebuild them. The manual's
+[open-files section](manual.md#open-files) has the background and the check.
 
 
 ## 7. OpenDeck plugin (optional)
@@ -162,6 +174,8 @@ rm ~/.config/systemd/user/openxlr-daemon.service
 sudo rm /etc/udev/rules.d/70-openxlr.rules
 rm -rf ~/.config/openxlr ~/.config/opendeck/plugins/com.emaspa.openxlr.sdPlugin
 rm ~/.config/wireplumber/wireplumber.conf.d/50-xlr-dock-capture-hold.conf
+rm -r ~/.config/systemd/user/pipewire-pulse.service.d   # the open-file drop-in, if you created it
+systemctl --user daemon-reload
 ```
 
 ## Environment variables

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -327,8 +327,10 @@ and Aux are listed but fixed.
 
 Every change is saved before the editor confirms it. If the settings
 file cannot be written the change is undone and the editor says why. The
-same happens when pipewire-pulse has no room for more streams;
-[section 5.8](#open-files) explains the limit and the drop-in that raises it.
+same happens when pipewire-pulse has no room for more streams
+([section 5.8](#open-files) explains the limit and the drop-in that raises
+it), and when the new channel's or mix's sends have not appeared within
+three seconds: nothing is kept that the daemon could not set.
 Ids are generated from names and never change afterwards, so profiles
 and Stream Deck keys survive a rename. The layout file is described in
 [mixer-layout.md](mixer-layout.md).
@@ -400,6 +402,9 @@ restart WirePlumber.
   before 0.1.9; opening the mixer window once repairs it, or remove the
   file, `systemctl --user daemon-reload`, then
   `systemctl --user enable --now openxlr-daemon`.
+- "another OpenXLR daemon is already running for this user": a second
+  daemon was started by hand while the service runs. It stops at once;
+  stop the service first if you meant to run the daemon by hand.
 - "port 37890 busy": another program holds the daemon's API port,
   which sits inside the kernel's ephemeral range. The daemon waits up
   to a minute for it and otherwise exits for systemd to retry; nothing
@@ -451,7 +456,9 @@ a hang, so nothing stays stuck inside the daemon. After three hangs in
 one run the daemon stops driving that interface and says so under the
 window's header, while the submixer and any other interface keep
 working. Unplug the interface and plug it back in, or restart the
-daemon, to try again.
+daemon, to try again. A helper whose device could not be opened at all
+(the udev rule not applied yet, see [section 5.1](#no-device)) is
+killed straight away and the daemon tries again two seconds later.
 Collect diagnostics afterwards ([section 5.9](#reporting)): the archive contains the
 exact transfer, and that is what makes the report actionable.
 
@@ -525,7 +532,8 @@ it to a public issue. Nothing is uploaded automatically.
 | `~/.config/openxlr/mixer.json` | every mixer decision, the layout included (`userChannels`, `userMixes`, see [mixer-layout.md](mixer-layout.md)), written by the daemon |
 | `~/.config/openxlr/profiles/<vid-pid>/<name>.json` | saved profiles, one file each |
 | `~/.config/openxlr/profiles/<vid-pid>/recall-on-connect` | the profile recalled when that interface connects, when one is chosen |
-| `$XDG_RUNTIME_DIR/openxlr/token` | the control API token for this daemon run, readable by your user only; the window and the OpenDeck plugin read it, a daemon older than the window will not have it ([section 3.10](#upgrade)) |
+| `$XDG_RUNTIME_DIR/openxlr/token` (or `~/.config/openxlr/token` without a runtime directory) | the control API token for this daemon run, readable by your user only; the window and the OpenDeck plugin read it, a daemon older than the window will not have it ([section 3.10](#upgrade)) |
+| `$XDG_RUNTIME_DIR/openxlr/daemon.lock` | held by the running daemon; a second daemon started for the same user stops at once instead of waiting for the port |
 | `~/.config/openxlr/devices/<vid-pid>/last-state.json` | the settings restored on connect to an interface without settings memory |
 | `~/.config/openxlr/devices/<vid-pid>/defaults.json` | the firmware defaults of such an interface, recorded after a power cycle, written back by "Reset device to defaults" |
 | `~/.config/openxlr/daemon.json` | the submixer on/off preference |

--- a/docs/mixer-layout.md
+++ b/docs/mixer-layout.md
@@ -40,7 +40,10 @@ acknowledged; a failed save restores the previous layout and reports an
 error. Ordinary fader saves keep their debounced, retried behaviour.
 
 - `createChannel {name}` adds an application channel. Only its sink is
-  loaded; it starts muted in every mix.
+  loaded; it starts muted in every mix. The sink's sends into the mixes
+  must appear within three seconds, or the sink is unloaded again and
+  the command fails: a send that showed up later would carry PipeWire's
+  defaults, full level and unmuted, instead of the stored fader.
 - `renameChannel {channel, name}` saves the name and reloads that channel's
   playback device under it, so desktop applets show the new name at once.
   PipeWire parks the streams that were playing into it on the default
@@ -50,7 +53,9 @@ error. Ordinary fader saves keep their debounced, retried behaviour.
   unloads its sink. The last application channel stays.
 - `createMix {name}` adds a virtual microphone. The channel sinks feed the
   mix sinks by name pattern, so every channel grows a send into the new mix
-  by itself, muted before the capture device is published.
+  by itself, muted before the capture device is published. If a channel's
+  send has not appeared within three seconds the mix is removed again and
+  the command fails, for the same reason.
 - `renameMix {mix, name}` changes the name in OpenXLR only. Reloading the
   capture device would drop every app recording from it onto another
   source, so its PipeWire description keeps the old name until the daemon

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ behaviour verified on hardware before it ships. The project is small on
 purpose. It prefers one small, idiomatic change over a framework, and a
 feature that is measured over one that is described.
 
-## Where it stands (0.1.24)
+## Where it stands (0.1.25)
 
 - [x] Wave XLR Pro, XLR Dock (MK.1 and MK.2 modules), Wave XLR, Wave XLR
   MK.2: hardware controls, verified by owners of each device.

--- a/src/OpenXLR.Daemon/DaemonLock.cs
+++ b/src/OpenXLR.Daemon/DaemonLock.cs
@@ -1,0 +1,30 @@
+using OpenXLR.Core;
+
+namespace OpenXLR.Daemon;
+
+/// <summary>
+/// One daemon per user. The lock file lives next to the token in the
+/// runtime directory and is held for the life of the process; the kernel
+/// releases it when the process ends, however it ends. A second instance,
+/// started by hand while the service runs, stops here with a clear message
+/// instead of waiting a minute for a port it will never get.
+/// </summary>
+public static class DaemonLock
+{
+    public static string Path => System.IO.Path.Combine(System.IO.Path.GetDirectoryName(OpenXlrPaths.TokenPath)!, "daemon.lock");
+
+    /// <summary>The held lock, or null when another process holds it.</summary>
+    public static FileStream? TryAcquire(string? path = null)
+    {
+        path ??= Path;
+        OpenXlrPaths.EnsurePrivateDir(System.IO.Path.GetDirectoryName(path)!);
+        try
+        {
+            // FileShare.None is an exclusive advisory lock on Unix; the
+            // stream is never written, only held.
+            return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+}

--- a/src/OpenXLR.Daemon/Program.cs
+++ b/src/OpenXLR.Daemon/Program.cs
@@ -71,6 +71,14 @@ app.Map("/ws", async (HttpContext ctx, WebSocketHub hub) =>
 
 app.MapGet("/", () => Results.Text($"OpenXLR daemon. Control API: ws://127.0.0.1:{ApiPort}/ws"));
 
+// One daemon per user, before anything else is touched.
+using FileStream? instanceLock = DaemonLock.TryAcquire();
+if (instanceLock is null)
+{
+    app.Logger.LogError("another OpenXLR daemon is already running for this user (it holds {Lock}); exiting", DaemonLock.Path);
+    return 75;
+}
+
 // The hosted services (device connect, PipeWire graph build) start before
 // Kestrel binds, so a busy port used to mean: build the whole submix graph,
 // fail to bind, abort with a core dump, get restarted by systemd, repeat.

--- a/src/OpenXLR.Tests/ApiTokenTests.cs
+++ b/src/OpenXLR.Tests/ApiTokenTests.cs
@@ -81,5 +81,23 @@ public sealed class ApiTokenTests
     }
 
     [Fact]
+    public void TheDaemonLockIsExclusiveAndReleasedWithItsHolder()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "openxlr-test-" + Guid.NewGuid().ToString("N"));
+        string path = Path.Combine(dir, "daemon.lock");
+        try
+        {
+            using (FileStream? first = DaemonLock.TryAcquire(path))
+            {
+                Assert.NotNull(first);
+                Assert.Null(DaemonLock.TryAcquire(path));   // a second instance is refused
+            }
+            using FileStream? again = DaemonLock.TryAcquire(path);   // the holder is gone, the lock is free
+            Assert.NotNull(again);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch (IOException) { } }
+    }
+
+    [Fact]
     public void NothingMatchesBeforeATokenExists() => Assert.False(ApiToken.Matches(null, Bytes("{\"cmd\":\"auth\",\"token\":\"\"}")));
 }

--- a/src/OpenXLR.Tests/DefaultDefenseTests.cs
+++ b/src/OpenXLR.Tests/DefaultDefenseTests.cs
@@ -7,28 +7,39 @@ public sealed class DefaultDefenseTests
     [Fact]
     public async Task EveryPassReassertsADriftedDefaultAndNothingRunsAfterAStop()
     {
+        // The first pass repairs the sink. The second pass is held inside its
+        // first helper call while the stop arrives; its repair must not run.
         var calls = new List<string>();
         string sink = "alsa_output.katana";
+        int gets = 0;
+        var secondPassInside = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var release = new ManualResetEventSlim();
         string run(string[] args)
         {
             lock (calls) calls.Add(string.Join(' ', args));
-            if (args[0] == "get-default-sink") return "OpenXLR_ch_system";   // WirePlumber moved it
-            if (args[0] == "get-default-source") return "OpenXLR_mic";       // already right
+            if (args[0] == "get-default-sink")
+            {
+                if (Interlocked.Increment(ref gets) == 2) { secondPassInside.TrySetResult(); release.Wait(TimeSpan.FromSeconds(5)); }
+                return "OpenXLR_ch_system";   // WirePlumber moved it
+            }
+            if (args[0] == "get-default-source") return "OpenXLR_mic";   // already right
             return "";
         }
         using var stop = new CancellationTokenSource();
-        Task loop = DefaultDefense.RunAsync(sink, "OpenXLR_mic", run, [50, 50, 50, 50], stop.Token);
-        await Task.Delay(140);
+        Task loop = DefaultDefense.RunAsync(sink, "OpenXLR_mic", run, [10, 10, 10, 10], stop.Token);
+        await secondPassInside.Task.WaitAsync(TimeSpan.FromSeconds(5));
         stop.Cancel();
+        release.Set();
         await loop.WaitAsync(TimeSpan.FromSeconds(2));
-        int passes;
-        lock (calls) passes = calls.Count(c => c == "get-default-sink");
-        Assert.InRange(passes, 1, 3);                                              // two passes fit in 140 ms, never all four
-        lock (calls) Assert.Equal(passes, calls.Count(c => c == $"set-default-sink {sink}"));   // each pass repaired the sink
-        lock (calls) Assert.DoesNotContain(calls, c => c.StartsWith("set-default-source"));   // the source was fine
+        lock (calls)
+        {
+            Assert.Equal(2, calls.Count(c => c == "get-default-sink"));                     // two passes started, never all four
+            Assert.Equal(1, calls.Count(c => c == $"set-default-sink {sink}"));             // only the first pass repaired
+            Assert.DoesNotContain(calls, c => c.StartsWith("set-default-source"));          // the source was fine
+        }
         int after; lock (calls) after = calls.Count;
-        await Task.Delay(200);
-        lock (calls) Assert.Equal(after, calls.Count);                             // no pass after the stop
+        await Task.Delay(100);
+        lock (calls) Assert.Equal(after, calls.Count);                                     // no pass after the stop
     }
 
     [Fact]

--- a/tools/check-spec.py
+++ b/tools/check-spec.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Every file the RPM %install section puts under %{buildroot} must be
+claimed by a %files entry, and no bare path may sit in %install (rpm
+would execute it as a command). Standard library only, so it runs on any
+CI runner without rpm tools."""
+import fnmatch
+import re
+import sys
+
+path = sys.argv[1] if len(sys.argv) > 1 else "packaging/rpm/openxlr.spec"
+text = open(path).read()
+
+
+SECTIONS = "prep|build|install|check|files|changelog|pre|post|preun|postun|description|package"
+
+
+def section(name):
+    m = re.search(r"^%" + name + r"\b[^\n]*\n(.*?)(?=^%(?:" + SECTIONS + r")\b|\Z)", text, re.S | re.M)
+    return m.group(1) if m else ""
+
+
+install, files = section("install"), section("files")
+errors = []
+# Files and directories the recipe installs; directories made for the
+# sake of a later install line are claimed through their contents.
+installed = [t for line in install.splitlines() if not re.search(r"install\s+-d|mkdir", line)
+             for t in re.findall(r"%\{buildroot\}(\S+)", line)]
+claims = [line.split()[-1] for line in files.splitlines()
+          if line.strip() and not line.startswith(("%license", "%doc", "%defattr", "#"))]
+claims = [re.sub(r"^%(?:config(?:\(noreplace\))?|attr\([^)]*\))\s*", "", c) for c in claims]
+
+
+def claimed(target):
+    for c in claims:
+        if fnmatch.fnmatch(target, c) or target == c.rstrip("/") or target.startswith(c.rstrip("/") + "/"):
+            return True
+    return False
+
+
+for line in install.splitlines():
+    s = line.strip()
+    if s.startswith("%{_") and not s.startswith("%{_bindir}/") and " " not in s:
+        errors.append(f"bare path in %install, rpm would execute it: {s}")
+for target in installed:
+    target = target.rstrip("/")
+    if not claimed(target):
+        errors.append(f"installed but not in %files: {target}")
+for e in errors:
+    print(f"spec: {e}", file=sys.stderr)
+print(f"spec: {len(installed)} install targets, {len(claims)} %files entries, {'ok' if not errors else str(len(errors)) + ' problems'}")
+sys.exit(1 if errors else 0)


### PR DESCRIPTION
The rpm recipe is checked in CI: every path installed under the build
root must have a %files entry and no bare path may sit in %install, the
defect that slipped in this afternoon. The release workflows assert the
pipewire-pulse drop-in is inside the built rpm and deb. One daemon per
user: a lock file next to the token, held for the life of the process,
stops a second instance at once with a clear message instead of a
minute's wait for the port.

Docs revised against the code before 0.1.25: the source install creates
the drop-in itself and removes it on uninstall; the lock file, the
token replaced only on listen, fail-closed layout edits, the killed
helper on a refused open, the catalog caps, the events route's status
codes, Monitor A+B on the deck key, the roadmap's version, the hardware
table's intro, and one lock-file recipe and one complete check list in
the contributor and agent notes.

Verified: 212 tests including the lock test, tools/check-spec.py passes on the current spec and flags both defects in this afternoon's broken one, and on this desk a hand-started second daemon exited with 75 in under a second while the service kept all nine sinks.