### PR TITLE
Reset the Wave XLR Pro to OpenXLR's baseline

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setActiveDevice` | `device` | switch to another attached interface (`vvvv:pppp`) |
 | `saveProfile` / `loadProfile` / `deleteProfile` | `name` | named scenes, scoped to the active device |
 | `setRecallOnConnect` | `name` | the profile recalled whenever the active device connects fresh (daemon start, replug, switch to it); empty clears it. With none chosen, a device whose capabilities say `retainsSettings: false` gets the last settings the daemon saw on it instead |
-| `resetDevice` | none | write the firmware defaults back to a device without settings memory and forget its last settings; an error until the daemon has seen the device connect after a power cycle once |
+| `resetDevice` | none | write the firmware defaults back to a device without settings memory and forget its last settings (an error until the daemon has seen the device connect after a power cycle once); on the Wave XLR Pro, which keeps its own settings, write OpenXLR's baseline instead: gain 30 dB on both inputs, every processing stage and phantom off, headphones, crossfade and aux level at half, routing untouched, refused while the gain lock is on. The capabilities say `builtInDefaults` when a model has a baseline |
 | `getDiagnostics` | none | vendor block dump for bug reports |
 
 The OpenDeck plugin in `plugin/` is a client of this API; the command

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setActiveDevice` | `device` | switch to another attached interface (`vvvv:pppp`) |
 | `saveProfile` / `loadProfile` / `deleteProfile` | `name` | named scenes, scoped to the active device |
 | `setRecallOnConnect` | `name` | the profile recalled whenever the active device connects fresh (daemon start, replug, switch to it); empty clears it. With none chosen, a device whose capabilities say `retainsSettings: false` gets the last settings the daemon saw on it instead |
-| `resetDevice` | none | write the firmware defaults back to a device without settings memory and forget its last settings (an error until the daemon has seen the device connect after a power cycle once); on the Wave XLR Pro, which keeps its own settings, write OpenXLR's baseline instead: gain 30 dB on both inputs, every processing stage and phantom off, headphones, crossfade and aux level at half, routing untouched, refused while the gain lock is on. The capabilities say `builtInDefaults` when a model has a baseline |
+| `resetDevice` | none | write the firmware defaults back to a device without settings memory and forget its last settings (an error until the daemon has seen the device connect after a power cycle once); on the Wave XLR Pro, which keeps its own settings, write OpenXLR's baseline instead: gain 30 dB on both inputs, every processing stage and phantom off, headphones and aux level at half, the crossfade fully on PC, routing untouched, refused while the gain lock is on. The capabilities say `builtInDefaults` when a model has a baseline |
 | `getDiagnostics` | none | vendor block dump for bug reports |
 
 The OpenDeck plugin in `plugin/` is a client of this API; the command

--- a/docs/features.md
+++ b/docs/features.md
@@ -162,7 +162,9 @@ marked to recall on connect: at daemon start, after a replug or power
 cycle, or when switching to that device. Interfaces without settings
 memory (Wave XLR, the first XLR Dock) get their last settings back
 on every fresh connect without a profile, and can be reset to the
-firmware defaults recorded after a power cycle. App routing and the
+firmware defaults recorded after a power cycle. The Wave XLR Pro, which
+keeps its own settings, can be reset to OpenXLR's baseline instead:
+gain 30 dB, everything off, levels at half. App routing and the
 enforced system defaults are global and not part of a profile, so
 recalling one does not rewire the desktop.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -164,7 +164,7 @@ memory (Wave XLR, the first XLR Dock) get their last settings back
 on every fresh connect without a profile, and can be reset to the
 firmware defaults recorded after a power cycle. The Wave XLR Pro, which
 keeps its own settings, can be reset to OpenXLR's baseline instead:
-gain 30 dB, everything off, levels at half. App routing and the
+gain 30 dB, everything off, levels at half, the crossfade on PC. App routing and the
 enforced system defaults are global and not part of a profile, so
 recalling one does not rewire the desktop.
 

--- a/docs/hardware-support.md
+++ b/docs/hardware-support.md
@@ -28,6 +28,7 @@ the commit block every selector write needs.
 | Mic and PC crossfade | verified | direct monitor inside the device |
 | Physical output routing | verified | HP1, HP2, Line Out, USB Aux; verified by listening on both jacks |
 | USB Aux input level + lock, aux return | verified | return routing latches at stream open; the daemon bounces the stream |
