### PR TITLE
Inserts: escape the hash in LV2 URIs for the filter chain

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -428,6 +428,12 @@ restart WirePlumber.
 - The insert picker lists what lilv finds in the standard LV2
   directories (`/usr/lib/lv2`, `~/.lv2`, or `LV2_PATH`). An empty
   picker means no LV2 plugins are installed, or lilv is missing.
+- Before 0.1.27 an insert whose plugin URI contains a `#` (the x42
+  plugins, for one: `darc#mono`) failed with "PipeWire filter chain did
+  not create the required ports ... Could not load module", because
+  PipeWire's argument parser reads the `#` as a comment. The daemon now
+  escapes it; on an older version pick a plugin without one, such as the
+  LSP set.
 
 <a name="wrong-device"></a>
 ### 5.5 Sound comes out of the wrong device

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -45,6 +45,18 @@ public sealed class PipeWireAdapter
     /// applet hides. Verified on PipeWire 1.6 with all four properties.
     /// </summary>
     private static string PropList(string props) => '"' + props + '"';
+
+    /// <summary>
+    /// A string inside a filter-chain (SPA JSON) argument. PipeWire's
+    /// property parser treats '#' as the start of a comment even inside a
+    /// quoted string, so an LV2 URI such as darc#mono broke the whole graph
+    /// with "Mismatched bracket" and "Could not load module". The JSON
+    /// unicode escape survives that pass and decodes to '#' afterwards
+    /// (verified on PipeWire 1.6.8). Quotes and backslashes are escaped the
+    /// JSON way.
+    /// </summary>
+    internal static string SpaString(string value)
+        => value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("#", "\\u0023");
     private static string PropValue(string value) => "'" + value.Replace("\\", "\\\\").Replace("'", "\\'") + "'";
 
     /// <summary>
@@ -536,8 +548,8 @@ public sealed class PipeWireAdapter
                 continue;   // unknown or wrong-width plugin: skipped, reported by the caller
             string name = $"i{k++}";
             string controls = ins.Params.Count == 0 ? "" :
-                " control = { " + string.Join(' ', ins.Params.Select(p => $"\"{p.Key}\" = {p.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}")) + " }";
-            stages.Add(($"{{ type = lv2 name = {name} plugin = \"{ins.Plugin}\"{controls} }}",
+                " control = { " + string.Join(' ', ins.Params.Select(p => $"\"{SpaString(p.Key)}\" = {p.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}")) + " }";
+            stages.Add(($"{{ type = lv2 name = {name} plugin = \"{SpaString(ins.Plugin)}\"{controls} }}",
                 [.. info.InputSymbols.Take(channels).Select(s => $"{name}:{s}")],
                 [.. info.OutputSymbols.Take(channels).Select(s => $"{name}:{s}")]));
         }
@@ -552,7 +564,7 @@ public sealed class PipeWireAdapter
         string outputs = string.Join(' ', stages[^1].Out.Select(p => $"\"{p}\""));
         string position = channels == 1 ? "[ MONO ]" : "[ FL FR ]";
         string spa =
-            $"{{ node.description = \"{description}\" " +
+            $"{{ node.description = \"{SpaString(description)}\" " +
             $"filter.graph = {{ nodes = [ {string.Join(' ', stages.Select(s => s.Node))} ] {links}" +
             $"inputs = [ {inputs} ] outputs = [ {outputs} ] }} " +
             $"capture.props = {{ node.name = {sinkName} media.class = Audio/Sink " +
@@ -607,7 +619,7 @@ public sealed class PipeWireAdapter
     {
         int id = FindNodeId(f.SinkName) ?? throw new InvalidOperationException($"filter node {f.SinkName} not found");
         string v = value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        Run("pw-cli", "set-param", id.ToString(), "Props", $"{{ params = [ \"{control}\" {v} ] }}");
+        Run("pw-cli", "set-param", id.ToString(), "Props", $"{{ params = [ \"{SpaString(control)}\" {v} ] }}");
     }
 
     /// <summary>Unload a filter by killing its holder process.</summary>

--- a/src/OpenXLR.Tests/SpaStringTests.cs
+++ b/src/OpenXLR.Tests/SpaStringTests.cs
@@ -1,0 +1,14 @@
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class SpaStringTests
+{
+    [Theory]
+    [InlineData("http://lsp-plug.in/plugins/lv2/compressor_mono", "http://lsp-plug.in/plugins/lv2/compressor_mono")]
+    [InlineData("http://gareus.org/oss/lv2/darc#mono", "http://gareus.org/oss/lv2/darc\\u0023mono")]
+    [InlineData("OpenXLR Mic #2 Inserts", "OpenXLR Mic \\u0023" + "2 Inserts")]
+    [InlineData("say \"hi\" \\ back", "say \\\"hi\\\" \\\\ back")]
+    public void HashesQuotesAndBackslashesSurviveThePropertyParser(string input, string expected)
+        => Assert.Equal(expected, PipeWireAdapter.SpaString(input));
+}


### PR DESCRIPTION
PipeWire's property parser treats '#' as the start of a comment even
inside a quoted string, so a plugin URI such as darc#mono broke the
whole filter-chain argument with "Mismatched bracket" and the insert
failed with "Could not load module". Every string the daemon puts into
that argument (plugin URIs, control symbols, the chain description) now
goes through one escape that writes the hash as the JSON unicode escape,
which survives the parser and decodes back. Reproduced with the x42
Dynamic Compressor Mono on this desk: refused before, loads and takes a
live control change after.

A user hit this with x42-comp on XLR 1. The manual's plugin troubleshooting names the symptom and the workaround for older versions. 218 tests.