### PR TITLE
Native host: the worker extension, and two fixes from using it

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -135,7 +135,8 @@ audio that is playing and its changes are saved like any other control.
 The plugin keeps processing if the editor stops answering or the X
 display goes away, and a chain whose host keeps crashing is switched off
 once it has failed three times in five minutes, with the reason on the
-insert. The manual covers the
+insert. Plugins that hand work to a background thread, which is how
+reverbs and convolvers build their impulse responses, are hosted too. The manual covers the
 setup in 3.12.
 
 The submixer can be switched off in Options. The daemon then controls

--- a/native/README.md
+++ b/native/README.md
@@ -73,8 +73,15 @@ Use the session's own value rather than a copy, and never `xhost +`.
 
 ## Scope
 
-URID map and unmap for the plugin, and the X11 editor features this host
-implements: instance access, parent, resize and the idle interface. Worker
-threads, state and presets, and the VST and CLAP formats are separate work.
-Changing an insert's host rebuilds its chain; nothing here swaps a plugin
-without a gap.
+For the plugin: URID map and unmap, the worker extension, options, and the
+promise that the block length is bounded. The worker runs on a thread of its
+own, fed by two lock-free rings, so a plugin that hands off heavy work never
+does it in the audio callback; its answers are delivered before the next run.
+That is what reverbs and convolvers ask for, and without it they could not be
+hosted at all.
+
+For the editor: instance access, parent, resize and the idle interface.
+
+State and presets, and the VST and CLAP formats, are separate work. Changing
+an insert's host rebuilds its chain; nothing here swaps a plugin without a
+gap.