+| Reset to OpenXLR's baseline | verified | the device keeps its settings, so the reset writes a known set (gain 30 dB, everything off, levels at half) instead of recorded firmware defaults |
 
 ## XLR Dock (0fd9:00a6)
 

--- a/docs/hardware-support.md
+++ b/docs/hardware-support.md
@@ -28,7 +28,7 @@ the commit block every selector write needs.
 | Mic and PC crossfade | verified | direct monitor inside the device |
 | Physical output routing | verified | HP1, HP2, Line Out, USB Aux; verified by listening on both jacks |
 | USB Aux input level + lock, aux return | verified | return routing latches at stream open; the daemon bounces the stream |
-| Reset to OpenXLR's baseline | verified | the device keeps its settings, so the reset writes a known set (gain 30 dB, everything off, levels at half) instead of recorded firmware defaults |
+| Reset to OpenXLR's baseline | verified | the device keeps its settings, so the reset writes a known set (gain 30 dB, everything off, levels at half, crossfade on PC) instead of recorded firmware defaults |
 
 ## XLR Dock (0fd9:00a6)
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -243,6 +243,14 @@ stay). The defaults are recorded the first time the interface connects
 after a power cycle, so the button asks for one replug on a fresh
 install.
 
+The Wave XLR Pro keeps its settings in its own memory, so there is no
+clean state to record and whatever is set on Linux is what Wave Link
+finds on Windows, and the other way round. For it the same button
+writes OpenXLR's baseline instead: gain 30 dB on both inputs, every
+processing stage and phantom power off, headphones, crossfade and aux
+level at half. Output routing and saved profiles stay. The gain lock
+has to be off.
+
 <a name="default-devices"></a>
 ### 3.7 Hold the system default devices
 
