### PR TITLE
Window: one instance per user, a second launch shows the running window

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -234,6 +234,8 @@ taps on the Stream Deck + XL need OpenDeck newer than 2.14.0
   It also holds every sink it created at full volume and unmuted, since
   a desktop applet or the session manager can turn one down and quietly
   cut the mixes it feeds
+- One window per user: a second launch brings the running window to the
+  front, out of the tray if it is hidden there, and exits
 - Tray icon, start-minimized option, daemon and window autostart from
   Options
 - Diagnostics archive: one action collects app and device state, a

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -282,6 +282,9 @@ Options, STARTUP:
   quitting; the tray icon's menu shows it again or quits. "Start
   minimized to tray" starts with no window at all; the tray icon shows
   it the first time you click it.
+- Only one window runs per user. Starting OpenXLR again, from the menu
+  or a shell, brings the running window to the front (out of the tray
+  if it is hidden there) instead of opening a second one.
 
 To land on a known scene at every login, mark a profile to recall on
 connect ([section 3.6](#profiles)). An interface without settings memory comes back

--- a/src/OpenXLR.Tests/SingleInstanceTests.cs
+++ b/src/OpenXLR.Tests/SingleInstanceTests.cs
@@ -1,0 +1,44 @@
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+public sealed class SingleInstanceTests
+{
+    [Fact]
+    public void ASecondLaunchAsksTheFirstToShowAndDoesNotRun()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "openxlr-test-" + Guid.NewGuid().ToString("N"));
+        string path = Path.Combine(dir, "ui.sock");
+        try
+        {
+            using SingleInstance? first = SingleInstance.TryBecomePrimary(path);
+            Assert.NotNull(first);
+            var shown = new ManualResetEventSlim();
+            first.ShowRequested = shown.Set;
+
+            using SingleInstance? second = SingleInstance.TryBecomePrimary(path);
+            Assert.Null(second);                                  // handed off, would exit
+            Assert.True(shown.Wait(TimeSpan.FromSeconds(5)));     // and the first was asked to show
+
+            first.Dispose();
+            using SingleInstance? again = SingleInstance.TryBecomePrimary(path);   // the socket is free again
+            Assert.NotNull(again);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch (IOException) { } }
+    }
+
+    [Fact]
+    public void AStaleSocketFileIsReplaced()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "openxlr-test-" + Guid.NewGuid().ToString("N"));
+        string path = Path.Combine(dir, "ui.sock");
+        try
+        {
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(path, "");   // a file nobody listens on
+            using SingleInstance? first = SingleInstance.TryBecomePrimary(path);
+            Assert.NotNull(first);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch (IOException) { } }
+    }
+}

--- a/src/OpenXLR.UI/App.axaml.cs
+++ b/src/OpenXLR.UI/App.axaml.cs
@@ -22,6 +22,15 @@ public partial class App : Application
                 StartupIntegration.RepairDaemonUnit();
 
             var window = new MainWindow();