--- a/native/lv2-host.c
+++ b/native/lv2-host.c
@@ -139,7 +139,7 @@ typedef struct {
   float rate_hz;
   LV2_Options_Option options[5];
   Display *display;
-  Window window;
+  Window window, child;
   Atom close_message;
   void *ui_library;
   const LV2UI_Descriptor *ui_descriptor;
@@ -352,6 +352,28 @@ static void forget_ui(Host *h) {
   h->idle = NULL;
   h->display = NULL;
   h->window = 0;
+  h->child = 0;
+}
+
+// A plugin builds its interface in a window of its own inside ours, at
+// whatever size it wants, and many never call the host's resize. Take the
+// size from that window, and watch it so later changes follow.
+static void fit_to_child(Host *h) {
+  Window root, parent, *children = NULL;
+  unsigned count = 0;
+  if (!XQueryTree(h->display, h->window, &root, &parent, &children, &count))
+    return;
+  if (count > 0) {
+    h->child = children[count - 1];
+    XSelectInput(h->display, h->child, StructureNotifyMask);
+    XWindowAttributes attributes;
+    if (XGetWindowAttributes(h->display, h->child, &attributes) &&
+        attributes.width > 0 && attributes.height > 0)
+      XResizeWindow(h->display, h->window, (unsigned)attributes.width,
+                    (unsigned)attributes.height);
+  }
+  if (children)
+    XFree(children);
 }
 
 static void close_ui(Host *h) {
@@ -430,6 +452,8 @@ static bool open_editor_window(Host *h, const char *bundle) {
                     (int)strlen(h->node_name));
     h->close_message = XInternAtom(h->display, "WM_DELETE_WINDOW", False);
     XSetWMProtocols(h->display, h->window, &h->close_message, 1);
+    XSelectInput(h->display, h->window,
+                 StructureNotifyMask | SubstructureNotifyMask);
     h->resize = (LV2UI_Resize){h, ui_resize};
     LV2_Feature parent = {LV2_UI__parent, (void *)(uintptr_t)h->window};
     LV2_Feature map = {LV2_URID__map, &h->map},
@@ -448,6 +472,7 @@ static bool open_editor_window(Host *h, const char *bundle) {
       h->idle = h->ui_descriptor->extension_data
                     ? h->ui_descriptor->extension_data(LV2_UI__idleInterface)
                     : NULL;
+      fit_to_child(h);  // before mapping, so the frame never opens wrong
       XMapRaised(h->display, h->window);
       XFlush(h->display);
     }
@@ -588,6 +613,27 @@ static void pump_editor(Host *h) {
       x_escape_armed = 0;
       close_ui(h);
       return;
+    }
+    // A plugin that builds its window after instantiate returns is found
+    // when that window appears.
+    if (!h->child && (event.type == MapNotify || event.type == CreateNotify))
+      fit_to_child(h);
+    // Keep the frame and the plugin's window the same size, whichever of
+    // the two changed. Each resize is skipped when the sizes already agree,
+    // so the two notifications cannot chase each other.
+    if (event.type == ConfigureNotify && h->child) {
+      const XConfigureEvent *c = &event.xconfigure;
+      XWindowAttributes attributes;
+      if (c->window == h->child &&
+          XGetWindowAttributes(h->display, h->window, &attributes) &&
+          (attributes.width != c->width || attributes.height != c->height))
+        XResizeWindow(h->display, h->window, (unsigned)c->width,
+                      (unsigned)c->height);
+      else if (c->window == h->window &&
+               XGetWindowAttributes(h->display, h->child, &attributes) &&
+               (attributes.width != c->width || attributes.height != c->height))
+        XResizeWindow(h->display, h->child, (unsigned)c->width,
+                      (unsigned)c->height);
     }
   }
   if (h->ui_descriptor->port_event)

--- a/native/lv2-host.c
+++ b/native/lv2-host.c
@@ -10,13 +10,18 @@
 #include <lilv/lilv.h>
 #include <lv2/atom/atom.h>
 #include <lv2/atom/util.h>
+#include <lv2/buf-size/buf-size.h>
 #include <lv2/instance-access/instance-access.h>
+#include <lv2/options/options.h>
+#include <lv2/parameters/parameters.h>
 #include <lv2/ui/ui.h>
 #include <lv2/urid/urid.h>
+#include <lv2/worker/worker.h>
 #include <math.h>
 #include <pipewire/filter.h>
 #include <pipewire/pipewire.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include <setjmp.h>
 #include <signal.h>
 #include <stdatomic.h>
@@ -32,8 +37,61 @@ enum {
   MAX_PORTS = 4096,
   MAX_FRAMES = 8192,
   ATOM_CAPACITY = 65536,
-  MAX_URIS = 4096
+  MAX_URIS = 4096,
+  // Worker traffic. The ring is a power of two so the counters can wrap.
+  WORK_RING = 65536,
+  WORK_FRAME_MAX = 8192
 };
+
+// One direction of worker traffic between the audio callback and the worker
+// thread: one writer, one reader, no locks and no allocation. The counters
+// count bytes ever written and read, so the difference is what is queued.
+typedef struct {
+  uint8_t data[WORK_RING];
+  _Atomic uint32_t written, read;
+} Ring;
+
+static void ring_copy_in(Ring *r, uint32_t at, const void *src, uint32_t size) {
+  uint32_t start = at & (WORK_RING - 1);
+  uint32_t first = size < WORK_RING - start ? size : WORK_RING - start;
+  memcpy(r->data + start, src, first);
+  memcpy(r->data, (const uint8_t *)src + first, size - first);
+}
+
+static void ring_copy_out(const Ring *r, uint32_t at, void *dst, uint32_t size) {
+  uint32_t start = at & (WORK_RING - 1);
+  uint32_t first = size < WORK_RING - start ? size : WORK_RING - start;
+  memcpy(dst, r->data + start, first);
+  memcpy((uint8_t *)dst + first, r->data, size - first);
+}
+
+static bool ring_push(Ring *r, const void *data, uint32_t size) {
+  uint32_t written = atomic_load_explicit(&r->written, memory_order_relaxed);
+  uint32_t read = atomic_load_explicit(&r->read, memory_order_acquire);
+  uint32_t need = size + (uint32_t)sizeof(uint32_t);
+  if (need > WORK_RING - (written - read))
+    return false;
+  ring_copy_in(r, written, &size, sizeof(size));
+  ring_copy_in(r, written + (uint32_t)sizeof(size), data, size);
+  atomic_store_explicit(&r->written, written + need, memory_order_release);
+  return true;
+}
+
+static bool ring_pop(Ring *r, void *dst, uint32_t *size_out) {
+  uint32_t read = atomic_load_explicit(&r->read, memory_order_relaxed);
+  uint32_t written = atomic_load_explicit(&r->written, memory_order_acquire);
+  if (written - read < sizeof(uint32_t))
+    return false;
+  uint32_t size;
+  ring_copy_out(r, read, &size, sizeof(size));
+  if (size > WORK_FRAME_MAX || written - read < sizeof(size) + size)
+    return false;
+  ring_copy_out(r, read + (uint32_t)sizeof(size), dst, size);
+  atomic_store_explicit(&r->read, read + (uint32_t)sizeof(size) + size,
+                        memory_order_release);
+  *size_out = size;
+  return true;
+}
 typedef struct {
   bool input, audio, control, atom;
   const char *symbol;
@@ -64,6 +122,22 @@ typedef struct {
   LV2_URID_Map map;
   LV2_URID_Unmap unmap;
   LV2_URID sequence_type;
+  // Worker: the plugin hands the audio thread's work to a thread that may
+  // block. Its answers come back before the next run.
+  const LV2_Worker_Interface *worker;
+  LV2_Worker_Schedule schedule;
+  pthread_t worker_thread;
+  sem_t work_ready;
+  bool work_ready_valid, worker_started;
+  _Atomic bool worker_stop;
+  Ring requests, responses;
+  uint8_t work_in[WORK_FRAME_MAX];   // worker thread only
+  uint8_t work_out[WORK_FRAME_MAX];  // audio thread only
+  // Options the plugin reads at instantiation. They outlive that call
+  // because plugins are permitted to keep the pointer.
+  int32_t min_block, max_block, sequence_size;
+  float rate_hz;
+  LV2_Options_Option options[5];
   Display *display;
   Window window;
   Atom close_message;
@@ -109,6 +183,10 @@ static bool required_features_supported(const LilvNodes *required, bool ui) {
       return false;
     if (!strcmp(uri, LV2_URID__map) || !strcmp(uri, LV2_URID__unmap))
       continue;
+    if (!ui && (!strcmp(uri, LV2_WORKER__schedule) ||
+                !strcmp(uri, LV2_OPTIONS__options) ||
+                !strcmp(uri, LV2_BUF_SIZE__boundedBlockLength)))
+      continue;
     if (ui && (!strcmp(uri, LV2_INSTANCE_ACCESS_URI) ||
                !strcmp(uri, LV2_UI__parent) || !strcmp(uri, LV2_UI__resize) ||
                !strcmp(uri, LV2_UI__idleInterface)))
@@ -117,6 +195,52 @@ static bool required_features_supported(const LilvNodes *required, bool ui) {
     return false;
   }
   return true;
+}
+
+// Called from the audio thread. Queue the work and wake the worker; never
+// touch the plugin here.
+static LV2_Worker_Status schedule_work(LV2_Worker_Schedule_Handle handle,
+                                       uint32_t size, const void *data) {
+  Host *h = handle;
+  if (size > WORK_FRAME_MAX || !ring_push(&h->requests, data, size))
+    return LV2_WORKER_ERR_NO_SPACE;
+  sem_post(&h->work_ready);
+  return LV2_WORKER_SUCCESS;
+}
+
+// Called from the worker thread, inside work().
+static LV2_Worker_Status worker_respond(LV2_Worker_Respond_Handle handle,
+                                        uint32_t size, const void *data) {
+  Host *h = handle;
+  return size <= WORK_FRAME_MAX && ring_push(&h->responses, data, size)
+             ? LV2_WORKER_SUCCESS
+             : LV2_WORKER_ERR_NO_SPACE;
+}
+
+static void *run_worker(void *data) {
+  Host *h = data;
+  while (!atomic_load(&h->worker_stop)) {
+    if (sem_wait(&h->work_ready) != 0)
+      continue;  // interrupted
+    if (atomic_load(&h->worker_stop))
+      break;
+    uint32_t size;
+    while (ring_pop(&h->requests, h->work_in, &size))
+      h->worker->work(lilv_instance_get_handle(h->instance), worker_respond, h,
+                      size, h->work_in);
+  }
+  return NULL;
+}
+
+// Idempotent: the plugin must not be asked to work after it is deactivated,
+// so this runs before that, and again on the paths that skip it.
+static void stop_worker(Host *h) {
+  if (!h->worker_started)
+    return;
+  atomic_store(&h->worker_stop, true);
+  sem_post(&h->work_ready);
+  pthread_join(h->worker_thread, NULL);
+  h->worker_started = false;
 }
 
 static void process_audio(void *data, struct spa_io_position *position) {
@@ -156,7 +280,15 @@ static void process_audio(void *data, struct spa_io_position *position) {
       p->sequence->body.pad = 0;
     }
   }
+  if (h->worker) {
+    uint32_t size;
+    while (ring_pop(&h->responses, h->work_out, &size))
+      h->worker->work_response(lilv_instance_get_handle(h->instance), size,
+                               h->work_out);
+  }
   lilv_instance_run(h->instance, frames);
+  if (h->worker && h->worker->end_run)
+    h->worker->end_run(lilv_instance_get_handle(h->instance));
   for (uint32_t i = 0; i < h->count; ++i) {
     Port *p = &h->ports[i];
     if (p->audio && !p->input && p->pw_port) {
@@ -562,16 +694,50 @@ int main(int argc, char **argv) {
   }
   h.map = (LV2_URID_Map){&h, map_uri};
   h.unmap = (LV2_URID_Unmap){&h, unmap_uri};
+  h.sequence_type = map_uri(&h, LV2_ATOM__Sequence);
+  h.schedule = (LV2_Worker_Schedule){&h, schedule_work};
+  if (sem_init(&h.work_ready, 0, 0) != 0) {
+    h.exit_code = 1;
+    goto cleanup;
+  }
+  h.work_ready_valid = true;
+  // The block length is bounded by the check in the audio callback, so the
+  // promise these options make is one this host keeps.
+  h.min_block = 1;
+  h.max_block = MAX_FRAMES;
+  h.sequence_size = ATOM_CAPACITY;
+  h.rate_hz = (float)h.rate;
+  LV2_URID atom_int = map_uri(&h, LV2_ATOM__Int),
+           atom_float = map_uri(&h, LV2_ATOM__Float);
+  h.options[0] = (LV2_Options_Option){
+      LV2_OPTIONS_INSTANCE, 0, map_uri(&h, LV2_BUF_SIZE__minBlockLength),
+      sizeof(int32_t), atom_int, &h.min_block};
+  h.options[1] = (LV2_Options_Option){
+      LV2_OPTIONS_INSTANCE, 0, map_uri(&h, LV2_BUF_SIZE__maxBlockLength),
+      sizeof(int32_t), atom_int, &h.max_block};
+  h.options[2] = (LV2_Options_Option){
+      LV2_OPTIONS_INSTANCE, 0, map_uri(&h, LV2_BUF_SIZE__sequenceSize),
+      sizeof(int32_t), atom_int, &h.sequence_size};
+  h.options[3] = (LV2_Options_Option){
+      LV2_OPTIONS_INSTANCE, 0, map_uri(&h, LV2_PARAMETERS__sampleRate),
+      sizeof(float), atom_float, &h.rate_hz};
+  h.options[4] = (LV2_Options_Option){LV2_OPTIONS_BLANK, 0, 0, 0, 0, NULL};
+
   LV2_Feature map = {LV2_URID__map, &h.map},
               unmap = {LV2_URID__unmap, &h.unmap};
-  const LV2_Feature *features[] = {&map, &unmap, NULL};
-  h.sequence_type = map_uri(&h, LV2_ATOM__Sequence);
+  LV2_Feature schedule = {LV2_WORKER__schedule, &h.schedule};
+  LV2_Feature options = {LV2_OPTIONS__options, h.options};
+  LV2_Feature bounded = {LV2_BUF_SIZE__boundedBlockLength, NULL};
+  const LV2_Feature *features[] = {&map,     &unmap,   &schedule,
+                                   &options, &bounded, NULL};
   h.instance = lilv_plugin_instantiate(h.plugin, h.rate, features);
   if (!h.instance) {
     fputs("LV2 instantiation failed\n", stderr);
     h.exit_code = 1;
     goto cleanup;
   }
+  h.worker = lilv_instance_get_extension_data(h.instance, LV2_WORKER__interface);
+  if (h.worker && !h.worker->work) h.worker = NULL;
   h.ports = calloc(h.count, sizeof(Port));
   float *ranges = calloc(h.count * 3, sizeof(float));
   if (!h.ports || !ranges) {
@@ -689,6 +855,13 @@ ports_done:
       goto cleanup;
     }
   }
+  if (h.worker && pthread_create(&h.worker_thread, NULL, run_worker, &h) == 0)
+    h.worker_started = true;
+  else if (h.worker) {
+    fputs("could not start the plugin's worker thread\n", stderr);
+    h.exit_code = 1;
+    goto cleanup;
+  }
   lilv_instance_activate(h.instance);
   if (pw_filter_connect(h.filter, PW_FILTER_FLAG_RT_PROCESS, NULL, 0) < 0) {
     h.exit_code = 1;
@@ -713,8 +886,12 @@ ports_done:
   pthread_join(monitor, NULL);
   pw_filter_disconnect(h.filter);
 deactivate:
+  stop_worker(&h);
   lilv_instance_deactivate(h.instance);
 cleanup:
+  stop_worker(&h);
+  if (h.work_ready_valid)
+    sem_destroy(&h.work_ready);
   close_ui(&h);
   if (h.filter)
     pw_filter_destroy(h.filter);

--- a/src/OpenXLR.Core/Mixing/Inserts.cs
+++ b/src/OpenXLR.Core/Mixing/Inserts.cs
@@ -67,8 +67,16 @@ public sealed record PluginInfo(
     public bool HasNativeUi { get; init; }
     /// <summary>Required features of the X11 UI selected by the native helper.</summary>
     public IReadOnlyList<string> NativeUiRequiredFeatures { get; init; } = [];
-    public bool NativeEditorAvailable => HasNativeUi
-        && System.IO.File.Exists(NativePluginHost.Executable)
+
+    /// <summary>
+    /// This plugin and its editor are ones the native host knows how to carry.
+    /// A property of the plugin, true whether or not the helper is installed,
+    /// so a machine without the helper can still say what is wrong.
+    /// </summary>
+    public bool NativeEditorSupported => HasNativeUi
         && NativePluginHost.SupportsFeatures(RequiredFeatures)
         && NativePluginHost.SupportsUiFeatures(NativeUiRequiredFeatures);
+
+    /// <summary>Supported, and the helper is here to do it.</summary>
+    public bool NativeEditorAvailable => NativeEditorSupported && NativePluginHost.HostInstalled;
 }

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -49,6 +49,9 @@ internal sealed class NativePluginHost : IDisposable
     private readonly TimeSpan _patience = TimeSpan.FromSeconds(10);
     public IReadOnlyDictionary<string, double> Meters => new Dictionary<string, double>(_meters);
     public static string Executable => Path.Combine(AppContext.BaseDirectory, "openxlr-lv2-host");
+
+    /// <summary>Whether the optional helper was built and installed beside the daemon.</summary>
+    public static bool HostInstalled => File.Exists(Executable);
     /// <summary>
     /// What the helper implements for a plugin's DSP. The list is the same one
     /// native/lv2-host.c checks, and the two have to agree: this side decides

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -49,9 +49,18 @@ internal sealed class NativePluginHost : IDisposable
     private readonly TimeSpan _patience = TimeSpan.FromSeconds(10);
     public IReadOnlyDictionary<string, double> Meters => new Dictionary<string, double>(_meters);
     public static string Executable => Path.Combine(AppContext.BaseDirectory, "openxlr-lv2-host");
+    /// <summary>
+    /// What the helper implements for a plugin's DSP. The list is the same one
+    /// native/lv2-host.c checks, and the two have to agree: this side decides
+    /// whether an editor is offered, that side refuses to load without it.
+    /// </summary>
     internal static bool SupportsFeatures(IEnumerable<string> required)
         => required.All(feature => feature is
-            "http://lv2plug.in/ns/ext/urid#map" or "http://lv2plug.in/ns/ext/urid#unmap");
+            "http://lv2plug.in/ns/ext/urid#map"
+            or "http://lv2plug.in/ns/ext/urid#unmap"
+            or "http://lv2plug.in/ns/ext/worker#schedule"
+            or "http://lv2plug.in/ns/ext/options#options"
+            or "http://lv2plug.in/ns/ext/buf-size#boundedBlockLength");
     internal static bool SupportsUiFeatures(IEnumerable<string> required)
         => required.All(feature => feature is
             "http://lv2plug.in/ns/ext/urid#map"

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -1169,6 +1169,7 @@ public sealed class PipeWireAdapter
         "pipewire", "pipewire-pulse", "wireplumber", "pactl", "parec", "paplay",
         "pw-cli", "pw-dump", "pw-cat", "pw-play", "pw-record", "pw-loopback",
         "pw-link", "pw-mon", "speech-dispatcher", "OpenXLR.Daemon", "OpenXLR.UI",
+        "openxlr-lv2-host",   // an insert's own plugin host, not an application
         "libcanberra", "xdg-desktop-portal", "xdg-desktop-portal-kde",
         "xdg-desktop-portal-gnome", "pavucontrol",
     ];

--- a/src/OpenXLR.Core/OpenXLR.Core.csproj
+++ b/src/OpenXLR.Core/OpenXLR.Core.csproj
@@ -9,9 +9,13 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="OpenXLR.Tests" />
+    <!-- The flag decides whether the helper is built; its presence decides
+         whether it is copied. Without the second half, one ordinary build
+         after a native one deletes the helper from the output again, and
+         every insert set to the native host reports it as unavailable. -->
     <None Include="../../native/openxlr-lv2-host" Link="openxlr-lv2-host"
           CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest"
-          Condition="'$(EnableNativeLv2Host)' == 'true' And $([MSBuild]::IsOSPlatform('Linux'))" />
+          Condition="$([MSBuild]::IsOSPlatform('Linux')) And ('$(EnableNativeLv2Host)' == 'true' Or Exists('$(MSBuildThisFileDirectory)../../native/openxlr-lv2-host'))" />
   </ItemGroup>
 
   <Target Name="BuildNativeLv2Host" BeforeTargets="BeforeBuild"

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -103,8 +103,10 @@ public static class CommandValidation
                         if (i.Plugin.Length > MaxUri) return "setInserts: plugin URI too long";
                         PluginInfo? plugin = findPlugin(i.Plugin);
                         if (plugin is null) return $"setInserts: plugin '{Short(i.Plugin)}' is not installed";
+                        if (i.NativeHost && !plugin.NativeEditorSupported)
+                            return $"setInserts: '{plugin.Name}' has no editor the native host can open";
                         if (i.NativeHost && !plugin.NativeEditorAvailable)
-                            return $"setInserts: native hosting is unavailable for '{plugin.Name}'";
+                            return "setInserts: the native LV2 host is not installed on this machine";
                         if (!plugin.Supported)
                             return $"setInserts: '{plugin.Name}' needs {string.Join(", ", plugin.UnsupportedFeatures.Select(Tail))}, which the PipeWire chain does not provide";
                         if (i.Params.Count > MaxParamsPerInsert) return "setInserts: too many parameters";

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -20,6 +20,40 @@ public sealed class NativeLv2HostTests
         => Assert.Equal(supported, NativePluginHost.SupportsFeatures([feature]));
 
     [Fact]
+    public void AMissingHelperIsReportedAsSuchAndNotAsAPluginFault()
+    {
+        // What a user hit: with the helper gone, every plugin was reported as
+        // unable to host an editor, so the reason looked like the plugin's.
+        var hostable = new PluginInfo("lv2", "urn:test", "Test", "", 1, 1, "in", "out",
+            [], [], ["in"], ["out"]) { HasNativeUi = true };
+        Assert.True(hostable.NativeEditorSupported);
+        Assert.Equal(NativePluginHost.HostInstalled, hostable.NativeEditorAvailable);
+
+        var noEditor = hostable with { HasNativeUi = false };
+        Assert.False(noEditor.NativeEditorSupported);
+        Assert.False(noEditor.NativeEditorAvailable);
+
+        var command = new Command
+        {
+            Cmd = "setInserts",
+            Channel = "xlr1",
+            Inserts = [new InsertDefinition { Id = "a", Kind = "lv2", Plugin = "urn:test", NativeHost = true }],
+        };
+        string? refusal = CommandValidation.Check(command, new Layout(), _ => noEditor);
+        Assert.Contains("no editor the native host can open", refusal);
+    }
+
+    private sealed class Layout : OpenXLR.Core.Mixing.ILayoutInfo
+    {
+        public bool HasChannel(string id) => true;
+        public bool HasMix(string id) => true;
+        public bool IsMonitorFeed(string feed) => true;
+        public bool IsMonitorOutput(string device) => true;
+        public bool IsInsertKey(string key) => true;
+        public int OverrideCount => 0;
+    }
+
+    [Fact]
     public void TheHelperIsPlumbing()
     {
         // Its PipeWire client would otherwise be offered as an application to

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -54,6 +54,35 @@ public sealed class NativeLv2HostTests
     }
 
     [Fact]
+    public async Task TheRowCarriesTheHostSwitchAndSaysWhatTheCogWillOpen()
+    {
+        await using var client = new DaemonClient();
+        var owner = new InsertsViewModel(client, "xlr1");
+        owner.PluginChoices.Add(new PluginChoice("urn:test", "Test", "", new JsonArray(),
+            NativeEditorAvailable: true, NativeEditorSupported: true));
+        var insert = new InsertViewModel(owner, "comp", "urn:test", "Test");
+        JsonNode definition = JsonNode.Parse(
+            "{\"id\":\"comp\",\"kind\":\"lv2\",\"plugin\":\"urn:test\",\"bypass\":false,\"params\":{}}")!;
+
+        insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: false);
+        Assert.True(insert.CanChooseNativeHost);      // the switch belongs on the row
+        Assert.True(insert.CanTurnNativeHostOn);      // and is usable: the helper is here
+        Assert.Contains("controls", insert.ControlsHint);
+
+        definition["nativeHost"] = true;
+        insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: true);
+        Assert.True(insert.NativeEditorAvailable);
+        Assert.Contains("own editor", insert.ControlsHint);   // the cog opens that instead
+
+        // Bypassed, there is no process to show, so the cog goes back to ours.
+        definition["bypass"] = true;
+        insert.ApplyFromDaemon(definition, error: null, nativeHostRunning: true);
+        Assert.False(insert.NativeEditorAvailable);
+        Assert.Contains("controls", insert.ControlsHint);
+        Assert.True(insert.CanTurnNativeHostOn);      // and it can still be switched back
+    }
+
+    [Fact]
     public void TheHelperIsPlumbing()
     {
         // Its PipeWire client would otherwise be offered as an application to

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -20,6 +20,16 @@ public sealed class NativeLv2HostTests
         => Assert.Equal(supported, NativePluginHost.SupportsFeatures([feature]));
 
     [Fact]
+    public void TheHelperIsPlumbing()
+    {
+        // Its PipeWire client would otherwise be offered as an application to
+        // route, which is what a user saw after the first release with it.
+        Assert.True(PipeWireAdapter.IsPlumbingIdentity("openxlr-lv2-host"));
+        Assert.True(PipeWireAdapter.IsPlumbingIdentity("OpenXLR.Daemon"));
+        Assert.False(PipeWireAdapter.IsPlumbingIdentity("Spotify"));
+    }
+
+    [Fact]
     public void EveryFeatureTheHelperAcceptsIsOneItImplements()
     {
         // The C source is the other half of this contract: it refuses to load

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -11,11 +11,27 @@ public sealed class NativeLv2HostTests
     [Theory]
     [InlineData("http://lv2plug.in/ns/ext/urid#map", true)]
     [InlineData("http://lv2plug.in/ns/ext/urid#unmap", true)]
-    [InlineData("http://lv2plug.in/ns/ext/worker#schedule", false)]
-    [InlineData("http://lv2plug.in/ns/ext/options#options", false)]
+    [InlineData("http://lv2plug.in/ns/ext/worker#schedule", true)]
+    [InlineData("http://lv2plug.in/ns/ext/options#options", true)]
+    [InlineData("http://lv2plug.in/ns/ext/buf-size#boundedBlockLength", true)]
+    [InlineData("http://lv2plug.in/ns/ext/state#loadDefaultState", false)]
     [InlineData("urn:unknown", false)]
     public void NativeHostDoesNotClaimFeaturesItDoesNotImplement(string feature, bool supported)
         => Assert.Equal(supported, NativePluginHost.SupportsFeatures([feature]));
+
+    [Fact]
+    public void EveryFeatureTheHelperAcceptsIsOneItImplements()
+    {
+        // The C source is the other half of this contract: it refuses to load
+        // a plugin whose required features it does not provide, so the two
+        // lists have to name the same extensions.
+        string source = File.ReadAllText(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "..", "native", "lv2-host.c"));
+        foreach (string macro in new[] { "LV2_WORKER__schedule", "LV2_OPTIONS__options", "LV2_BUF_SIZE__boundedBlockLength" })
+            Assert.Contains(macro, source);
+        Assert.True(NativePluginHost.SupportsFeatures(
+            ["http://lv2plug.in/ns/ext/worker#schedule", "http://lv2plug.in/ns/ext/options#options"]));
+    }
 
     [Theory]
     [InlineData("http://lv2plug.in/ns/ext/urid#map", true)]

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml
@@ -48,22 +48,26 @@
         </StackPanel>
         <TextBlock Text="{Binding Plugin}" Classes="h" FontSize="11"/>
         <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
-        <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Left"
+      </StackPanel>
+      <!-- Every button lives on the right, in two rows when this plugin can
+           be hosted natively. -->
+      <StackPanel Grid.Column="1" Spacing="6" VerticalAlignment="Top" HorizontalAlignment="Right">
+        <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right">
+          <Button Content="Plugin UI" Padding="12,4" Click="OnNativeEditor"
+                  IsVisible="{Binding NativeEditorSupported}"
+                  IsEnabled="{Binding NativeEditorAvailable}"
+                  ToolTip.Tip="Open this plugin's own editor on the live audio instance"/>
+          <Button Content="Defaults" Padding="12,4" Click="OnDefaults"
+                  ToolTip.Tip="Put every control back to the plugin's own defaults"/>
+          <ToggleButton Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}" Padding="12,4"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right"
                     IsVisible="{Binding CanChooseNativeHost}">
           <ToggleButton Content="Native host" IsChecked="{Binding NativeHost, Mode=TwoWay}" Padding="12,4"
                         ToolTip.Tip="Run this insert in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
-          <Button Content="Manual" Padding="10,4" Click="OnEditorManual" VerticalAlignment="Center"
+          <Button Content="Manual" Padding="10,4" Click="OnEditorManual"
                   ToolTip.Tip="Open the manual section on plugin editors"/>
         </StackPanel>
-      </StackPanel>
-      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Top">
-        <Button Content="Plugin UI" Padding="12,4" Click="OnNativeEditor"
-                IsVisible="{Binding NativeEditorSupported}"
-                IsEnabled="{Binding NativeEditorAvailable}"
-                ToolTip.Tip="Open this plugin's own editor on the live audio instance"/>
-        <Button Content="Defaults" Padding="12,4" Click="OnDefaults"
-                ToolTip.Tip="Put every control back to the plugin's own defaults"/>
-        <ToggleButton Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}" Padding="12,4"/>
       </StackPanel>
     </Grid>
     <Button DockPanel.Dock="Bottom" Content="Close" HorizontalAlignment="Right" Padding="18,6" Margin="0,10,0,0" Click="OnClose"/>

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -9,7 +9,8 @@ using Avalonia.Threading;
 namespace OpenXLR.UI;
 
 /// <summary>A plugin the picker offers (mono in / mono out only for the mic path).</summary>
-public sealed record PluginChoice(string Uri, string Name, string Category, JsonNode Params, bool NativeEditorAvailable = false)
+public sealed record PluginChoice(string Uri, string Name, string Category, JsonNode Params,
+    bool NativeEditorAvailable = false, bool NativeEditorSupported = false)
 {
     public override string ToString() => Category.Length > 0 ? $"{Name}  ({Category})" : Name;
 }
@@ -110,7 +111,8 @@ public sealed class InsertsViewModel : ViewModelBase
                     p["name"]?.GetValue<string>() ?? p["plugin"]!.GetValue<string>(),
                     p["category"]?.GetValue<string>() ?? "",
                     p["params"] ?? new JsonArray(),
-                    p["nativeEditorAvailable"]?.GetValue<bool>() == true));
+                    p["nativeEditorAvailable"]?.GetValue<bool>() == true,
+                    p["nativeEditorSupported"]?.GetValue<bool>() == true));
             }
             string width = _channels == 1 ? "mono" : "stereo";
             Note = PluginChoices.Count == 0