@@ -535,7 +543,7 @@ it to a public issue. Nothing is uploaded automatically.
 | `$XDG_RUNTIME_DIR/openxlr/token` (or `~/.config/openxlr/token` without a runtime directory) | the control API token for this daemon run, readable by your user only; the window and the OpenDeck plugin read it, a daemon older than the window will not have it ([section 3.10](#upgrade)) |
 | `$XDG_RUNTIME_DIR/openxlr/daemon.lock` | held by the running daemon; a second daemon started for the same user stops at once instead of waiting for the port |
 | `~/.config/openxlr/devices/<vid-pid>/last-state.json` | the settings restored on connect to an interface without settings memory |
-| `~/.config/openxlr/devices/<vid-pid>/defaults.json` | the firmware defaults of such an interface, recorded after a power cycle, written back by "Reset device to defaults" |
+| `~/.config/openxlr/devices/<vid-pid>/defaults.json` | the firmware defaults of such an interface, recorded after a power cycle, written back by "Reset device to defaults" (the Pro has no such file: its reset writes OpenXLR's baseline) |
 | `~/.config/openxlr/daemon.json` | the submixer on/off preference |
 | `~/.config/openxlr/gainlock.json` | which devices have the gain lock set |
 | `~/.config/openxlr/ui.json` | window preferences |

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -237,7 +237,8 @@ daemon remembers every change and writes it back whenever the
 interface connects fresh, so a reboot or a replug leaves you where you
 were, with no profile needed. The picker shows "(last settings)" in
 place of "(none)" on these devices; a chosen profile takes precedence.
-"Reset device to defaults" under the picker writes the firmware
+"Reset device to defaults", in Options under INTERFACE (away from the
+profile picker, where a slip would be costly), writes the firmware
 defaults back and forgets the remembered settings (saved profiles
 stay). The defaults are recorded the first time the interface connects
 after a power cycle, so the button asks for one replug on a fresh

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -247,9 +247,9 @@ The Wave XLR Pro keeps its settings in its own memory, so there is no
 clean state to record and whatever is set on Linux is what Wave Link
 finds on Windows, and the other way round. For it the same button
 writes OpenXLR's baseline instead: gain 30 dB on both inputs, every
-processing stage and phantom power off, headphones, crossfade and aux
-level at half. Output routing and saved profiles stay. The gain lock
-has to be off.
+processing stage and phantom power off, headphones and aux level at
+half, the crossfade fully on PC. Output routing and saved profiles
+stay. The gain lock has to be off.
 
 <a name="default-devices"></a>
 ### 3.7 Hold the system default devices

--- a/src/OpenXLR.Core/Devices/DeviceDefaults.cs
+++ b/src/OpenXLR.Core/Devices/DeviceDefaults.cs
@@ -5,7 +5,8 @@ namespace OpenXLR.Core.Devices;
 /// memory. Such a device never boots to a clean state, so there is nothing
 /// to record after a power cycle; instead a known, safe set is written on
 /// request: a moderate gain, every processing stage and phantom power off,
-/// every level at half. Output routing and the monitor mix membership are
+/// every level at half, the headphone crossfade fully on PC. Output routing
+/// and the monitor mix membership are
 /// left as they are, since the daemon drives those from the mixer.
 /// </summary>
 public static class DeviceDefaults
@@ -30,7 +31,7 @@ public static class DeviceDefaults
             Compressor = false, Compressor2 = false,
             HpVolumeDb = -30, Hp2VolumeDb = -30,   // half of the 60 dB attenuator range
             LowImpedance = false,
-            Crossfade = 100,                       // centre
+            Crossfade = 200,                       // all the way to PC: the mixer's monitor mix, not the direct mic
             AuxLevelDb = -30,                      // half of the -60..0 dB range
             AuxLevelLock = false,
         };

--- a/src/OpenXLR.Core/Devices/DeviceDefaults.cs
+++ b/src/OpenXLR.Core/Devices/DeviceDefaults.cs
@@ -1,0 +1,38 @@
+namespace OpenXLR.Core.Devices;
+
+/// <summary>
+/// OpenXLR's baseline for an interface that keeps its settings in its own
+/// memory. Such a device never boots to a clean state, so there is nothing
+/// to record after a power cycle; instead a known, safe set is written on
+/// request: a moderate gain, every processing stage and phantom power off,
+/// every level at half. Output routing and the monitor mix membership are
+/// left as they are, since the daemon drives those from the mixer.
+/// </summary>
+public static class DeviceDefaults
+{
+    /// <summary>Whether a baseline exists for this model.</summary>
+    public static bool HasBaseline(DeviceInfo info) => info.ProductId == WaveXlrProDevice.ProductId;
+
+    /// <summary>The baseline for <paramref name="info"/> over the current state, or null for a model without one.</summary>
+    public static DeviceState? Baseline(DeviceInfo info, DeviceState current)
+    {
+        if (!HasBaseline(info)) return null;
+        return current with
+        {
+            GainDb = 30, Gain2Db = 30,
+            Mute = false, Mute2 = false,
+            LowCut = false, LowCut2 = false,
+            Expander = false, Expander2 = false,
+            VoiceTune = false, VoiceTune2 = false,
+            VoiceTuneStrength = 50, VoiceTuneStrength2 = 50,
+            Phantom = false, Phantom2 = false,
+            ClipGuard = false, ClipGuard2 = false,
+            Compressor = false, Compressor2 = false,
+            HpVolumeDb = -30, Hp2VolumeDb = -30,   // half of the 60 dB attenuator range
+            LowImpedance = false,
+            Crossfade = 100,                       // centre
+            AuxLevelDb = -30,                      // half of the -60..0 dB range
+            AuxLevelLock = false,
+        };
+    }
+}

--- a/src/OpenXLR.Core/Devices/IAudioDevice.cs
+++ b/src/OpenXLR.Core/Devices/IAudioDevice.cs
@@ -118,4 +118,11 @@ public sealed record DeviceCapabilities
     /// one of them connects fresh, and offers a reset to those defaults.
     /// </summary>
     public bool RetainsSettings { get; init; } = true;
+
+    /// <summary>
+    /// Whether OpenXLR ships a baseline for this model (see
+    /// <see cref="DeviceDefaults"/>), so a device that keeps its settings can
+    /// still be reset to a known state.
+    /// </summary>
+    public bool BuiltInDefaults { get; init; }
 }

--- a/src/OpenXLR.Core/Devices/WaveXlrProDevice.cs
+++ b/src/OpenXLR.Core/Devices/WaveXlrProDevice.cs
@@ -25,6 +25,7 @@ public sealed class WaveXlrProDevice : IAudioDevice, IDisposable
         Phantom = true, ClipGuard = true, Compressor = true,
         OutputRouting = true, AuxInput = true,
         XlrInputs = 2, HpOutputs = 2,
+        BuiltInDefaults = true,
     };
 
     private const ushort VIndex = 0x0103;