+            // A later launch asks for the window through the single-instance
+            // socket: bring it up, from the tray or from behind other windows.
+            if (Program.Instance is { } instance)
+                instance.ShowRequested = () => Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    window.Show();
+                    if (window.WindowState == WindowState.Minimized) window.WindowState = WindowState.Normal;
+                    window.Activate();
+                });
             if (window.StartsHidden)
             {
                 // Starting in the tray means the window must never be

--- a/src/OpenXLR.UI/Program.cs
+++ b/src/OpenXLR.UI/Program.cs
@@ -8,9 +8,18 @@ class Program
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
+    /// <summary>The listening single-instance guard, or null in a process that handed off and exits.</summary>
+    internal static SingleInstance? Instance { get; private set; }
+
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        // A window is already open: it shows itself, this process is done.
+        Instance = SingleInstance.TryBecomePrimary();
+        if (Instance is null) return;
+        try { BuildAvaloniaApp().StartWithClassicDesktopLifetime(args); }
+        finally { Instance.Dispose(); }
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()

--- a/src/OpenXLR.UI/SingleInstance.cs
+++ b/src/OpenXLR.UI/SingleInstance.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+
+namespace OpenXLR.UI;
+
+/// <summary>
+/// One window per user. The first instance listens on a Unix socket next
+/// to the daemon's token; a later launch (the application menu, a second
+/// autostart, a shell) finds it, asks it to show its window and exits at
+/// once, so nothing ever opens twice. A socket file whose owner is gone is
+/// replaced, so a crash never blocks the next start.
+/// </summary>
+internal sealed class SingleInstance : IDisposable
+{
+    private const string Show = "show";
+    private readonly Socket _listener;
+    private readonly string _path;
+
+    /// <summary>Runs on a background thread when another launch asks for the window.</summary>
+    public Action? ShowRequested { get; set; }
+
+    private SingleInstance(Socket listener, string path) { _listener = listener; _path = path; }
+
+    public static string DefaultPath => Path.Combine(Path.GetDirectoryName(OpenXlrPaths.TokenPath)!, "ui.sock");
+
+    /// <summary>
+    /// The listening primary, or null when a running window took the request
+    /// and this process should end.
+    /// </summary>
+    public static SingleInstance? TryBecomePrimary(string? path = null)
+    {
+        path ??= DefaultPath;
+        try { OpenXlrPaths.EnsurePrivateDir(Path.GetDirectoryName(path)!); }
+        catch (Exception) { return Listen(path) ?? Fallback(); }
+        if (AskRunningWindow(path)) return null;
+        return Listen(path) ?? (AskRunningWindow(path) ? null : Fallback());
+
+        // No socket at all (an unwritable runtime directory): run without the
+        // guard rather than refuse to start.
+        static SingleInstance? Fallback() => new(new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified), "");
+    }
+
+    private static bool AskRunningWindow(string path)
+    {
+        if (!File.Exists(path)) return false;
+        using var client = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        try
+        {
+            client.Connect(new UnixDomainSocketEndPoint(path));
+            client.Send(Encoding.ASCII.GetBytes(Show + "\n"));
+            client.Shutdown(SocketShutdown.Send);
+            return true;
+        }
+        catch (SocketException)
+        {
+            // Nobody listens: a leftover from a window that did not exit cleanly.
+            try { File.Delete(path); } catch (Exception) { }
+            return false;
+        }
+    }
+
+    private static SingleInstance? Listen(string path)
+    {
+        var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        try
+        {
+            listener.Bind(new UnixDomainSocketEndPoint(path));
+            listener.Listen(4);
+        }
+        catch (SocketException)
+        {
+            listener.Dispose();
+            return null;   // another launch bound it first
+        }
+        var instance = new SingleInstance(listener, path);
+        new Thread(instance.Accept) { IsBackground = true, Name = "single-instance" }.Start();
+        return instance;
+    }
+
+    private void Accept()
+    {
+        var buf = new byte[64];
+        while (true)
+        {
+            Socket peer;
+            try { peer = _listener.Accept(); }
+            catch (Exception) { return; }   // disposed
+            using (peer)
+            {
+                try
+                {
+                    peer.ReceiveTimeout = 2000;
+                    int n = peer.Receive(buf);
+                    if (Encoding.ASCII.GetString(buf, 0, n).Trim() == Show) ShowRequested?.Invoke();
+                }
+                catch (Exception) { /* a peer that says nothing is ignored */ }
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        try { _listener.Dispose(); } catch (Exception) { }
+        if (_path.Length > 0) { try { File.Delete(_path); } catch (Exception) { } }
+    }
+}


### PR DESCRIPTION
The first window listens on a Unix socket next to the daemon's token. A
later launch, from the application menu, a second autostart entry or a
shell, connects, asks the running window to show itself and exits at
once, so nothing opens twice; the running window comes up out of the
tray or from behind other windows. A socket file whose owner is gone is
replaced, so a crash never blocks the next start, and an unwritable
runtime directory falls back to running without the guard. Verified on
this desk: a second launch exits in 20 ms with one process left.

Two tests cover the hand-off and a stale socket file; the manual's tray section and the features page say so. 222 tests.