@@ -236,8 +238,18 @@ public sealed class InsertViewModel : ViewModelBase
 
     /// <summary>The channel chain this insert belongs to (row buttons route through it).</summary>
     public InsertsViewModel Owner => _owner;
-    public bool NativeEditorSupported => _owner.PluginChoices.Any(p => p.Uri == Plugin && p.NativeEditorAvailable);
-    public bool NativeEditorAvailable => NativeEditorSupported && NativeHost && !Bypass && !HasError && NativeHostRunning;
+    /// <summary>
+    /// The plugin could be hosted, whether or not the helper is here. A daemon
+    /// that only reports availability is older than this window, and anything
+    /// it calls available is by definition supported.
+    /// </summary>
+    public bool NativeEditorSupported => _owner.PluginChoices.Any(
+        p => p.Uri == Plugin && (p.NativeEditorSupported || p.NativeEditorAvailable));
+
+    /// <summary>The helper is here too, so turning the host on can work.</summary>
+    public bool NativeHostInstalled => _owner.PluginChoices.Any(p => p.Uri == Plugin && p.NativeEditorAvailable);
+
+    public bool NativeEditorAvailable => NativeHostInstalled && NativeHost && !Bypass && !HasError && NativeHostRunning;
 
     private bool _nativeHost;
     public bool NativeHost