--- a/src/OpenXLR.Daemon/DeviceManager.cs
+++ b/src/OpenXLR.Daemon/DeviceManager.cs
@@ -445,7 +445,18 @@ public sealed class DeviceManager : BackgroundService
         lock (_gate)
         {
             if (_device is null || !_device.Connected) return "no device connected";
-            if (_device.Capabilities.RetainsSettings) return "resetDevice: this interface keeps its own settings";
+            if (_device.Capabilities.RetainsSettings)
+            {
+                // Nothing to record on a device that keeps its settings:
+                // OpenXLR's own baseline is written instead, when the model has one.
+                DeviceState current;
+                try { current = _last ?? Stamp(_device.ReadState()); }
+                catch (Exception ex) { return ex.Message; }
+                DeviceState? baseline = DeviceDefaults.Baseline(_device.Info, current);
+                if (baseline is null) return "resetDevice: this interface keeps its own settings and OpenXLR has no baseline for it";
+                if (GainIsLocked) return "resetDevice: release the gain lock first";
+                return ApplyProfile(baseline);
+            }
             string id = DevId(_device);
             DeviceState? defaults;
             try { defaults = DeviceStateStore.LoadDefaults(id); }

--- a/src/OpenXLR.Tests/DeviceDefaultsTests.cs
+++ b/src/OpenXLR.Tests/DeviceDefaultsTests.cs
@@ -1,0 +1,35 @@
+using OpenXLR.Core.Devices;
+
+namespace OpenXLR.Tests;
+
+public sealed class DeviceDefaultsTests
+{
+    [Fact]
+    public void TheProBaselineIsSafeAndKeepsRouting()
+    {
+        var info = new DeviceInfo("Elgato", "Wave XLR Pro", 0x0fd9, 0x00b4);
+        var current = new DeviceState
+        {
+            GainDb = 72, Gain2Db = 0, Phantom = true, Phantom2 = true, ClipGuard = true, Compressor = true,
+            LowCut = true, Expander = true, VoiceTune = true, VoiceTuneStrength = 90, Mute = true,
+            HpVolumeDb = 0, Hp2VolumeDb = -60, LowImpedance = true, Crossfade = 0, AuxLevelDb = 0, AuxLevelLock = true,
+            OutHp1 = true, OutHp2 = false, OutUsbAux = true, OutLineOut = false,
+            HpMixMonitorReturn = true, HpMixMicDirect = false, AuxReturnEnabled = true,
+        };
+        DeviceState b = DeviceDefaults.Baseline(info, current)!;
+        Assert.Equal((30, 30), (b.GainDb, b.Gain2Db));
+        Assert.False(b.Phantom || b.Phantom2 || b.ClipGuard || b.Compressor || b.LowCut || b.Expander || b.VoiceTune || b.Mute || b.LowImpedance || b.AuxLevelLock);
+        Assert.Equal((-30.0, -30.0, 100, -30.0, 50), (b.HpVolumeDb, b.Hp2VolumeDb, b.Crossfade, b.AuxLevelDb, b.VoiceTuneStrength));
+        // Routing and mix membership are the mixer's business and stay.
+        Assert.Equal((true, false, true, false), (b.OutHp1, b.OutHp2, b.OutUsbAux, b.OutLineOut));
+        Assert.Equal((true, false, true), (b.HpMixMonitorReturn, b.HpMixMicDirect, b.AuxReturnEnabled));
+    }
+
+    [Fact]
+    public void OnlyModelsWithABaselineGetOne()
+    {
+        Assert.Null(DeviceDefaults.Baseline(new DeviceInfo("Elgato", "Wave XLR", 0x0fd9, 0x007d), new DeviceState()));
+        Assert.False(DeviceDefaults.HasBaseline(new DeviceInfo("Elgato", "XLR Dock MK.2", 0x0fd9, 0x00c7)));
+        Assert.True(DeviceDefaults.HasBaseline(new DeviceInfo("Elgato", "Wave XLR Pro", 0x0fd9, 0x00b4)));
+    }
+}

--- a/src/OpenXLR.Tests/DeviceDefaultsTests.cs
+++ b/src/OpenXLR.Tests/DeviceDefaultsTests.cs
@@ -19,7 +19,7 @@ public sealed class DeviceDefaultsTests
         DeviceState b = DeviceDefaults.Baseline(info, current)!;
         Assert.Equal((30, 30), (b.GainDb, b.Gain2Db));
         Assert.False(b.Phantom || b.Phantom2 || b.ClipGuard || b.Compressor || b.LowCut || b.Expander || b.VoiceTune || b.Mute || b.LowImpedance || b.AuxLevelLock);
-        Assert.Equal((-30.0, -30.0, 100, -30.0, 50), (b.HpVolumeDb, b.Hp2VolumeDb, b.Crossfade, b.AuxLevelDb, b.VoiceTuneStrength));
+        Assert.Equal((-30.0, -30.0, 200, -30.0, 50), (b.HpVolumeDb, b.Hp2VolumeDb, b.Crossfade, b.AuxLevelDb, b.VoiceTuneStrength));
         // Routing and mix membership are the mixer's business and stay.
         Assert.Equal((true, false, true, false), (b.OutHp1, b.OutHp2, b.OutUsbAux, b.OutLineOut));
         Assert.Equal((true, false, true), (b.HpMixMonitorReturn, b.HpMixMicDirect, b.AuxReturnEnabled));

--- a/src/OpenXLR.UI/Dialogs.cs
+++ b/src/OpenXLR.UI/Dialogs.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+
+namespace OpenXLR.UI;
+
+/// <summary>The window's small confirmation dialog, shared by every window that asks before acting.</summary>
+internal static class Dialogs
+{
+    /// <summary>True when the user accepts; closing the dialog any other way is a no.</summary>
+    public static async Task<bool> ConfirmAsync(Window owner, string title, string message, string yesLabel)
+    {
+        var yes = new Button { Content = yesLabel, Background = Avalonia.Media.Brush.Parse("#a03434") };
+        var no = new Button { Content = "Cancel", IsCancel = true };
+        var dialog = new Window
+        {
+            Title = title,
+            SizeToContent = SizeToContent.WidthAndHeight,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Background = Avalonia.Media.Brush.Parse("#1d2027"),
+            Content = new StackPanel
+            {
+                Margin = new Avalonia.Thickness(18),
+                Spacing = 14,
+                Children =
+                {
+                    new TextBlock { Text = message, TextWrapping = Avalonia.Media.TextWrapping.Wrap, MaxWidth = 380 },
+                    new StackPanel
+                    {
+                        Orientation = Avalonia.Layout.Orientation.Horizontal,
+                        Spacing = 8,
+                        HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                        Children = { no, yes },
+                    },
+                },
+            },
+        };
+        var done = new TaskCompletionSource<bool>();
+        yes.Click += (_, _) => { done.TrySetResult(true); dialog.Close(); };
+        no.Click += (_, _) => { done.TrySetResult(false); dialog.Close(); };
+        dialog.Closed += (_, _) => done.TrySetResult(false);
+        await dialog.ShowDialog(owner);
+        return await done.Task;
+    }
+}

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -196,10 +196,6 @@
                               ItemsSource="{Binding RecallChoices}"
                               SelectedItem="{Binding RecallOnConnectChoice}"/>
                   </Grid>
-                  <Button Content="Reset device to defaults" FontSize="12" Margin="0,6,0,0"
-                          HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
-                          IsVisible="{Binding ShowResetDefaults}" Click="OnResetDevice"
-                          ToolTip.Tip="{Binding ResetDescription}"/>
                 </StackPanel>
               </Flyout>
             </DropDownButton.Flyout>

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -199,7 +199,7 @@
                   <Button Content="Reset device to defaults" FontSize="12" Margin="0,6,0,0"
                           HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
                           IsVisible="{Binding ShowResetDefaults}" Click="OnResetDevice"
-                          ToolTip.Tip="Write the firmware defaults back to the interface and forget the settings OpenXLR restores on connect. Recorded the first time the interface is plugged in after a power cycle."/>
+                          ToolTip.Tip="{Binding ResetDescription}"/>
                 </StackPanel>
               </Flyout>
             </DropDownButton.Flyout>

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -180,10 +180,7 @@ public partial class MainWindow : Window
 
     private async void OnResetDevice(object? sender, RoutedEventArgs e)
     {
-        if (!await ConfirmAsync("Reset device to defaults?",
-                "The interface goes back to the settings its firmware starts with, and the " +
-                "settings OpenXLR restores when it connects are forgotten. Saved profiles stay.",
-                yesLabel: "Reset"))
+        if (!await ConfirmAsync("Reset device to defaults?", _vm.ResetDescription, yesLabel: "Reset"))
             return;
         _vm.ResetDevice();
     }

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -131,42 +131,8 @@ public partial class MainWindow : Window
         ProfileNameBox.Text = "";
     }
 
