### PR TITLE
Daemon: hold every OpenXLR sink at full volume

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -230,7 +230,10 @@ taps on the Stream Deck + XL need OpenDeck newer than 2.14.0
   with an OpenAPI document ([http-api.md](http-api.md))
 - The daemon rebuilds its graph after a pipewire-pulse restart, and
   refuses to grow the layout when pipewire-pulse has no open-file
-  headroom left; the packages raise that limit with a systemd drop-in
+  headroom left; the packages raise that limit with a systemd drop-in.
+  It also holds every sink it created at full volume and unmuted, since
+  a desktop applet or the session manager can turn one down and quietly
+  cut the mixes it feeds
 - Tray icon, start-minimized option, daemon and window autostart from
   Options
 - Diagnostics archive: one action collects app and device state, a

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -445,7 +445,7 @@ device ignores the write, the control snaps back. On the Wave XLR Pro
 the mute button shows a countdown after every 48V change: the firmware
 holds that input muted for about 13 seconds and unmutes it itself. On
 other devices this would be new information: collect diagnostics
-([section 5.9](#reporting)) and open an issue.
+([section 5.10](#reporting)) and open an issue.
 
 <a name="daemon-hang"></a>
 ### 5.7 The daemon froze, or a control hung the window
@@ -468,7 +468,7 @@ working. Unplug the interface and plug it back in, or restart the
 daemon, to try again. A helper whose device could not be opened at all
 (the udev rule not applied yet, see [section 5.1](#no-device)) is
 killed straight away and the daemon tries again two seconds later.
-Collect diagnostics afterwards ([section 5.9](#reporting)): the archive contains the
+Collect diagnostics afterwards ([section 5.10](#reporting)): the archive contains the
 exact transfer, and that is what makes the report actionable.
 
 <a name="open-files"></a>
@@ -515,8 +515,25 @@ limit to 65536:
    It should say 65536. If it still says 1024 the file is not where systemd
    looks; `systemctl --user cat pipewire-pulse` lists every file it read.
 
+<a name="quiet-mixes"></a>
+### 5.9 The mixes are quieter than the microphone
+
+If OBS or a recorder shows the raw Wave XLR device peaking near -6 dB
+while the OpenXLR Stream and Chat microphones sit some 15 dB lower, with
+every send and master at 100, one of OpenXLR's own sinks has been turned
+down. The channel sinks are playback devices, and a desktop applet or
+the session manager restoring a remembered level can set one to half
+volume; nothing in OpenXLR uses a sink's own volume as a control, so
+that only cuts audio. Since 0.1.27 the daemon puts every OpenXLR sink
+back to full volume on its sweep and logs when it had to. On an older
+version, set them by hand:
+
+```sh
+for s in $(pactl list sinks short | awk '/OpenXLR_/ {print $2}'); do pactl set-sink-volume "$s" 100%; done
+```
+
 <a name="reporting"></a>
-### 5.9 Reporting a problem
+### 5.10 Reporting a problem
 
 Ask on the OpenXLR Discord server (<https://discord.gg/4bswtnGPW4>,
 one post per problem in its support forum), on Reddit at

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -1095,6 +1095,35 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
             => a.HasValue != b.HasValue || (a.HasValue && Math.Abs(a.Value - b!.Value) > 0.005);
     }
 
+    /// <summary>
+    /// Hold every OpenXLR sink at unity and unmuted. The faders are the
+    /// combine legs and the mix masters; a sink's own volume is never a
+    /// control here, so anything that turned one down (the session manager
+    /// restoring a stored level, a desktop applet) only cuts audio. Returns
+    /// the sinks put back.
+    /// </summary>
+    public IReadOnlyList<string> EnsureOwnSinkLevels()
+    {
+        lock (_gate)
+        {
+            if (!_built) return [];
+            var restored = new List<string>();
+            foreach (OwnSinkLevel sink in _pw.OwnSinkLevels())
+            {
+                bool off = Math.Abs(sink.Volume - 1.0) > 0.01;
+                if (!off && !sink.Muted) continue;
+                try
+                {
+                    if (off) _pw.SetSinkVolume(sink.Name, 1.0);
+                    if (sink.Muted) _pw.SetSinkMuted(sink.Name, false);
+                    restored.Add(sink.Name);
+                }
+                catch (InvalidOperationException) { /* the sink went away; the next sweep sees the rest */ }
+            }
+            return restored;
+        }
+    }
+
     /// <summary>First selected monitor output, or null (legacy single view).</summary>
     public string? MonitorOutput { get { lock (_gate) return _monitorOutputs.FirstOrDefault(); } }
 

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -219,6 +219,51 @@ public sealed class PipeWireAdapter
         return marker >= 0 ? sinkName[..marker] : sinkName;
     }
 
+    /// <summary>
+    /// Volume and mute of every sink this daemon created, read from the
+    /// graph dump. The session manager or a desktop applet can turn one of
+    /// them down, and a channel sink at half volume quietly cuts every mix
+    /// it feeds by 15 dB (seen on a user's machine: all nine channel sinks
+    /// restored to 55% by something outside OpenXLR).
+    /// </summary>
+    public IReadOnlyList<OwnSinkLevel> OwnSinkLevels() => OwnSinkLevels(DumpJson());
+
+    internal static IReadOnlyList<OwnSinkLevel> OwnSinkLevels(byte[] json)
+    {
+        var found = new List<OwnSinkLevel>();
+        JsonDocument doc;
+        try { doc = PipeWireSnapshot.Parse(json); }
+        catch (JsonException) { return found; }
+        using (doc)
+        {
+            foreach (JsonElement o in doc.RootElement.EnumerateArray())
+            {
+                if (!o.TryGetProperty("type", out JsonElement t) ||
+                    !(t.GetString()?.EndsWith("Node", StringComparison.Ordinal) ?? false)) continue;
+                if (!o.TryGetProperty("info", out JsonElement info) ||
+                    !info.TryGetProperty("props", out JsonElement props)) continue;
+                string? name = props.TryGetProperty("node.name", out JsonElement n) ? n.GetString() : null;
+                if (name is null || !name.StartsWith("OpenXLR_", StringComparison.Ordinal)) continue;
+                if (!props.TryGetProperty("media.class", out JsonElement m) || m.GetString() != "Audio/Sink") continue;
+                if (!info.TryGetProperty("params", out JsonElement pars) ||
+                    !pars.TryGetProperty("Props", out JsonElement list) || list.ValueKind != JsonValueKind.Array) continue;
+                foreach (JsonElement p in list.EnumerateArray())
+                {
+                    if (!p.TryGetProperty("channelVolumes", out JsonElement cv) || cv.ValueKind != JsonValueKind.Array) continue;
+                    double volume = 1.0;
+                    bool any = false;
+                    foreach (JsonElement v in cv.EnumerateArray())
+                        if (v.TryGetDouble(out double d)) { volume = any ? Math.Min(volume, d) : d; any = true; }
+                    if (!any) continue;
+                    bool muted = p.TryGetProperty("mute", out JsonElement mu) && mu.ValueKind == JsonValueKind.True;
+                    found.Add(new OwnSinkLevel(name, volume, muted));
+                    break;
+                }
+            }
+        }
+        return found;
+    }
+
     /// <summary>Set a sink's volume.</summary>
     public void SetSinkVolume(string sinkName, double volume)
         => Run("pactl", "set-sink-volume", BareSink(sinkName),
@@ -1301,3 +1346,6 @@ public enum AudioNodeKind { Sink, Source }
 /// </summary>
 public sealed record AudioNode(string Name, string Description, AudioNodeKind Kind, bool IsOwn,
     bool IsPhysical = false);
+
+/// <summary>One of the daemon's own sinks: its linear volume (1.0 = unity) and mute.</summary>
+public sealed record OwnSinkLevel(string Name, double Volume, bool Muted);

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -218,6 +218,10 @@ public sealed class MixerService : IHostedService, IDisposable
                     // Software DSP only for devices without the hardware version.
                     _mixer.SetLowCutApplicable(!(_devices.ActiveCapabilities?.LowCut ?? false));
                     _mixer.SetClipGuardApplicable(!(_devices.ActiveCapabilities?.ClipGuard ?? false));
+                    IReadOnlyList<string> restoredSinks = _mixer.EnsureOwnSinkLevels();
+                    if (restoredSinks.Count > 0)
+                        _log.LogWarning("put {n} OpenXLR sink(s) back to full volume, unmuted ({names}); something outside OpenXLR had changed them",
+                            restoredSinks.Count, string.Join(", ", restoredSinks));
                     if (_mixer.SyncStreams() | _mixer.SyncDeviceVolumes() | _mixer.EnforceDefaults()
                         | _mixer.EnsureInputFeeds() | _mixer.EnsureAuxRoute()
                         | _mixer.EnsureFilterRoutes()

--- a/src/OpenXLR.Tests/OwnSinkLevelsTests.cs
+++ b/src/OpenXLR.Tests/OwnSinkLevelsTests.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class OwnSinkLevelsTests
+{
+    private static byte[] Dump(params string[] nodes) => Encoding.UTF8.GetBytes("[" + string.Join(",", nodes) + "]");
+
+    private static string Node(string name, string mediaClass, string volumes, bool mute)
+        => "{\"id\": 1, \"type\": \"PipeWire:Interface:Node\", \"info\": {\"props\": {\"node.name\": \"" + name +
+           "\", \"media.class\": \"" + mediaClass + "\"}, \"params\": {\"Props\": [{\"volume\": 1.0, \"channelVolumes\": [" +
+           volumes + "], \"mute\": " + (mute ? "true" : "false") + "}]}}}";
+
+    [Fact]
+    public void OnlyOurSinksAreListedWithTheirLowestChannelVolume()
+    {
+        byte[] json = Dump(
+            Node("OpenXLR_ch_xlr1", "Audio/Sink", "0.166378, 0.166378", false),
+            Node("OpenXLR_mix_stream", "Audio/Sink", "1.0, 1.0", true),
+            Node("OpenXLR_ch_game", "Audio/Sink", "1.0, 0.5", false),
+            Node("OpenXLR_ch_xlr1.monitor", "Audio/Source", "0.2, 0.2", false),
+            Node("alsa_output.usb-Elgato_Wave_XLR_Pro-00.multichannel-output", "Audio/Sink", "1.0", false));
+        var levels = PipeWireAdapter.OwnSinkLevels(json);
+        Assert.Equal(["OpenXLR_ch_xlr1", "OpenXLR_mix_stream", "OpenXLR_ch_game"], levels.Select(l => l.Name));
+        Assert.Equal(0.166378, levels[0].Volume, 6);
+        Assert.False(levels[0].Muted);
+        Assert.True(levels[1].Muted);
+        Assert.Equal(0.5, levels[2].Volume);
+    }
+
+    [Fact]
+    public void ABrokenDumpYieldsNothing()
+        => Assert.Empty(PipeWireAdapter.OwnSinkLevels(Encoding.UTF8.GetBytes("[{\"type\": \"PipeWire:Interface:Node\"")));
+}


### PR DESCRIPTION
A user's diagnostics showed all nine channel sinks at 55% (16.6% linear),
set by something outside OpenXLR, so every mix sat 15 dB below the raw
microphone while every send and master read 100. A sink's own volume is
never a control in this mixer: the faders are the combine legs and the
mix masters. The sweep now reads the daemon's sinks from the graph dump
it already parses and puts any that drifted back to unity and unmuted,
logging which. Reproduced and confirmed on this desk within one sweep.

Manual gains a troubleshooting entry (5.9, anchor quiet-mixes) with the one-off command for older versions. 216 tests.