@@ -388,6 +400,7 @@ public sealed class InsertViewModel : ViewModelBase
     private void BuildParams()
     {
         Raise(nameof(NativeEditorSupported));
+        Raise(nameof(NativeHostInstalled));
         Raise(nameof(CanChooseNativeHost));
         Raise(nameof(NativeEditorAvailable));
         if (_owner.ParamsFor(Plugin) is not JsonArray arr) return;

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -251,6 +251,28 @@ public sealed class InsertViewModel : ViewModelBase
 
     public bool NativeEditorAvailable => NativeHostInstalled && NativeHost && !Bypass && !HasError && NativeHostRunning;
 
+    /// <summary>
+    /// The switch can be turned on only where the helper is installed. It
+    /// stays usable while it is on, so a chain can always be moved back.
+    /// </summary>
+    public bool CanTurnNativeHostOn => NativeHostInstalled || NativeHost;
+
+    /// <summary>What the cog will open, which depends on what is running.</summary>
+    public string ControlsHint => NativeEditorAvailable
+        ? "Open this plugin's own editor"
+        : "Open this plugin's controls";
+
+    /// <summary>Everything the row and the controls window derive from the host state.</summary>
+    private void RaiseNativeFlags()
+    {
+        Raise(nameof(NativeEditorSupported));
+        Raise(nameof(NativeHostInstalled));
+        Raise(nameof(NativeEditorAvailable));
+        Raise(nameof(CanChooseNativeHost));
+        Raise(nameof(CanTurnNativeHostOn));
+        Raise(nameof(ControlsHint));
+    }
+
     private bool _nativeHost;
     public bool NativeHost
     {
@@ -259,8 +281,7 @@ public sealed class InsertViewModel : ViewModelBase
         {
             if (Set(ref _nativeHost, value))
             {
-                Raise(nameof(NativeEditorAvailable));
-                Raise(nameof(CanChooseNativeHost));
+                RaiseNativeFlags();
                 _owner.SendHostChoice();
             }
         }
@@ -273,14 +294,14 @@ public sealed class InsertViewModel : ViewModelBase
     public bool Bypass
     {
         get => _bypass;
-        set { if (Set(ref _bypass, value)) { Raise(nameof(StateText)); Raise(nameof(IsActive)); Raise(nameof(NativeEditorAvailable)); _owner.SendBypass(this, value); } }
+        set { if (Set(ref _bypass, value)) { Raise(nameof(StateText)); Raise(nameof(IsActive)); RaiseNativeFlags(); _owner.SendBypass(this, value); } }
     }
 
     private string? _error;
     public string? Error
     {
         get => _error;
-        private set { if (Set(ref _error, value)) { Raise(nameof(HasError)); Raise(nameof(StateText)); Raise(nameof(IsActive)); Raise(nameof(NativeEditorAvailable)); } }
+        private set { if (Set(ref _error, value)) { Raise(nameof(HasError)); Raise(nameof(StateText)); Raise(nameof(IsActive)); RaiseNativeFlags(); } }
     }
     public bool HasError => _error is not null;
 
@@ -288,7 +309,7 @@ public sealed class InsertViewModel : ViewModelBase
     public bool NativeHostRunning
     {
         get => _nativeHostRunning;
-        private set { if (Set(ref _nativeHostRunning, value)) Raise(nameof(NativeEditorAvailable)); }
+        private set { if (Set(ref _nativeHostRunning, value)) RaiseNativeFlags(); }
     }
 
     public string StateText => HasError ? "problem" : Bypass ? "bypassed" : "active";
@@ -369,11 +390,10 @@ public sealed class InsertViewModel : ViewModelBase
         _bypass = ins["bypass"]?.GetValue<bool>() ?? false;
         _nativeHost = ins["nativeHost"]?.GetValue<bool>() ?? false;
         Raise(nameof(NativeHost));
-        Raise(nameof(CanChooseNativeHost));
         Raise(nameof(Bypass));
         Raise(nameof(StateText));
         Raise(nameof(IsActive));
-        Raise(nameof(NativeEditorAvailable));
+        RaiseNativeFlags();
         Error = error;
         NativeHostRunning = nativeHostRunning;
         _params.Clear();
@@ -399,10 +419,7 @@ public sealed class InsertViewModel : ViewModelBase
 
     private void BuildParams()
     {
-        Raise(nameof(NativeEditorSupported));
-        Raise(nameof(NativeHostInstalled));
-        Raise(nameof(CanChooseNativeHost));
-        Raise(nameof(NativeEditorAvailable));
+        RaiseNativeFlags();
         if (_owner.ParamsFor(Plugin) is not JsonArray arr) return;
         foreach (JsonNode? p in arr)
         {

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -569,16 +569,22 @@
                   <ItemsControl ItemsSource="{Binding Inserts.Items}" IsVisible="{Binding Inserts.HasItems}">
                     <ItemsControl.ItemTemplate>
                       <DataTemplate x:DataType="vm:InsertViewModel">
-                        <Grid ColumnDefinitions="Auto,*,Auto,Auto" Margin="0,2,0,0">
+                        <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,2,0,0">
                           <Ellipse Width="8" Height="8" VerticalAlignment="Center" Margin="0,0,6,0"
                                    Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
                           <TextBlock Grid.Column="1" Text="{Binding Label}" Foreground="#e6e9f0" FontSize="11"
                                      VerticalAlignment="Center" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
-                          <ToggleButton Grid.Column="2" Content="B" IsChecked="{Binding Bypass, Mode=TwoWay}"
+                          <ToggleButton Grid.Column="2" Content="N" IsChecked="{Binding NativeHost, Mode=TwoWay}"
+                                        IsVisible="{Binding CanChooseNativeHost}"
+                                        IsEnabled="{Binding CanTurnNativeHostOn}"
+                                        Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,0,0"
+                                        HorizontalAlignment="Right"
+                                        ToolTip.Tip="Run this plugin in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
+                          <ToggleButton Grid.Column="3" Content="B" IsChecked="{Binding Bypass, Mode=TwoWay}"
                                         Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,2,0"
                                         HorizontalAlignment="Right" ToolTip.Tip="Bypass"/>
-                          <Button Grid.Column="3" Content="⚙" Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10"
-                                  Click="OnInsertControls" ToolTip.Tip="Open this plugin's controls"/>
+                          <Button Grid.Column="4" Content="⚙" Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10"
+                                  Click="OnInsertControls" ToolTip.Tip="{Binding ControlsHint}"/>
                         </Grid>
                       </DataTemplate>
                     </ItemsControl.ItemTemplate>

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -163,9 +163,14 @@ public partial class MainWindow : Window
         if (choice is not null) chain.Add(choice);
     }
 
-    private void OnInsertControls(object? sender, RoutedEventArgs e)
+    private async void OnInsertControls(object? sender, RoutedEventArgs e)
     {
-        if ((sender as Control)?.DataContext is InsertViewModel ins) InsertWindows.OpenControls(this, ins);
+        if ((sender as Control)?.DataContext is not InsertViewModel insert) return;
+        // A plugin running in its own process has an editor of its own, which
+        // is the better one to open. Anything else, including a native host
+        // that is bypassed or not running, opens the generated controls.
+        if (insert.NativeEditorAvailable) await insert.Owner.ShowNativeEditorAsync(insert);
+        else InsertWindows.OpenControls(this, insert);
     }
 
     private void OnMixInserts(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
Three changes from putting the native host in front of a real plugin set.

**The worker extension.** Reverbs and convolvers hand their heavy work to
the host instead of doing it in the audio callback. The helper could not do
that, so they could not be hosted, so their editors could never open. It now
runs that work on a thread of its own, fed by two lock-free rings: requests
leave the audio callback, answers come back and are delivered before the
next run. Neither side allocates or locks.

Every plugin here that wants the worker also wants `options` and the promise
that the block length is bounded, so both come with it. The block length
already is bounded, by the check the audio callback makes.

On this desk that moves nine plugins from unhostable to hostable, including
the three Dragonfly reverbs and the x42 convolvers. Verified live: Dragonfly
Hall Reverb runs as an insert on a mix and its editor opens with its
spectrogram drawn, which is exactly the thing the worker computes. Every
plugin installed here that has an X11 editor can now be hosted.

**The helper is plumbing.** An insert in the native host registers a
PipeWire client, so it appeared in the window's application list as
something to route, beside Discord and Spotify. It now joins the daemon, the
window and the PipeWire tools in the ignore list. A remembered entry from
before the fix stays until it is forgotten from the list.

**Buttons on one side.** Native host and Manual sat on the left under the
plugin name while Plugin UI, Defaults and Bypass sat on the right. They now
share the right side in two rows.

253 tests. The C helper builds with warnings as errors, here and in CI.