-    /// <summary>Small in-app confirmation dialog; true when the user accepts.</summary>
-    private async Task<bool> ConfirmAsync(string title, string message, string yesLabel = "Overwrite")
-    {
-        var yes = new Button { Content = yesLabel, Background = Avalonia.Media.Brush.Parse("#a03434") };
-        var no = new Button { Content = "Cancel" };
-        var dialog = new Window
-        {
-            Title = title,
-            SizeToContent = SizeToContent.WidthAndHeight,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
-            CanResize = false,
-            Background = Avalonia.Media.Brush.Parse("#1d2027"),
-            Content = new StackPanel
-            {
-                Margin = new Avalonia.Thickness(18),
-                Spacing = 14,
-                Children =
-                {
-                    new TextBlock { Text = message, TextWrapping = Avalonia.Media.TextWrapping.Wrap, MaxWidth = 380 },
-                    new StackPanel
-                    {
-                        Orientation = Avalonia.Layout.Orientation.Horizontal,
-                        Spacing = 8,
-                        HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
-                        Children = { no, yes },
-                    },
-                },
-            },
-        };
-        var done = new TaskCompletionSource<bool>();
-        yes.Click += (_, _) => { done.TrySetResult(true); dialog.Close(); };
-        no.Click += (_, _) => { done.TrySetResult(false); dialog.Close(); };
-        dialog.Closed += (_, _) => done.TrySetResult(false);
-        await dialog.ShowDialog(this);
-        return await done.Task;
-    }
+    private Task<bool> ConfirmAsync(string title, string message, string yesLabel = "Overwrite")
+        => Dialogs.ConfirmAsync(this, title, message, yesLabel);
 
     private void OnProfileLoad(object? sender, RoutedEventArgs e)
     {
@@ -176,13 +142,6 @@ public partial class MainWindow : Window
     private void OnProfileDelete(object? sender, RoutedEventArgs e)
     {
         if ((sender as Button)?.Tag is string name) _vm.DeleteProfile(name);
-    }
-
-    private async void OnResetDevice(object? sender, RoutedEventArgs e)
-    {
-        if (!await ConfirmAsync("Reset device to defaults?", _vm.ResetDescription, yesLabel: "Reset"))
-            return;
-        _vm.ResetDevice();
     }
 
     private void OnPickDevice(object? sender, RoutedEventArgs e)

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -22,6 +22,9 @@ public sealed class OptionsViewModel : ViewModelBase
     public DaemonClient Client => _client;
     public UpdatesViewModel Updates => _main.Updates;
 
+    /// <summary>The main view model, for the interface reset that lives in Options.</summary>
+    public MainViewModel Main => _main;
+
     public OptionsViewModel(DaemonClient client, MainViewModel main)
     {
         _client = client;

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -94,6 +94,15 @@
       </StackPanel>
     </Border>
 
+    <Border Classes="card" IsVisible="{Binding Main.ShowResetDefaults}">
+      <StackPanel Spacing="6">
+        <TextBlock Text="INTERFACE" Classes="h"/>
+        <TextBlock Text="{Binding Main.ResetDescription}"
+                   FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
+        <Button Content="Reset device to defaults" Padding="14,5" HorizontalAlignment="Left" Click="OnResetDevice"/>
+      </StackPanel>
+    </Border>
+
     <Border Classes="card">
       <StackPanel Spacing="6">
         <TextBlock Text="SUPPORT" Classes="h"/>

--- a/src/OpenXLR.UI/OptionsWindow.axaml.cs
+++ b/src/OpenXLR.UI/OptionsWindow.axaml.cs
@@ -37,6 +37,13 @@ public partial class OptionsWindow : Window
         }
     }
 
+    private async void OnResetDevice(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not OptionsViewModel vm) return;
+        if (await Dialogs.ConfirmAsync(this, "Reset device to defaults?", vm.Main.ResetDescription, "Reset"))
+            vm.Main.ResetDevice();
+    }
+
     private void OnClose(object? sender, RoutedEventArgs e) => Close();
 
     private async void OnCheckUpdates(object? sender, RoutedEventArgs e)

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -154,7 +154,7 @@ public sealed class MainViewModel : ViewModelBase
 
     /// <summary>What the reset button does on this device, for its tooltip and confirmation.</summary>
     public string ResetDescription => CapRetainsSettings
-        ? "Write OpenXLR's baseline to the interface: gain 30 dB on both inputs, every processing stage and phantom power off, headphones, crossfade and aux level at half. Output routing stays. Saved profiles stay."
+        ? "Write OpenXLR's baseline to the interface: gain 30 dB on both inputs, every processing stage and phantom power off, headphones and aux level at half, the crossfade fully on PC. Output routing stays. Saved profiles stay."
         : "The interface goes back to the settings its firmware starts with, and the settings OpenXLR restores when it connects are forgotten. Saved profiles stay.";
 
     private bool _showResetDefaults;

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -148,6 +148,15 @@ public sealed class MainViewModel : ViewModelBase
     private bool _capRetainsSettings = true;
     public bool CapRetainsSettings { get => _capRetainsSettings; set => Set(ref _capRetainsSettings, value); }
 
+    private bool _capBuiltInDefaults;
+    /// <summary>OpenXLR ships a baseline for this model, so a device with its own memory can still be reset.</summary>
+    public bool CapBuiltInDefaults { get => _capBuiltInDefaults; set { if (Set(ref _capBuiltInDefaults, value)) Raise(nameof(ResetDescription)); } }
+
+    /// <summary>What the reset button does on this device, for its tooltip and confirmation.</summary>
+    public string ResetDescription => CapRetainsSettings
+        ? "Write OpenXLR's baseline to the interface: gain 30 dB on both inputs, every processing stage and phantom power off, headphones, crossfade and aux level at half. Output routing stays. Saved profiles stay."
+        : "The interface goes back to the settings its firmware starts with, and the settings OpenXLR restores when it connects are forgotten. Saved profiles stay.";
+
     private bool _showResetDefaults;
     public bool ShowResetDefaults { get => _showResetDefaults; private set => Set(ref _showResetDefaults, value); }
 
@@ -619,6 +628,7 @@ public sealed class MainViewModel : ViewModelBase
                 CapOutputRouting = Cap("outputRouting");
                 CapPhysicalControls = Cap("physicalControls");
                 CapRetainsSettings = caps["retainsSettings"]?.GetValue<bool>() ?? true;
+                CapBuiltInDefaults = caps["builtInDefaults"]?.GetValue<bool>() ?? false;
             }
 
             if (node["state"] is JsonNode s)
@@ -667,7 +677,8 @@ public sealed class MainViewModel : ViewModelBase
             ShowSoftLowCut = DeviceConnected && !CapLowCut && HasMixer;
             ShowSoftClipGuard = DeviceConnected && !CapClipGuard && HasMixer;
             ShowGainLock = DeviceConnected && !CapPhysicalControls;
-            ShowResetDefaults = DeviceConnected && !CapRetainsSettings;
+            ShowResetDefaults = DeviceConnected && (!CapRetainsSettings || CapBuiltInDefaults);
+            Raise(nameof(ResetDescription));
             Status = DeviceConnected ? "ready" : "no device";
         }
         finally { _applying = false; }


### PR DESCRIPTION
The Pro keeps its settings in its own memory, so there is no clean state to record after a power cycle and whatever is set on Linux is what Wave Link finds on Windows. The reset button and resetDevice now write a known set on such a device when its model has one: gain 30 dB on both inputs, every processing stage and phantom power off, headphones and aux level at half, the crossfade fully on PC. Output routing and the monitor mix membership stay with the mixer, saved profiles stay, and the gain lock has to be off. The capabilities say builtInDefaults for a model with a baseline.

The button moved from the profile flyout to Options under INTERFACE, where a slip cannot reach it, with the same description and confirmation on every device that offers a reset.

Verified on this desk's Pro: saved the current state to a profile, reset, read back gain 30/30, everything off, headphones and aux at -30 dB, crossfade at full PC, routing untouched; loaded the profile back and the state matched the original field for field. 214 tests.