### PR TITLE
Inserts: install plugins from the window, Windows ones included

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,7 +37,7 @@ bursts of up to 300 commands and a sustained 100 per second; beyond
 that it is disconnected with close code 1008. At most 32 clients can be
 connected at once. The plugin catalog is bounded too: a plugin with a
 URI over 512 characters, more than 4096 ports, or one that would push
-the catalog past 6 MiB is left out of `plugins` altogether, and at most
+the catalog past 7 MiB is left out of `plugins` altogether, and at most
 512 controls, 256 scale points and 64 required features are read per
 plugin; a plugin that is listed with `supported: false` is a different
 case, one the chain host cannot run.
@@ -49,6 +49,8 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `state` | on connect and on every change | `daemonVersion`, device state, capabilities, mixer state, the device list, the app registry, profile names, `activeProfile` (the profile last recalled or saved for the active device; not cleared by later manual changes), `recallOnConnect` (the profile recalled when the device connects, or null), `warning` (one sentence the user should see, or null: mixer settings that cannot be written to disk, which the daemon keeps retrying with backoff, or a device set aside after three hung USB transfers in one run). In the mixer state, each channel carries `hardware` (true for the fixed input channels), `renamedSinceStart` says a virtual microphone was renamed since the daemon started (its PipeWire device keeps the old name until a restart), and `layoutWarning` is a sentence for the layout editor when pipewire-pulse nears its open-file limit, or null |
 | `meters` | 15 Hz while the mixer is built | live stereo levels per channel and mix |
 | `plugins` | in answer to `listPlugins` | the installed LV2 plugins with their controls; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
+| `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, and `windowsDirectories` (the folders yabridge bridges) |
+| `pluginInstall` | in answer to `installPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
 | `error` | when a command without a `requestId` is rejected | `message` |
 | `commandResult` | in answer to a command that carried a `requestId` | `requestId`, `error` (null on success); preceded by the state the result refers to |
 
@@ -82,6 +84,10 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setAuxPortEnabled` | `value` | send the Aux mix to the USB Aux port |
 | `setOutputVolume` | `value` | volume of the selected monitor devices |
 | `listPlugins` | none | the installed LV2 plugins, answered with a `plugins` message |
+| `getPluginSetup` | none | where plugins are installed and what bridges Windows ones, answered with a `pluginSetup` message |
+| `installPlugin` | `path` | install what is at an absolute path the user picked: a `.clap` or single-file `.vst3` is copied into `~/.clap` or `~/.vst3`, a `.vst3` or `.lv2` directory into `~/.vst3` or `~/.lv2`, a plain directory installs every plugin inside it, and a Windows VST3 or CLAP plugin has its directory added to yabridge and synced. Archives, installers and VST2 files are refused with a message that says what to do. The catalogues are read again before the `pluginInstall` answer |
+| `syncWindowsPlugins` | none | run yabridge's sync over the folders it knows, then read the catalogues again; answered with `pluginInstall` |
+| `rescanPlugins` | none | read the plugin directories again, for plugins installed by other means; answered with `pluginInstall` |
 | `setInserts` | `channel`, `inserts[]` | replace a chain; `channel` is `xlr1`, `xlr2` or `mix:<id>`, each insert is `{id, kind, plugin, label?, bypass?, params?}` where `kind` is `"lv2"` with the plugin URI, `"clap"` with the plugin's id, or `"vst3"` with the class id as 32 hex digits; a CLAP or VST3 insert always runs in the native host, so its `nativeHost` reads true whatever was sent |
 | `setInsertBypass` | `channel`, `insertId`, `value` | bypass one insert |
 | `setInsertParam` | `channel`, `insertId`, `symbol`, `value` | one plugin control, by its LV2 port symbol |

--- a/docs/features.md
+++ b/docs/features.md
@@ -135,6 +135,17 @@ bundle and nothing else, and what it learns is kept until the bundle
 changes. Windows VST3 plugins come through yabridge, which presents them
 as ordinary bundles under `~/.vst3`. VST2 plugins are not supported.
 
+Installing a plugin is a pick in the picker or in Options: a file or a
+folder the user downloaded. The daemon works out what it is from its
+name and its first bytes, copies a Linux `.clap`, `.vst3` or `.lv2` into
+the matching directory under the home, hands a folder of Windows plugins
+to yabridge and runs its sync, and answers in a sentence when it cannot
+help: an archive to extract, a Windows installer to run with Wine first,
+a VST2 file. The catalogues are read again afterwards, and every open
+chain fetches the list, so the plugin is in the picker a moment later.
+The Options window says where plugins go, whether yabridge and Wine are
+installed and how many folders they bridge, with a rescan and a sync.
+
 The list a window is sent has a size limit. The same plugin often ships
 in more than one format, and while everything fits every copy is offered;
 past the limit, LV2 stays whole and the other formats fill what room is

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -211,23 +211,43 @@ plugin's own editor can be opened as well, with the native host described
 in 3.12. CLAP and VST3 plugins appear in the same picker and always run in
 that host. VST2 plugins cannot be loaded.
 
-To install plugins, use your distribution's packages or copy the bundles
-into your home directory: LV2 bundles go in `~/.lv2` or `/usr/lib/lv2`,
-CLAP bundles in `~/.clap` or `/usr/lib/clap`, VST3 bundles in `~/.vst3` or
-`/usr/lib/vst3` (`LV2_PATH`, `CLAP_PATH` and `VST3_PATH` override those).
-On Arch, `lsp-plugins-lv2` and `x42-plugins` cover the microphone path
+<a name="install-plugins"></a>
+**Installing plugins.** The quickest set comes from your distribution:
+on Arch, `lsp-plugins-lv2` and `x42-plugins` cover the microphone path
 well, `lsp-plugins-vst3` is the same set as VST3, and `dragonfly-reverb-clap`,
 `dpf-plugins-clap` and `elephantdsp-roomreverb-clap` are CLAP effects for a
-mix. Windows VST3 plugins work through [yabridge](https://github.com/robbert-vdh/yabridge):
-install it with Wine, add the Windows plugin directory with `yabridgectl add`
-and run `yabridgectl sync`, and the bridged plugins appear under `~/.vst3`
-like any other. The daemon reads the catalogues once, when it starts, and
-keeps what it learnt about each bundle until that bundle changes, so restart
-it after installing:
+mix. For a plugin you downloaded, press "Install file…" or "Install
+folder…" in the picker or in Options and pick it; OpenXLR puts it where
+it looks and the picker lists it a moment later. A file is a `.clap` or a
+single-file `.vst3`; a folder is a `.vst3` or `.lv2` bundle, or a folder
+holding several of them, such as an extracted download. Linux plugins are
+copied into `~/.clap`, `~/.vst3` or `~/.lv2`, so the download can go
+afterwards. An archive has to be extracted first. Plugins installed by
+other means, or copied into `/usr/lib/clap`, `/usr/lib/vst3` or
+`/usr/lib/lv2` by a package, appear after "Rescan" in Options or a daemon
+restart (`LV2_PATH`, `CLAP_PATH` and `VST3_PATH` override the places
+searched).
+
+Windows VST3 and CLAP plugins run through
+[yabridge](https://github.com/robbert-vdh/yabridge), which wraps each one
+in a bundle that OpenXLR loads like any other. Install `yabridge` and
+`wine` from your distribution (Arch has both; Fedora has yabridge in the
+`patrickl/yabridge` Copr; on Debian and Ubuntu, unpack the release
+archive from its GitHub page into `~/.local/share/yabridge` and put
+`yabridgectl` on your PATH). Then run the plugin's Windows installer with
+Wine:
 
 ```sh
-systemctl --user restart openxlr-daemon.service
+wine ~/Downloads/PluginSetup.exe
 ```
+
+and install the folder it created, usually
+`~/.wine/drive_c/Program Files/Common Files/VST3`, with "Install
+folder…". OpenXLR adds that folder to yabridge and runs its sync, and the
+Options window says how many folders are bridged; "Sync Windows plugins"
+bridges again after another installer has run. A plugin that comes as a
+bare Windows `.vst3` or `.clap` file works the same way when picked as a
+file. VST2 `.dll` files are left out, since OpenXLR cannot load VST2.
 
 The picker marks each plugin with its format, since the same plugin often
 ships in more than one, and its LV2, CLAP and VST3 buttons narrow the list

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -129,9 +129,12 @@ host mechanism stable than two half-finished ones.
   Scans are cached per bundle, since a module of two hundred plugins takes
   a quarter of a minute to describe. Carla was considered and dropped: no
   commit in six months, no CLAP, and a second audio engine.
-- [ ] Windows plugins made easy: detect yabridge, run its sync when the
-  catalogue refreshes, and a card in Options that shows what was found with
-  the install steps behind a Manual link.
+- [x] Installing plugins from the window: pick a file or a folder and the
+  daemon puts it where it looks, copies Linux bundles into the home
+  directories, hands Windows plugins to yabridge and syncs, and reads the
+  catalogues again. A card in Options says where plugins go and whether
+  yabridge and Wine are there, with a rescan, a sync and the steps behind a
+  Manual link.
 - [ ] Presets: per-plugin and whole-chain, with export and import; copy a
   chain between channels; A/B comparison.
 - [ ] Plugin latency reported per insert and compensated across mixes.

--- a/src/OpenXLR.Core/Mixing/ClapCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/ClapCatalog.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace OpenXLR.Core.Mixing;
 
@@ -13,9 +12,11 @@ namespace OpenXLR.Core.Mixing;
 /// </summary>
 public static class ClapCatalog
 {
-    private static readonly Lazy<IReadOnlyList<PluginInfo>> Scan = new(() => ScanNow(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Refreshable<IReadOnlyList<PluginInfo>> Scan = new(() => ScanNow());
 
     public static IReadOnlyList<PluginInfo> Plugins => Scan.Value;
+
+    public static void Reset() => Scan.Reset();
 
     /// <summary>Where bundles live, in the order the CLAP specification gives.</summary>
     public static IReadOnlyList<string> SearchPath()
@@ -42,9 +43,11 @@ public static class ClapCatalog
 /// </summary>
 public static class Vst3Catalog
 {
-    private static readonly Lazy<IReadOnlyList<PluginInfo>> Scan = new(() => ScanNow(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Refreshable<IReadOnlyList<PluginInfo>> Scan = new(() => ScanNow());
 
     public static IReadOnlyList<PluginInfo> Plugins => Scan.Value;
+
+    public static void Reset() => Scan.Reset();
 
     public static IReadOnlyList<string> SearchPath()
     {
@@ -130,49 +133,122 @@ internal static class HostScan
 
     /// <summary>
     /// The scanner's JSON for one bundle, as plugins the picker can offer.
-    /// Read from bytes: a large module's description would double in size as
-    /// a string, and the daemon's heap is bounded.
+    /// Read as a stream of tokens rather than into a tree: one module can
+    /// describe two hundred plugins in several megabytes, and a tree of that
+    /// runs to many times its size, which the daemon's bounded heap does not
+    /// have. Nothing is held but the plugins themselves.
     /// </summary>
     internal static IReadOnlyList<PluginInfo> Parse(ReadOnlySpan<byte> json, string kind)
     {
         var result = new List<PluginInfo>();
-        if (JsonNode.Parse(json) is not JsonObject root) return result;
-        string file = root["file"]?.GetValue<string>() ?? "";
-        foreach (JsonNode? node in root["plugins"] as JsonArray ?? [])
+        var reader = new Utf8JsonReader(json, new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject) return result;
+        // The scanner writes "file" before "plugins", so a plugin's path is
+        // known by the time one is read; if it is not, the bundle is unnamed.
+        string file = "";
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
         {
-            if (node is not JsonObject p) continue;
-            string? id = p["id"]?.GetValue<string>();
-            if (string.IsNullOrWhiteSpace(id)) continue;
-            var features = (p["features"] as JsonArray)?.Select(f => f?.GetValue<string>() ?? "").ToList() ?? [];
-            var parameters = new List<PluginParam>();
-            foreach (JsonNode? q in p["params"] as JsonArray ?? [])
+            if (reader.ValueTextEquals("file"u8))
             {
-                if (q is not JsonObject param) continue;
-                double min = param["min"]?.GetValue<double>() ?? 0, max = param["max"]?.GetValue<double>() ?? 1;
-                double def = param["default"]?.GetValue<double>() ?? min;
-                bool stepped = param["stepped"]?.GetValue<bool>() == true;
-                bool enumeration = param["enum"]?.GetValue<bool>() == true;
-                parameters.Add(new PluginParam(
-                    (param["id"]?.GetValue<long>() ?? 0).ToString(CultureInfo.InvariantCulture),
-                    param["name"]?.GetValue<string>() ?? "",
-                    min, max, def,
-                    Toggled: stepped && min == 0 && max == 1,
-                    Integer: stepped,
-                    Logarithmic: false,
-                    Enumeration: enumeration,
-                    []));
-                if (parameters.Count == Lv2Catalog.MaxControls) break;
+                reader.Read();
+                file = reader.TokenType == JsonTokenType.String ? reader.GetString() ?? "" : "";
             }
-            int ins = p["audioIns"]?.GetValue<int>() ?? 0, outs = p["audioOuts"]?.GetValue<int>() ?? 0;
-            result.Add(new PluginInfo(kind, id, p["name"]?.GetValue<string>() ?? id, Category(features),
-                ins, outs, "", "", parameters, [], [], [])
+            else if (reader.ValueTextEquals("plugins"u8))
             {
-                HasNativeUi = p["gui"]?.GetValue<bool>() == true,
-                Path = file,
-            });
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.StartArray) { reader.Skip(); continue; }
+                while (reader.Read() && reader.TokenType == JsonTokenType.StartObject)
+                    if (ReadPlugin(ref reader, kind, file) is PluginInfo info)
+                        result.Add(info);
+            }
+            else { reader.Read(); reader.Skip(); }
         }
         return result;
     }
+
+    /// <summary>One plugin, from the object the reader stands on to its end.</summary>
+    private static PluginInfo? ReadPlugin(ref Utf8JsonReader reader, string kind, string file)
+    {
+        string? id = null, name = null;
+        var features = new List<string>();
+        var parameters = new List<PluginParam>();
+        int ins = 0, outs = 0;
+        bool gui = false;
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            if (reader.ValueTextEquals("id"u8)) { reader.Read(); id = Text(ref reader); }
+            else if (reader.ValueTextEquals("name"u8)) { reader.Read(); name = Text(ref reader); }
+            else if (reader.ValueTextEquals("audioIns"u8)) { reader.Read(); ins = Whole(ref reader); }
+            else if (reader.ValueTextEquals("audioOuts"u8)) { reader.Read(); outs = Whole(ref reader); }
+            else if (reader.ValueTextEquals("gui"u8)) { reader.Read(); gui = reader.TokenType == JsonTokenType.True; }
+            else if (reader.ValueTextEquals("features"u8))
+            {
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.StartArray) { reader.Skip(); continue; }
+                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                {
+                    if (features.Count < Lv2Catalog.MaxFeatures && reader.TokenType == JsonTokenType.String)
+                        features.Add(reader.GetString() ?? "");
+                    else reader.Skip();
+                }
+            }
+            else if (reader.ValueTextEquals("params"u8))
+            {
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.StartArray) { reader.Skip(); continue; }
+                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                {
+                    if (reader.TokenType != JsonTokenType.StartObject || parameters.Count >= Lv2Catalog.MaxControls) { reader.Skip(); continue; }
+                    if (ReadParam(ref reader) is PluginParam param) parameters.Add(param);
+                }
+            }
+            else { reader.Read(); reader.Skip(); }
+        }
+        if (string.IsNullOrWhiteSpace(id)) return null;
+        return new PluginInfo(kind, id, string.IsNullOrWhiteSpace(name) ? id : name, Category(features),
+            ins, outs, "", "", parameters, [], [], [])
+        {
+            HasNativeUi = gui,
+            Path = file,
+        };
+    }
+
+    /// <summary>One parameter, addressed by its id, which is how the helper takes it.</summary>
+    private static PluginParam? ReadParam(ref Utf8JsonReader reader)
+    {
+        long id = 0;
+        string name = "";
+        double min = 0, max = 1;
+        double? initial = null;
+        bool stepped = false, enumeration = false;
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            if (reader.ValueTextEquals("id"u8)) { reader.Read(); id = (long)Number(ref reader); }
+            else if (reader.ValueTextEquals("name"u8)) { reader.Read(); name = Text(ref reader) ?? ""; }
+            else if (reader.ValueTextEquals("min"u8)) { reader.Read(); min = Number(ref reader); }
+            else if (reader.ValueTextEquals("max"u8)) { reader.Read(); max = Number(ref reader, 1); }
+            else if (reader.ValueTextEquals("default"u8)) { reader.Read(); initial = Number(ref reader); }
+            else if (reader.ValueTextEquals("stepped"u8)) { reader.Read(); stepped = reader.TokenType == JsonTokenType.True; }
+            else if (reader.ValueTextEquals("enum"u8)) { reader.Read(); enumeration = reader.TokenType == JsonTokenType.True; }
+            else { reader.Read(); reader.Skip(); }
+        }
+        return new PluginParam(
+            id.ToString(CultureInfo.InvariantCulture), name, min, max, initial ?? min,
+            Toggled: stepped && min == 0 && max == 1,
+            Integer: stepped,
+            Logarithmic: false,
+            Enumeration: enumeration,
+            []);
+    }
+
+    private static string? Text(ref Utf8JsonReader reader)
+        => reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+
+    private static double Number(ref Utf8JsonReader reader, double fallback = 0)
+        => reader.TokenType == JsonTokenType.Number && reader.TryGetDouble(out double value) ? value : fallback;
+
+    private static int Whole(ref Utf8JsonReader reader)
+        => reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int value) ? value : 0;
 
     /// <summary>
     /// The picker's grouping, from the plugin's own feature list: CLAP

--- a/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
+++ b/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
@@ -16,7 +16,7 @@ namespace OpenXLR.Core.Mixing;
 /// </summary>
 public static class Lv2Catalog
 {
-    private static readonly Lazy<IReadOnlyList<PluginInfo>> Scan = new(() => ScanNow(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Refreshable<IReadOnlyList<PluginInfo>> Scan = new(() => ScanNow());
 
     /// <summary>
     /// The host features PipeWire's filter-chain LV2 loader provides (read
@@ -42,6 +42,9 @@ public static class Lv2Catalog
 
     /// <summary>Every LV2 plugin lilv can see (blocks on the first call).</summary>
     public static IReadOnlyList<PluginInfo> Plugins => Scan.Value;
+
+    /// <summary>Forget what was read; the next read scans again.</summary>
+    public static void Reset() => Scan.Reset();
 
     /// <summary>Kick the scan off without waiting for it.</summary>
     public static void Warm() => ThreadPool.QueueUserWorkItem(_ => { try { _ = Scan.Value; } catch (Exception) { } });
@@ -114,15 +117,26 @@ public static class Lv2Catalog
     internal const int MaxUri = 512;
     /// <summary>Required features beyond this count are not read; no real plugin declares more than a handful.</summary>
     internal const int MaxFeatures = 64;
-    /// <summary>Rough serialized size the whole catalog may reach; the window reads at most 8 MiB per message.</summary>
-    internal const int CatalogBudgetBytes = 6 * 1024 * 1024;
+    /// <summary>
+    /// Serialized size the whole catalog may reach. A client reads at most
+    /// 8 MiB in one message and drops anything longer, which would leave a
+    /// picker with nothing in it, so the catalog stops short of that with
+    /// room for the message around it.
+    /// </summary>
+    internal const int CatalogBudgetBytes = 7 * 1024 * 1024;
 
     private static string Clip(string s) => s.Length <= MaxText ? s : s[..MaxText];
 
-    /// <summary>A plugin's approximate footprint in the serialized catalog.</summary>
+    /// <summary>
+    /// A plugin's footprint in the serialized catalog. The fixed parts are
+    /// the field names and punctuation JSON puts around each value, measured
+    /// against what the daemon actually sends, and rounded up: an estimate
+    /// that ran under the truth would let the catalog past the size a client
+    /// will read.
+    /// </summary>
     internal static int Footprint(PluginInfo p)
-        => 160 + p.Plugin.Length + p.Name.Length + p.Category.Length
-           + p.Params.Sum(q => 120 + q.Symbol.Length + q.Name.Length + q.ScalePoints.Sum(sp => 24 + sp.Label.Length))
+        => 220 + p.Plugin.Length + p.Name.Length + p.Category.Length
+           + p.Params.Sum(q => 152 + q.Symbol.Length + q.Name.Length + q.ScalePoints.Sum(sp => 24 + sp.Label.Length))
            + p.RequiredFeatures.Sum(f => f.Length + 4) + (p.InputSymbols.Count + p.OutputSymbols.Count) * 16;
 
     /// <summary>

--- a/src/OpenXLR.Core/Mixing/PluginCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/PluginCatalog.cs
@@ -7,7 +7,7 @@ namespace OpenXLR.Core.Mixing;
 /// </summary>
 public static class PluginCatalog
 {
-    private static readonly Lazy<IReadOnlyList<PluginInfo>> All = new(Build, LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Refreshable<IReadOnlyList<PluginInfo>> All = new(Build);
 
     private static IReadOnlyList<PluginInfo> Build()
     {
@@ -67,6 +67,44 @@ public static class PluginCatalog
 
     /// <summary>The whole catalogue, within the size a client is sent (blocks on the first call).</summary>
     public static IReadOnlyList<PluginInfo> Plugins => All.Value;
+
+    /// <summary>
+    /// Read every source again, for plugins installed since. What was
+    /// learnt about a bundle that did not change comes from the scan cache,
+    /// so only new bundles cost a scan. Blocks until the new list is ready.
+    ///
+    /// The old catalogue is dropped first and the heap swept before the new
+    /// one is built: the daemon runs under a firm heap limit, and holding
+    /// two catalogues and a large module's description at once does not fit
+    /// in it. Whatever a caller still holds keeps its own copy alive, so a
+    /// caller that only wants to compare should keep the plugins' names,
+    /// not the plugins.
+    /// </summary>
+    public static IReadOnlyList<PluginInfo> Refresh()
+    {
+        Lv2Catalog.Reset();
+        ClapCatalog.Reset();
+        Vst3Catalog.Reset();
+        All.Reset();
+        GC.Collect(2, GCCollectionMode.Aggressive, blocking: true);
+        NativeHeap.Trim();
+        IReadOnlyList<PluginInfo> plugins = All.Value;
+        // lilv builds and frees a large model to answer this; without the
+        // trim the C library keeps every megabyte of it for a use that never
+        // comes, and a few rescans cost more memory than the daemon ever needs.
+        GC.Collect(2, GCCollectionMode.Aggressive, blocking: true);
+        NativeHeap.Trim();
+        return plugins;
+    }
+
+    /// <summary>Every plugin listed now, by format and identifier: enough to tell what a rescan gained.</summary>
+    public static HashSet<(string Kind, string Plugin)> Identities()
+        => [.. Plugins.Select(p => (p.Kind, p.Plugin))];
+
+    /// <summary>The same, but only for plugins that came from one of these directories.</summary>
+    public static int CountUnder(IReadOnlyCollection<string> directories, HashSet<(string Kind, string Plugin)> known)
+        => Plugins.Count(p => !known.Contains((p.Kind, p.Plugin))
+            && (directories.Count == 0 || p.Path is null || directories.Any(d => p.Path.StartsWith(d, StringComparison.Ordinal))));
 
     /// <summary>Kick both scans off without waiting for them.</summary>
     public static void Warm() => ThreadPool.QueueUserWorkItem(_ => { try { _ = All.Value; } catch (Exception) { } });

--- a/src/OpenXLR.Core/Mixing/PluginInstaller.cs
+++ b/src/OpenXLR.Core/Mixing/PluginInstaller.cs
@@ -1,0 +1,377 @@
+using System.Text;
+
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>What a path the user picked turned out to be.</summary>
+public enum PluginItemKind
+{
+    /// <summary>A directory named .lv2 with a manifest inside.</summary>
+    Lv2Bundle,
+    /// <summary>A .clap file built for Linux.</summary>
+    ClapBundle,
+    /// <summary>A .vst3 directory or file built for Linux.</summary>
+    Vst3Bundle,
+    /// <summary>A VST3 or CLAP plugin built for Windows: yabridge's job.</summary>
+    WindowsPlugin,
+    /// <summary>A Windows VST2 .dll, which nothing here can load.</summary>
+    WindowsVst2,
+    /// <summary>A Windows installer (.exe or .msi).</summary>
+    Installer,
+    /// <summary>A zip or tar the user has not extracted.</summary>
+    Archive,
+    /// <summary>Nothing that can be installed.</summary>
+    Unknown,
+}
+
+public sealed record PluginItem(PluginItemKind Kind, string Path);
+
+/// <summary>Where plugins are found and installed, and what is there to bridge Windows ones.</summary>
+public sealed record PluginSetup(
+    bool HostInstalled,
+    string Lv2Directory, string ClapDirectory, string Vst3Directory,
+    string? YabridgeVersion, bool Wine,
+    IReadOnlyList<string> WindowsDirectories);
+
+/// <summary>
+/// How an install went, in words the user can read. The destinations are
+/// where the plugins landed, so the caller can tell which of the plugins it
+/// finds afterwards came from this install.
+/// </summary>
+public sealed record InstallOutcome(bool Ok, string Message, IReadOnlyList<string> Installed, IReadOnlyList<string>? Destinations = null);
+
+/// <summary>
+/// Puts a plugin the user picked where the catalogues look. A Linux bundle
+/// is copied into the matching directory under the home, a Windows plugin
+/// directory is handed to yabridge, and everything else gets an answer
+/// that says what to do instead. Nothing here loads plugin code.
+/// </summary>
+public sealed class PluginInstaller
+{
+    /// <summary>How long yabridge gets to bridge a directory: it copies files, it does not run them.</summary>
+    private static readonly TimeSpan YabridgeTimeout = TimeSpan.FromMinutes(3);
+
+    private readonly string _lv2, _clap, _vst3;
+    private readonly string? _yabridgectl, _wine;
+    private readonly bool _hostInstalled;
+
+    /// <summary>The daemon's own: the home directories, the tools on PATH.</summary>
+    public PluginInstaller()
+        : this(HomeDirectory(".lv2"), HomeDirectory(".clap"), HomeDirectory(".vst3"),
+               OnPath("yabridgectl"), OnPath("wine"), NativePluginHost.HostInstalled) { }
+
+    public PluginInstaller(string lv2Directory, string clapDirectory, string vst3Directory,
+        string? yabridgectl, string? wine, bool hostInstalled = true)
+    {
+        _lv2 = lv2Directory;
+        _clap = clapDirectory;
+        _vst3 = vst3Directory;
+        _yabridgectl = yabridgectl;
+        _wine = wine;
+        _hostInstalled = hostInstalled;
+    }
+
+    private static string HomeDirectory(string name)
+        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), name);
+
+    /// <summary>A tool on PATH, or under ~/.local/bin where a tarball install puts it.</summary>
+    internal static string? OnPath(string name)
+    {
+        var directories = new List<string>();
+        string? path = Environment.GetEnvironmentVariable("PATH");
+        if (!string.IsNullOrEmpty(path)) directories.AddRange(path.Split(':', StringSplitOptions.RemoveEmptyEntries));
+        directories.Add(HomeDirectory(Path.Combine(".local", "bin")));
+        foreach (string directory in directories)
+        {
+            string candidate = Path.Combine(directory, name);
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    // --- what a path is ---------------------------------------------------------
+
+    /// <summary>What one path is, from its name and, for a file, its first bytes.</summary>
+    public static PluginItem Inspect(string path)
+    {
+        string name = Path.GetFileName(path.TrimEnd('/'));
+        string lower = name.ToLowerInvariant();
+        if (Directory.Exists(path))
+        {
+            if (lower.EndsWith(".lv2", StringComparison.Ordinal))
+                return new(File.Exists(Path.Combine(path, "manifest.ttl")) ? PluginItemKind.Lv2Bundle : PluginItemKind.Unknown, path);
+            if (lower.EndsWith(".vst3", StringComparison.Ordinal))
+            {
+                string contents = Path.Combine(path, "Contents");
+                if (Directory.Exists(contents))
+                {
+                    string[] architectures = Directory.GetDirectories(contents).Select(d => Path.GetFileName(d).ToLowerInvariant()).ToArray();
+                    if (architectures.Any(a => a.EndsWith("-linux", StringComparison.Ordinal))) return new(PluginItemKind.Vst3Bundle, path);
+                    if (architectures.Any(a => a.EndsWith("-win", StringComparison.Ordinal))) return new(PluginItemKind.WindowsPlugin, path);
+                }
+                return new(PluginItemKind.Unknown, path);
+            }
+            return new(PluginItemKind.Unknown, path);
+        }
+        if (!File.Exists(path)) return new(PluginItemKind.Unknown, path);
+        if (lower.EndsWith(".zip", StringComparison.Ordinal) || lower.EndsWith(".7z", StringComparison.Ordinal)
+            || lower.EndsWith(".rar", StringComparison.Ordinal) || lower.Contains(".tar", StringComparison.Ordinal)
+            || lower.EndsWith(".tgz", StringComparison.Ordinal) || lower.EndsWith(".txz", StringComparison.Ordinal))
+            return new(PluginItemKind.Archive, path);
+        if (lower.EndsWith(".exe", StringComparison.Ordinal) || lower.EndsWith(".msi", StringComparison.Ordinal))
+            return new(PluginItemKind.Installer, path);
+        bool clap = lower.EndsWith(".clap", StringComparison.Ordinal);
+        bool vst3 = lower.EndsWith(".vst3", StringComparison.Ordinal);
+        bool dll = lower.EndsWith(".dll", StringComparison.Ordinal);
+        if (!clap && !vst3 && !dll) return new(PluginItemKind.Unknown, path);
+        switch (Header(path))
+        {
+            case Binary.Elf when clap: return new(PluginItemKind.ClapBundle, path);
+            case Binary.Elf when vst3: return new(PluginItemKind.Vst3Bundle, path);
+            case Binary.Windows when dll: return new(PluginItemKind.WindowsVst2, path);
+            case Binary.Windows: return new(PluginItemKind.WindowsPlugin, path);
+            default: return new(PluginItemKind.Unknown, path);
+        }
+    }
+
+    private enum Binary { Other, Elf, Windows }
+
+    private static Binary Header(string path)
+    {
+        try
+        {
+            using FileStream stream = File.OpenRead(path);
+            Span<byte> head = stackalloc byte[4];
+            int read = stream.Read(head);
+            if (read >= 4 && head[0] == 0x7f && head[1] == (byte)'E' && head[2] == (byte)'L' && head[3] == (byte)'F') return Binary.Elf;
+            if (read >= 2 && head[0] == (byte)'M' && head[1] == (byte)'Z') return Binary.Windows;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+        return Binary.Other;
+    }
+
+    /// <summary>
+    /// Everything installable at a path: the path itself when it is a
+    /// plugin, else the plugins inside it, a few levels deep, so a folder
+    /// of Windows plugins or an extracted download works as one pick.
+    /// </summary>
+    public static IReadOnlyList<PluginItem> Items(string path)
+    {
+        PluginItem self = Inspect(path);
+        if (self.Kind != PluginItemKind.Unknown || !Directory.Exists(path)) return [self];
+        var found = new List<PluginItem>();
+        Collect(path, 0, found);
+        return found.Count == 0 ? [self] : found;
+    }
+
+    private static void Collect(string directory, int depth, List<PluginItem> found)
+    {
+        if (depth > 3 || found.Count >= 200) return;
+        IEnumerable<string> entries;
+        try { entries = Directory.EnumerateFileSystemEntries(directory).OrderBy(e => e, StringComparer.Ordinal).ToList(); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return; }
+        foreach (string entry in entries)
+        {
+            PluginItem item = Inspect(entry);
+            if (item.Kind is PluginItemKind.Archive or PluginItemKind.Installer) continue;   // not what a folder pick means
+            if (item.Kind != PluginItemKind.Unknown) found.Add(item);
+            else if (Directory.Exists(entry)) Collect(entry, depth + 1, found);
+        }
+    }
+
+    // --- installing -------------------------------------------------------------
+
+    /// <summary>Install whatever is at the path. Never throws; the outcome says what happened.</summary>
+    public InstallOutcome Install(string path)
+    {
+        if (!Path.IsPathRooted(path)) return new(false, "The path has to be absolute.", []);
+        if (!File.Exists(path) && !Directory.Exists(path)) return new(false, $"There is nothing at {path}.", []);
+        IReadOnlyList<PluginItem> items = Items(path);
+        string name = Path.GetFileName(path.TrimEnd('/'));
+        if (items.Count == 1 && items[0].Kind is PluginItemKind.Unknown or PluginItemKind.Archive or PluginItemKind.Installer or PluginItemKind.WindowsVst2)
+            return new(false, Refusal(items[0], name), []);
+
+        var installed = new List<string>();
+        var destinations = new List<string>();
+        var notes = new List<string>();
+        var windows = new List<string>();
+        int vst2 = 0;
+        foreach (PluginItem item in items)
+        {
+            switch (item.Kind)
+            {
+                case PluginItemKind.Lv2Bundle: Copy(item.Path, _lv2, installed, destinations, notes); break;
+                case PluginItemKind.ClapBundle: Copy(item.Path, _clap, installed, destinations, notes); break;
+                case PluginItemKind.Vst3Bundle: Copy(item.Path, _vst3, installed, destinations, notes); break;
+                case PluginItemKind.WindowsPlugin:
+                    // yabridge takes directories: a picked plugin means the
+                    // directory it is in, a picked directory means itself.
+                    windows.Add(string.Equals(item.Path, path, StringComparison.Ordinal) ? Path.GetDirectoryName(path.TrimEnd('/'))! : path);
+                    break;
+                case PluginItemKind.WindowsVst2: vst2++; break;
+            }
+        }
+        if (windows.Count > 0)
+        {
+            bool pickedOne = items.Count == 1 && string.Equals(items[0].Path, path, StringComparison.Ordinal);
+            notes.Add(Bridge(windows.Distinct(StringComparer.Ordinal).ToList(), pickedOne ? name : null, installed, destinations));
+        }
+        else if (vst2 > 0) notes.Add(vst2 == 1 ? "One VST2 plugin was left out: OpenXLR cannot load VST2." : $"{vst2} VST2 plugins were left out: OpenXLR cannot load VST2.");
+        if (installed.Count > 0 && !_hostInstalled && items.Any(i => i.Kind is not PluginItemKind.Lv2Bundle))
+            notes.Add("The native plugin host is not installed beside the daemon, so CLAP and VST3 plugins cannot run.");
+        bool ok = installed.Count > 0;
+        if (!ok && notes.Count == 0) notes.Add($"Nothing was installed from {name}.");
+        return new(ok, string.Join(" ", notes), installed, destinations);
+    }
+
+    private static string Refusal(PluginItem item, string name) => item.Kind switch
+    {
+        PluginItemKind.Archive => $"{name} is an archive. Extract it first, then pick the plugin inside.",
+        PluginItemKind.Installer => $"{name} is a Windows installer. Run it with Wine (wine {name}), then pick the folder it installed into, usually Program Files/Common Files/VST3 under the Wine prefix.",
+        PluginItemKind.WindowsVst2 => $"{name} is a VST2 plugin, which OpenXLR cannot load. Its VST3 or CLAP version works.",
+        _ => $"Nothing to install at {name}. Pick a .clap file, a .vst3 or .lv2 folder, or a folder holding plugins.",
+    };
+
+    private static void Copy(string source, string directory, List<string> installed, List<string> destinations, List<string> notes)
+    {
+        string name = Path.GetFileName(source.TrimEnd('/'));
+        string destination = Path.Combine(directory, name);
+        string sourceFull = Path.GetFullPath(source).TrimEnd('/');
+        if (string.Equals(sourceFull, Path.GetFullPath(destination).TrimEnd('/'), StringComparison.Ordinal))
+        {
+            installed.Add(name);   // already where it belongs: a rescan is all it needs
+            destinations.Add(destination);
+            return;
+        }
+        try
+        {
+            Directory.CreateDirectory(directory);
+            if (Directory.Exists(destination)) Directory.Delete(destination, recursive: true);
+            else if (File.Exists(destination)) File.Delete(destination);
+            if (Directory.Exists(source)) CopyTree(source, destination);
+            else File.Copy(source, destination);
+            installed.Add(name);
+            destinations.Add(destination);
+            notes.Add($"Installed {name} in {Shorten(directory)}.");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            notes.Add($"Could not copy {name} to {Shorten(directory)}: {ex.Message}");
+        }
+    }
+
+    private static void CopyTree(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        foreach (string entry in Directory.EnumerateFileSystemEntries(source))
+        {
+            string target = Path.Combine(destination, Path.GetFileName(entry));
+            var info = new FileInfo(entry);
+            if (info.LinkTarget is not null)
+            {
+                // A link inside a bundle points within it; a copied link does the same.
+                File.CreateSymbolicLink(target, info.LinkTarget);
+            }
+            else if (Directory.Exists(entry)) CopyTree(entry, target);
+            else File.Copy(entry, target);
+        }
+    }
+
+    private static string Shorten(string path)
+    {
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return path.StartsWith(home + "/", StringComparison.Ordinal) ? "~" + path[home.Length..] : path;
+    }
+
+    // --- Windows plugins through yabridge ------------------------------------------
+
+    /// <summary>
+    /// Add each directory to yabridge and sync once. Returns a sentence.
+    /// <paramref name="picked"/> names the plugin when the user picked one
+    /// rather than a folder, for the wording.
+    /// </summary>
+    private string Bridge(IReadOnlyList<string> directories, string? picked, List<string> installed, List<string> destinations)
+    {
+        if (_yabridgectl is null || _wine is null)
+        {
+            string missing = _yabridgectl is null && _wine is null ? "yabridge and Wine are" : _yabridgectl is null ? "yabridge is" : "Wine is";
+            string what = picked is not null ? $"{picked} is a Windows plugin"
+                : directories.Count == 1 ? $"{Path.GetFileName(directories[0])} holds Windows plugins" : "These are Windows plugins";
+            return $"{what}, and {missing} not installed. Install {(missing.StartsWith("yabridge and", StringComparison.Ordinal) ? "them" : "it")}, then add {(picked is not null || directories.Count == 1 ? "it" : "them")} again.";
+        }
+        HashSet<string> known = WindowsDirectories().ToHashSet(StringComparer.Ordinal);
+        foreach (string directory in directories)
+        {
+            if (known.Contains(Path.GetFullPath(directory).TrimEnd('/'))) continue;
+            ProcessResult? add = Run("add", directory);
+            if (add is null || add.ExitCode != 0)
+                return $"yabridge would not take {Shorten(directory)}: {Tail(add)}";
+        }
+        ProcessResult? sync = Run("sync");
+        if (sync is null || sync.ExitCode != 0) return $"yabridge could not bridge the plugins: {Tail(sync)}";
+        installed.AddRange(directories.Select(Shorten));
+        destinations.Add(Path.Combine(_vst3, "yabridge"));   // where yabridge writes its bundles
+        destinations.Add(Path.Combine(_clap, "yabridge"));
+        return directories.Count == 1
+            ? $"Bridged the Windows plugins in {Shorten(directories[0])} with yabridge."
+            : $"Bridged the Windows plugins in {directories.Count} folders with yabridge.";
+    }
+
+    /// <summary>Bridge again whatever yabridge knows, for plugins installed into those folders since.</summary>
+    public InstallOutcome SyncWindows()
+    {
+        if (_yabridgectl is null) return new(false, "yabridge is not installed.", []);
+        if (_wine is null) return new(false, "Wine is not installed, and yabridge needs it.", []);
+        IReadOnlyList<string> directories = WindowsDirectories();
+        if (directories.Count == 0) return new(false, "yabridge has no plugin folders yet. Add a Windows plugin to give it one.", []);
+        ProcessResult? sync = Run("sync");
+        if (sync is null || sync.ExitCode != 0) return new(false, $"yabridge could not bridge the plugins: {Tail(sync)}", []);
+        return new(true, directories.Count == 1
+            ? $"Bridged the Windows plugins in {Shorten(directories[0])}."
+            : $"Bridged the Windows plugins in {directories.Count} folders.", directories.Select(Shorten).ToList(),
+            [Path.Combine(_vst3, "yabridge"), Path.Combine(_clap, "yabridge")]);
+    }
+
+    /// <summary>The directories yabridge watches, from `yabridgectl list`.</summary>
+    public IReadOnlyList<string> WindowsDirectories()
+    {
+        if (_yabridgectl is null) return [];
+        ProcessResult? list = Run("list");
+        if (list is null || list.ExitCode != 0) return [];
+        return Encoding.UTF8.GetString(list.Stdout).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(line => line.StartsWith('/')).Select(line => line.TrimEnd('/')).ToList();
+    }
+
+    /// <summary>What is there: the directories, the host, yabridge and Wine.</summary>
+    public PluginSetup Setup()
+    {
+        string? version = null;
+        if (_yabridgectl is not null)
+        {
+            ProcessResult? result = Run("--version");
+            if (result is not null && result.ExitCode == 0)
+            {
+                string text = Encoding.UTF8.GetString(result.Stdout).Trim();
+                version = text.Split(' ', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? text;
+                if (version.Length == 0) version = "installed";
+            }
+            else version = "installed";
+        }
+        return new(_hostInstalled, Shorten(_lv2), Shorten(_clap), Shorten(_vst3), version, _wine is not null, WindowsDirectories());
+    }
+
+    private ProcessResult? Run(params string[] arguments)
+    {
+        if (_yabridgectl is null) return null;
+        try { return ProcessRunner.Run(_yabridgectl, arguments, YabridgeTimeout, cLocale: false); }
+        catch (Exception) { return null; }
+    }
+
+    private static string Tail(ProcessResult? result)
+    {
+        if (result is null) return "it could not be started.";
+        if (result.TimedOut) return "it did not finish in time.";
+        string text = (result.Stderr.Length > 0 ? result.Stderr : Encoding.UTF8.GetString(result.Stdout)).Trim();
+        string[] lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return lines.Length == 0 ? $"exit code {result.ExitCode}." : lines[^1];
+    }
+}

--- a/src/OpenXLR.Core/NativeHeap.cs
+++ b/src/OpenXLR.Core/NativeHeap.cs
@@ -1,0 +1,29 @@
+using System.Runtime.InteropServices;
+
+namespace OpenXLR.Core;
+
+/// <summary>
+/// Giving native memory back to the system. Scanning the LV2 world builds
+/// and frees a large model in C, and the C library keeps what it frees for
+/// its own next use, so a daemon that rescans a few times holds hundreds of
+/// megabytes it will never ask for again. One call after a scan hands the
+/// free pages back.
+/// </summary>
+public static class NativeHeap
+{
+    [DllImport("libc", EntryPoint = "malloc_trim", SetLastError = false)]
+    private static extern int MallocTrim(nuint pad);
+
+    private static bool _unavailable;
+
+    /// <summary>Return what the C library is holding free. Does nothing where there is no such call.</summary>
+    public static void Trim()
+    {
+        if (_unavailable || !OperatingSystem.IsLinux()) return;
+        try { MallocTrim(0); }
+        catch (Exception ex) when (ex is EntryPointNotFoundException or DllNotFoundException)
+        {
+            _unavailable = true;   // not glibc: nothing to do here
+        }
+    }
+}

--- a/src/OpenXLR.Core/Refreshable.cs
+++ b/src/OpenXLR.Core/Refreshable.cs
@@ -1,0 +1,25 @@
+namespace OpenXLR.Core;
+
+/// <summary>
+/// A value computed once and kept, like a Lazy, that can be thrown away so
+/// the next read computes it again. Reads during a reset get either the old
+/// value or the new one, never an exception from the swap.
+/// </summary>
+public sealed class Refreshable<T>
+{
+    private readonly Func<T> _compute;
+    private Lazy<T> _current;
+
+    public Refreshable(Func<T> compute)
+    {
+        _compute = compute;
+        _current = Fresh();
+    }
+
+    private Lazy<T> Fresh() => new(_compute, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public T Value => Volatile.Read(ref _current).Value;
+
+    /// <summary>Forget the value; the next read computes it again.</summary>
+    public void Reset() => Volatile.Write(ref _current, Fresh());
+}

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -79,6 +79,38 @@ public sealed record Command
 
     /// <summary>"setInsertParam": the control port symbol.</summary>
     [JsonPropertyName("symbol")] public string? Symbol { get; init; }
+
+    /// <summary>"installPlugin": the file or directory the user picked, absolute.</summary>
+    [JsonPropertyName("path")] public string? Path { get; init; }
+}
+
+/// <summary>Reply to "getPluginSetup": where plugins go and what bridges Windows ones.</summary>
+public sealed record PluginSetupMessage(PluginSetup Setup)
+{
+    [JsonPropertyName("type")] public string Type => "pluginSetup";
+    [JsonPropertyName("hostInstalled")] public bool HostInstalled => Setup.HostInstalled;
+    [JsonPropertyName("lv2Directory")] public string Lv2Directory => Setup.Lv2Directory;
+    [JsonPropertyName("clapDirectory")] public string ClapDirectory => Setup.ClapDirectory;
+    [JsonPropertyName("vst3Directory")] public string Vst3Directory => Setup.Vst3Directory;
+    /// <summary>yabridgectl's version when it is installed, else null.</summary>
+    [JsonPropertyName("yabridge")] public string? Yabridge => Setup.YabridgeVersion;
+    [JsonPropertyName("wine")] public bool Wine => Setup.Wine;
+    [JsonPropertyName("windowsDirectories")] public IReadOnlyList<string> WindowsDirectories => Setup.WindowsDirectories;
+    [JsonIgnore] public PluginSetup Setup { get; } = Setup;
+}
+
+/// <summary>Reply to "installPlugin", "syncWindowsPlugins" and "rescanPlugins": what happened, and what the catalogue gained.</summary>
+public sealed record PluginInstallMessage(bool Ok, string Message, IReadOnlyList<string> Installed, int Added, int Total)
+{
+    [JsonPropertyName("type")] public string Type => "pluginInstall";
+    [JsonPropertyName("ok")] public bool Ok { get; } = Ok;
+    /// <summary>A sentence or two for the user.</summary>
+    [JsonPropertyName("message")] public string Message { get; } = Message;
+    /// <summary>The bundles or directories installed, by name.</summary>
+    [JsonPropertyName("installed")] public IReadOnlyList<string> Installed { get; } = Installed;
+    /// <summary>Plugins in the catalogue now that were not before.</summary>
+    [JsonPropertyName("added")] public int Added { get; } = Added;
+    [JsonPropertyName("total")] public int Total { get; } = Total;
 }
 
 /// <summary>Reply to "listPlugins": everything the insert picker can offer.</summary>

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -197,6 +197,19 @@ public sealed class WebSocketHub
                 IReadOnlyList<OpenXLR.Core.Mixing.PluginInfo> plugins = await Task.Run(() => OpenXLR.Core.Mixing.PluginCatalog.Plugins);
                 await reply(new PluginsMessage(plugins));
                 break;
+            case "getPluginSetup":
+                await reply(new PluginSetupMessage(await Task.Run(() => new OpenXLR.Core.Mixing.PluginInstaller().Setup())));
+                break;
+            case "installPlugin":
+                if (string.IsNullOrWhiteSpace(cmd.Path)) { error = "installPlugin: missing 'path'"; break; }
+                await reply(await Task.Run(() => InstallPlugin(installer => installer.Install(cmd.Path))));
+                break;
+            case "syncWindowsPlugins":
+                await reply(await Task.Run(() => InstallPlugin(installer => installer.SyncWindows())));
+                break;
+            case "rescanPlugins":
+                await reply(await Task.Run(() => InstallPlugin(_ => new OpenXLR.Core.Mixing.InstallOutcome(true, "", []))));
+                break;
             case "set":
                 error = cmd.Control is null ? "set: missing 'control'" : _devices.Apply(cmd.Control, cmd.Value);  // broadcasts on success
                 break;
@@ -339,6 +352,37 @@ public sealed class WebSocketHub
     /// <summary>The active device's usb id, or null while disconnected.</summary>
     private string? ActiveDeviceId() => _devices.Snapshot().Device?.UsbId;
 
+    /// <summary>
+    /// Run one install step, then read the catalogues again and say what
+    /// they gained. Installs are serialised: two at once would copy over
+    /// each other and race yabridge.
+    /// </summary>
+    private PluginInstallMessage InstallPlugin(Func<OpenXLR.Core.Mixing.PluginInstaller, OpenXLR.Core.Mixing.InstallOutcome> step)
+    {
+        lock (_installGate)
+        {
+            // Only the plugins' identities are kept across the rescan: the
+            // catalogue itself is large, and holding the old one while the
+            // new is built would not fit in the daemon's heap.
+            HashSet<(string Kind, string Plugin)> before = OpenXLR.Core.Mixing.PluginCatalog.Identities();
+            OpenXLR.Core.Mixing.InstallOutcome outcome;
+            try { outcome = step(new OpenXLR.Core.Mixing.PluginInstaller()); }
+            catch (Exception ex) { outcome = new(false, ex.Message, []); }
+            OpenXLR.Core.Mixing.PluginCatalog.Refresh();
+            // What this install brought: plugins not listed before, and when
+            // the install landed somewhere, only those found there, so a
+            // catalogue trimmed to its budget shifting underneath does not
+            // count as new plugins.
+            int added = OpenXLR.Core.Mixing.PluginCatalog.CountUnder(outcome.Destinations ?? [], before);
+            int total = OpenXLR.Core.Mixing.PluginCatalog.Plugins.Count;
+            if (outcome.Ok) _log.LogInformation("plugins: {message} {added} new in the catalogue", outcome.Message, added);
+            else _log.LogInformation("plugins: {message}", outcome.Message);
+            return new PluginInstallMessage(outcome.Ok, outcome.Message, outcome.Installed, added, total);
+        }
+    }
+
+    private readonly object _installGate = new();
+
     /// <summary>Save, load, or delete a named profile (per device). Null on success.</summary>
     private string? HandleProfile(Command cmd)
     {
@@ -375,7 +419,7 @@ public sealed class WebSocketHub
 
     private void Broadcast(object message)
     {
-        string text;
+        byte[] text;
         try { text = Serialize(message); }
         catch (Exception ex)
         {
@@ -395,7 +439,12 @@ public sealed class WebSocketHub
         }
     }
 
-    private static string Serialize(object o) => JsonSerializer.Serialize(o, Json);
+    /// <summary>
+    /// A message as the bytes that go on the wire. The plugin catalogue runs
+    /// to megabytes, and building it as a string first would hold it twice
+    /// over in a daemon whose heap is bounded, so nothing here becomes text.
+    /// </summary>
+    private static byte[] Serialize(object o) => JsonSerializer.SerializeToUtf8Bytes(o, Json);
 
     /// <summary>
     /// A connection with one bounded send pump. WebSocket forbids concurrent
@@ -427,15 +476,15 @@ public sealed class WebSocketHub
             _sendPump = Task.Run(SendPumpAsync);
         }
 
-        public bool TrySend(string text)
+        public bool TrySend(byte[] payload)
             => Socket.State == WebSocketState.Open &&
-               _outgoing.Writer.TryWrite(new PendingSend(text, null));
+               _outgoing.Writer.TryWrite(new PendingSend(payload, null));
 
-        public Task SendAsync(string text)
+        public Task SendAsync(byte[] payload)
         {
             if (Socket.State != WebSocketState.Open) return Task.CompletedTask;
             var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            if (_outgoing.Writer.TryWrite(new PendingSend(text, sent))) return sent.Task;
+            if (_outgoing.Writer.TryWrite(new PendingSend(payload, sent))) return sent.Task;
             // The queue holds about two seconds of meter frames. A client that
             // has not drained it is stuck; drop it rather than let the send
             // fault propagate through the command pipeline. The receive loop
@@ -455,7 +504,7 @@ public sealed class WebSocketHub
                     active = pending;
                     using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token);
                     timeout.CancelAfter(SendTimeout);
-                    await Socket.SendAsync(Encoding.UTF8.GetBytes(pending.Text),
+                    await Socket.SendAsync(pending.Payload,
                         WebSocketMessageType.Text, true, timeout.Token);
                     pending.Completion?.TrySetResult();
                     active = null;
@@ -487,6 +536,6 @@ public sealed class WebSocketHub
             _ = _sendPump.ContinueWith(_ => _lifetime.Dispose(), TaskScheduler.Default);
         }
 
-        private sealed record PendingSend(string Text, TaskCompletionSource? Completion);
+        private sealed record PendingSend(byte[] Payload, TaskCompletionSource? Completion);
     }
 }

--- a/src/OpenXLR.Tests/ClapCatalogTests.cs
+++ b/src/OpenXLR.Tests/ClapCatalogTests.cs
@@ -232,4 +232,76 @@ public sealed class ClapCatalogTests
         public bool IsInsertKey(string key) => true;
         public int OverrideCount => 0;
     }
+
+    [Fact]
+    public void ALargeDescriptionIsReadWithoutHoldingATreeOfIt()
+    {
+        // What a module of two hundred plugins looks like: too large to hold
+        // as a node tree in the daemon's heap, so the parser reads it as a
+        // stream. The test is that everything survives the reading, unknown
+        // fields with a structure of their own included.
+        var json = new System.Text.StringBuilder("{\"file\":\"/usr/lib/vst3/big.vst3\",\"plugins\":[");
+        for (int i = 0; i < 200; i++)
+        {
+            if (i > 0) json.Append(',');
+            json.Append("{\"id\":\"" + i.ToString("D32") + "\",\"name\":\"Plugin " + i + "\",\"vendor\":\"Test\",");
+            json.Append("\"features\":[\"Fx\",\"Reverb\"],\"unknown\":{\"nested\":[1,2,{\"deep\":true}]},");
+            json.Append("\"audioIns\":2,\"audioOuts\":2,\"gui\":true,\"params\":[");
+            for (int q = 0; q < 60; q++)
+            {
+                if (q > 0) json.Append(',');
+                json.Append("{\"id\":" + q + ",\"name\":\"Param " + q + "\",\"module\":\"Group\",");
+                json.Append("\"min\":-12.5,\"max\":12.5,\"default\":0,\"readonly\":false,\"stepped\":false,\"enum\":false}");
+            }
+            json.Append("]}");
+        }
+        json.Append("]}");
+
+        IReadOnlyList<PluginInfo> found = Vst3Catalog.Parse(json.ToString());
+        Assert.Equal(200, found.Count);
+        Assert.Equal("Plugin 7", found[7].Name);
+        Assert.Equal("/usr/lib/vst3/big.vst3", found[7].Path);
+        Assert.Equal("Reverb", found[7].Category);
+        Assert.Equal((2, 2), (found[7].AudioIns, found[7].AudioOuts));
+        Assert.True(found[7].HasNativeUi);
+        Assert.Equal(60, found[7].Params.Count);
+        Assert.Equal("3", found[7].Params[3].Symbol);
+        Assert.Equal(-12.5, found[7].Params[3].Min);
+        Assert.Equal(0, found[7].Params[3].Default);
+    }
+
+    [Fact]
+    public void WhatTheScannerLeavesOutTakesItsUsualValue()
+    {
+        const string sparse = """
+            {"plugins":[
+              {"name":"No id","audioIns":1,"audioOuts":1},
+              {"id":"only.id"},
+              {"id":"defaults","name":"Defaults","extra":{"a":[1,{"b":2}]},
+               "params":[{"id":4,"name":"Level","min":-60},{"id":5,"stepped":true,"min":0,"max":1}]}
+            ]}
+            """;
+        IReadOnlyList<PluginInfo> found = ClapCatalog.Parse(sparse);
+        Assert.Equal(2, found.Count);                  // the one without an id is not a plugin
+        Assert.Equal("only.id", found[0].Name);        // no name: its id stands in
+        Assert.Equal("", found[0].Path);               // no file: an unnamed bundle
+        Assert.Equal((0, 0), (found[0].AudioIns, found[0].AudioOuts));
+        Assert.False(found[0].HasNativeUi);
+
+        PluginInfo defaults = found[1];
+        Assert.Equal(2, defaults.Params.Count);
+        Assert.Equal(-60, defaults.Params[0].Min);
+        Assert.Equal(1, defaults.Params[0].Max);    // no max: one
+        Assert.Equal(-60, defaults.Params[0].Default);  // no default: the minimum
+        Assert.True(defaults.Params[1].Toggled);        // stepped from zero to one
+    }
+
+    [Fact]
+    public void WhatIsNotADescriptionDescribesNothing()
+    {
+        Assert.Empty(ClapCatalog.Parse("[1,2,3]"));
+        Assert.Empty(ClapCatalog.Parse("\"a string\""));
+        Assert.Empty(ClapCatalog.Parse("{\"plugins\":\"not an array\"}"));
+        Assert.Empty(ClapCatalog.Parse("{}"));
+    }
 }

--- a/src/OpenXLR.Tests/PluginInstallerTests.cs
+++ b/src/OpenXLR.Tests/PluginInstallerTests.cs
@@ -1,0 +1,315 @@
+using System.Text.Json;
+using OpenXLR.Core;
+using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+public sealed class PluginInstallerTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "openxlr-test-" + Guid.NewGuid().ToString("N"));
+    private readonly string _lv2, _clap, _vst3, _picked;
+
+    public PluginInstallerTests()
+    {
+        _lv2 = Path.Combine(_root, "home", ".lv2");
+        _clap = Path.Combine(_root, "home", ".clap");
+        _vst3 = Path.Combine(_root, "home", ".vst3");
+        _picked = Path.Combine(_root, "Downloads");
+        Directory.CreateDirectory(_picked);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+    }
+
+    private static readonly byte[] Elf = [0x7f, (byte)'E', (byte)'L', (byte)'F', 2, 1, 1, 0];
+    private static readonly byte[] Windows = [(byte)'M', (byte)'Z', 0x90, 0, 3, 0, 0, 0];
+
+    private string File_(string relative, byte[] head)
+    {
+        string path = Path.Combine(_picked, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, head);
+        return path;
+    }
+
+    private string LinuxVst3(string name)
+    {
+        string bundle = Path.Combine(_picked, name);
+        File_(Path.Combine(name, "Contents", "x86_64-linux", Path.GetFileNameWithoutExtension(name) + ".so"), Elf);
+        File.WriteAllText(Path.Combine(bundle, "Contents", "moduleinfo.json"), "{}");
+        return bundle;
+    }
+
+    private string WindowsVst3(string name)
+    {
+        string bundle = Path.Combine(_picked, name);
+        File_(Path.Combine(name, "Contents", "x86_64-win", Path.GetFileNameWithoutExtension(name) + ".vst3"), Windows);
+        return bundle;
+    }
+
+    private string Lv2(string name)
+    {
+        string bundle = Path.Combine(_picked, name);
+        Directory.CreateDirectory(bundle);
+        File.WriteAllText(Path.Combine(bundle, "manifest.ttl"), "@prefix lv2: <http://lv2plug.in/ns/lv2core#> .");
+        File_(Path.Combine(name, "plugin.so"), Elf);
+        return bundle;
+    }
+
+    private PluginInstaller Installer(string? yabridgectl = null, string? wine = null, bool host = true)
+        => new(_lv2, _clap, _vst3, yabridgectl, wine, host);
+
+    [Fact]
+    public void WhatAPathIsComesFromItsNameAndItsFirstBytes()
+    {
+        Assert.Equal(PluginItemKind.ClapBundle, PluginInstaller.Inspect(File_("Hall.clap", Elf)).Kind);
+        Assert.Equal(PluginItemKind.WindowsPlugin, PluginInstaller.Inspect(File_("Hall-win.clap", Windows)).Kind);
+        Assert.Equal(PluginItemKind.Vst3Bundle, PluginInstaller.Inspect(File_("Old.vst3", Elf)).Kind);
+        Assert.Equal(PluginItemKind.WindowsPlugin, PluginInstaller.Inspect(File_("Old-win.vst3", Windows)).Kind);
+        Assert.Equal(PluginItemKind.WindowsVst2, PluginInstaller.Inspect(File_("Synth.dll", Windows)).Kind);
+        Assert.Equal(PluginItemKind.Vst3Bundle, PluginInstaller.Inspect(LinuxVst3("Comp.vst3")).Kind);
+        Assert.Equal(PluginItemKind.WindowsPlugin, PluginInstaller.Inspect(WindowsVst3("Comp-win.vst3")).Kind);
+        Assert.Equal(PluginItemKind.Lv2Bundle, PluginInstaller.Inspect(Lv2("gate.lv2")).Kind);
+        Assert.Equal(PluginItemKind.Archive, PluginInstaller.Inspect(File_("Plugin-1.0.zip", [0x50, 0x4b])).Kind);
+        Assert.Equal(PluginItemKind.Archive, PluginInstaller.Inspect(File_("Plugin-1.0.tar.gz", [0x1f, 0x8b])).Kind);
+        Assert.Equal(PluginItemKind.Installer, PluginInstaller.Inspect(File_("Setup.exe", Windows)).Kind);
+        Assert.Equal(PluginItemKind.Unknown, PluginInstaller.Inspect(File_("readme.txt", [0x41])).Kind);
+        Assert.Equal(PluginItemKind.Unknown, PluginInstaller.Inspect(File_("odd.clap", [0x41, 0x42, 0x43, 0x44])).Kind);
+        // A .lv2 directory without a manifest is just a directory.
+        string empty = Path.Combine(_picked, "empty.lv2");
+        Directory.CreateDirectory(empty);
+        Assert.Equal(PluginItemKind.Unknown, PluginInstaller.Inspect(empty).Kind);
+    }
+
+    [Fact]
+    public void AFolderPickIsEverythingInstallableInside()
+    {
+        LinuxVst3(Path.Combine("set", "A.vst3"));
+        File_(Path.Combine("set", "deeper", "B.clap"), Elf);
+        File_(Path.Combine("set", "notes.txt"), [0x41]);
+        File_(Path.Combine("set", "Setup.exe"), Windows);   // not what a folder pick means
+        IReadOnlyList<PluginItem> items = PluginInstaller.Items(Path.Combine(_picked, "set"));
+        Assert.Equal(2, items.Count);
+        Assert.Contains(items, i => i.Kind == PluginItemKind.Vst3Bundle && i.Path.EndsWith("A.vst3"));
+        Assert.Contains(items, i => i.Kind == PluginItemKind.ClapBundle && i.Path.EndsWith("B.clap"));
+    }
+
+    [Fact]
+    public void LinuxBundlesAreCopiedIntoTheHomeDirectories()
+    {
+        string clap = File_("Hall.clap", Elf);
+        string vst3 = LinuxVst3("Comp.vst3");
+        string lv2 = Lv2("gate.lv2");
+        PluginInstaller installer = Installer();
+
+        InstallOutcome one = installer.Install(clap);
+        Assert.True(one.Ok, one.Message);
+        Assert.Equal(["Hall.clap"], one.Installed);
+        Assert.True(File.Exists(Path.Combine(_clap, "Hall.clap")));
+        Assert.Contains("Installed Hall.clap", one.Message);
+        Assert.Equal([Path.Combine(_clap, "Hall.clap")], one.Destinations);
+
+        InstallOutcome two = installer.Install(vst3);
+        Assert.True(two.Ok, two.Message);
+        Assert.True(File.Exists(Path.Combine(_vst3, "Comp.vst3", "Contents", "x86_64-linux", "Comp.so")));
+        Assert.True(File.Exists(Path.Combine(_vst3, "Comp.vst3", "Contents", "moduleinfo.json")));
+
+        InstallOutcome three = installer.Install(lv2);
+        Assert.True(three.Ok, three.Message);
+        Assert.True(File.Exists(Path.Combine(_lv2, "gate.lv2", "manifest.ttl")));
+
+        // Installing again replaces what is there rather than failing on it.
+        File.WriteAllBytes(clap, [.. Elf, 1, 2, 3]);
+        Assert.True(installer.Install(clap).Ok);
+        Assert.Equal(Elf.Length + 3, new FileInfo(Path.Combine(_clap, "Hall.clap")).Length);
+    }
+
+    [Fact]
+    public void ABundleAlreadyInPlaceIsOnlyRescanned()
+    {
+        Directory.CreateDirectory(_clap);
+        string inPlace = Path.Combine(_clap, "Hall.clap");
+        File.WriteAllBytes(inPlace, Elf);
+        InstallOutcome outcome = Installer().Install(inPlace);
+        Assert.True(outcome.Ok);
+        Assert.Equal(["Hall.clap"], outcome.Installed);
+        Assert.Equal("", outcome.Message);   // nothing was copied, and nothing went wrong
+    }
+
+    [Fact]
+    public void WhatCannotBeInstalledGetsAnAnswerThatSaysWhatToDo()
+    {
+        PluginInstaller installer = Installer();
+        InstallOutcome archive = installer.Install(File_("Plugin-1.0.zip", [0x50, 0x4b]));
+        Assert.False(archive.Ok);
+        Assert.Contains("Extract it first", archive.Message);
+
+        InstallOutcome setup = installer.Install(File_("Setup.exe", Windows));
+        Assert.False(setup.Ok);
+        Assert.Contains("Run it with Wine", setup.Message);
+
+        InstallOutcome vst2 = installer.Install(File_("Synth.dll", Windows));
+        Assert.False(vst2.Ok);
+        Assert.Contains("VST2", vst2.Message);
+
+        InstallOutcome text = installer.Install(File_("readme.txt", [0x41]));
+        Assert.False(text.Ok);
+        Assert.Contains("Nothing to install", text.Message);
+
+        Assert.False(installer.Install("relative/path.clap").Ok);
+        Assert.False(installer.Install(Path.Combine(_picked, "missing.clap")).Ok);
+    }
+
+    [Fact]
+    public void WindowsPluginsWithoutYabridgeSaySo()
+    {
+        string bundle = WindowsVst3("Comp-win.vst3");
+        InstallOutcome none = Installer().Install(bundle);
+        Assert.False(none.Ok);
+        Assert.Equal("Comp-win.vst3 is a Windows plugin, and yabridge and Wine are not installed. Install them, then add it again.", none.Message);
+        InstallOutcome folder = Installer().Install(Path.GetDirectoryName(bundle)!);
+        Assert.Contains("Downloads holds Windows plugins", folder.Message);
+
+        InstallOutcome noWine = Installer(yabridgectl: "/bin/true").Install(bundle);
+        Assert.False(noWine.Ok);
+        Assert.Contains("Wine is not installed", noWine.Message);
+    }
+
+    /// <summary>A yabridgectl that records its calls and answers like the real one.</summary>
+    private string FakeYabridgectl(string knownDirectory = "")
+    {
+        string log = Path.Combine(_root, "yabridgectl.log");
+        string script = Path.Combine(_root, "yabridgectl");
+        File.WriteAllText(script, $$"""
+            #!/bin/sh
+            echo "$@" >> "{{log}}"
+            case "$1" in
+              --version) echo "yabridgectl 5.1.1" ;;
+              list) [ -n "{{knownDirectory}}" ] && echo "{{knownDirectory}}" ;;
+              add) [ -d "$2" ] || { echo "not a directory" >&2; exit 1; } ;;
+              sync) echo "Finished setting up 3 files" ;;
+            esac
+            exit 0
+            """);
+        if (!OperatingSystem.IsWindows())   // where these tests run; the analyser wants it said
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return script;
+    }
+
+    private string[] YabridgeCalls() => File.Exists(Path.Combine(_root, "yabridgectl.log"))
+        ? File.ReadAllLines(Path.Combine(_root, "yabridgectl.log")) : [];
+
+    [Fact]
+    public void AWindowsPluginIsHandedToYabridgeByItsDirectory()
+    {
+        string bundle = WindowsVst3(Path.Combine("VST3", "Comp-win.vst3"));
+        string directory = Path.GetDirectoryName(bundle)!;
+        PluginInstaller installer = Installer(FakeYabridgectl(), wine: "/bin/true");
+
+        InstallOutcome outcome = installer.Install(bundle);
+        Assert.True(outcome.Ok, outcome.Message);
+        Assert.Contains("Bridged the Windows plugins", outcome.Message);
+        Assert.Equal([$"list", $"add {directory}", "sync"], YabridgeCalls());
+        Assert.Equal([Path.Combine(_vst3, "yabridge"), Path.Combine(_clap, "yabridge")], outcome.Destinations);
+
+        // A picked folder of Windows plugins is the folder itself, added once.
+        File_(Path.Combine("VST3", "Other.vst3"), Windows);
+        File.Delete(Path.Combine(_root, "yabridgectl.log"));
+        outcome = installer.Install(directory);
+        Assert.True(outcome.Ok, outcome.Message);
+        Assert.Equal([$"list", $"add {directory}", "sync"], YabridgeCalls());
+    }
+
+    [Fact]
+    public void ADirectoryYabridgeKnowsIsOnlySynced()
+    {
+        string bundle = WindowsVst3(Path.Combine("VST3", "Comp-win.vst3"));
+        string directory = Path.GetDirectoryName(bundle)!;
+        PluginInstaller installer = Installer(FakeYabridgectl(directory), wine: "/bin/true");
+        Assert.True(installer.Install(bundle).Ok);
+        Assert.Equal(["list", "sync"], YabridgeCalls());
+
+        InstallOutcome sync = installer.SyncWindows();
+        Assert.True(sync.Ok, sync.Message);
+        PluginSetup setup = installer.Setup();
+        Assert.Equal("5.1.1", setup.YabridgeVersion);
+        Assert.True(setup.Wine);
+        Assert.Equal([directory], setup.WindowsDirectories);
+    }
+
+    [Fact]
+    public void AMixedFolderInstallsTheLinuxPluginsAndBridgesTheRest()
+    {
+        string folder = Path.Combine(_picked, "mixed");
+        File_(Path.Combine("mixed", "Hall.clap"), Elf);
+        WindowsVst3(Path.Combine("mixed", "Comp-win.vst3"));
+        File_(Path.Combine("mixed", "Old.dll"), Windows);
+        InstallOutcome outcome = Installer(FakeYabridgectl(), wine: "/bin/true").Install(folder);
+        Assert.True(outcome.Ok, outcome.Message);
+        Assert.True(File.Exists(Path.Combine(_clap, "Hall.clap")));
+        Assert.Contains("Installed Hall.clap", outcome.Message);
+        Assert.Contains("Bridged the Windows plugins", outcome.Message);
+        Assert.Contains($"add {folder}", YabridgeCalls());
+    }
+
+    [Fact]
+    public void WithoutTheNativeHostAClapInstallSaysItCannotRun()
+    {
+        InstallOutcome outcome = Installer(host: false).Install(File_("Hall.clap", Elf));
+        Assert.True(outcome.Ok);
+        Assert.Contains("native plugin host is not installed", outcome.Message);
+    }
+
+    [Fact]
+    public void TheSetupNamesTheDirectoriesAndWhatIsMissing()
+    {
+        PluginSetup setup = Installer().Setup();
+        Assert.Null(setup.YabridgeVersion);
+        Assert.False(setup.Wine);
+        Assert.Empty(setup.WindowsDirectories);
+        Assert.EndsWith(".clap", setup.ClapDirectory);
+        Assert.True(setup.HostInstalled);
+    }
+
+    [Fact]
+    public void ARefreshableForgetsItsValueOnReset()
+    {
+        int computed = 0;
+        var value = new Refreshable<int>(() => ++computed);
+        Assert.Equal(1, value.Value);
+        Assert.Equal(1, value.Value);
+        value.Reset();
+        Assert.Equal(2, value.Value);
+        Assert.Equal(2, computed);
+    }
+
+    [Fact]
+    public void TheInstallCommandCarriesThePath()
+    {
+        Command? cmd = JsonSerializer.Deserialize<Command>("""{"cmd":"installPlugin","path":"/home/me/Downloads/Hall.clap","requestId":"r1"}""");
+        Assert.NotNull(cmd);
+        Assert.Equal("/home/me/Downloads/Hall.clap", cmd.Path);
+        var message = new PluginInstallMessage(true, "Installed Hall.clap in ~/.clap.", ["Hall.clap"], 1, 278);
+        string json = JsonSerializer.Serialize(message);
+        Assert.Contains("\"type\":\"pluginInstall\"", json);
+        Assert.Contains("\"added\":1", json);
+        var setup = new PluginSetupMessage(new PluginSetup(true, "~/.lv2", "~/.clap", "~/.vst3", "5.1.1", true, ["/home/me/.wine/drive_c/VST3"]));
+        string setupJson = JsonSerializer.Serialize(setup);
+        Assert.Contains("\"yabridge\":\"5.1.1\"", setupJson);
+        Assert.DoesNotContain("\"Setup\"", setupJson);
+    }
+
+    [Fact]
+    public void TheOptionsLineOnWindowsPluginsSaysWhatIsMissing()
+    {
+        Assert.Contains("yabridge and Wine are not installed", OptionsViewModel.WindowsLine(null, false, 0));
+        Assert.Contains("yabridge is not", OptionsViewModel.WindowsLine(null, true, 0));
+        Assert.Contains("Wine is not", OptionsViewModel.WindowsLine("5.1.1", false, 0));
+        Assert.Contains("no folder bridged yet", OptionsViewModel.WindowsLine("5.1.1", true, 0));
+        Assert.Contains("2 folders bridged", OptionsViewModel.WindowsLine("5.1.1", true, 2));
+    }
+}

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -60,7 +60,28 @@ public sealed class DaemonClient : IAsyncDisposable
     public Task<JsonNode?> RequestPluginsAsync(TimeSpan timeout)
         => QueryAsync("plugins", "listPlugins", timeout);
 
-    private async Task<JsonNode?> QueryAsync(string type, string command, TimeSpan timeout)
+    /// <summary>Where plugins go and what bridges Windows ones (a "pluginSetup" message); null on timeout.</summary>
+    public Task<JsonNode?> RequestPluginSetupAsync(TimeSpan timeout)
+        => QueryAsync("pluginSetup", "getPluginSetup", timeout);
+
+    /// <summary>
+    /// Ask the daemon to install the plugin at a path the user picked. The
+    /// reply says what happened and how many plugins the catalogue gained;
+    /// null when the daemon did not answer in time. A scan of a large
+    /// bundle can take a while, so callers wait generously.
+    /// </summary>
+    public Task<JsonNode?> InstallPluginAsync(string path, TimeSpan timeout)
+        => QueryAsync("pluginInstall", "installPlugin", timeout, new Dictionary<string, object> { ["path"] = path });
+
+    /// <summary>Bridge again what yabridge knows; the reply is as for an install.</summary>
+    public Task<JsonNode?> SyncWindowsPluginsAsync(TimeSpan timeout)
+        => QueryAsync("pluginInstall", "syncWindowsPlugins", timeout);
+
+    /// <summary>Read the catalogues again, for plugins installed by other means.</summary>
+    public Task<JsonNode?> RescanPluginsAsync(TimeSpan timeout)
+        => QueryAsync("pluginInstall", "rescanPlugins", timeout);
+
+    private async Task<JsonNode?> QueryAsync(string type, string command, TimeSpan timeout, Dictionary<string, object>? fields = null)
     {
         PendingQuery query;
         bool send;
@@ -73,7 +94,8 @@ public sealed class DaemonClient : IAsyncDisposable
         }
         try
         {
-            if (send && !await SendAsync(new { cmd = command, requestId = query.Id }, reportErrors: false))
+            var payload = new Dictionary<string, object>(fields ?? []) { ["cmd"] = command, ["requestId"] = query.Id };
+            if (send && !await SendAsync(payload, reportErrors: false))
                 query.Reply.TrySetResult(null);
             return await query.Reply.Task.WaitAsync(timeout);
         }
@@ -211,6 +233,7 @@ public sealed class DaemonClient : IAsyncDisposable
             else if (type == "state") { LastStateJson = text; StateReceived?.Invoke(node); }
             else if (type == "diagnostics") StoreReply(type, node);
             else if (type == "plugins") StoreReply(type, node["plugins"]);
+            else if (type is "pluginSetup" or "pluginInstall") StoreReply(type, node);
             else if (type == "commandResult" && node["requestId"]?.GetValue<string>() is string requestId)
             {
                 CompleteQuery(requestId);

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -127,6 +127,20 @@ public sealed class InsertsViewModel : ViewModelBase
 
     public void ResetForNewConnection() { _pluginsRequested = false; _catalogTask = null; }
 
+    /// <summary>
+    /// After a plugin was installed: every chain fetches the catalogue
+    /// again, sharing one request. The main view model wires this to all
+    /// of its chains; the picker and Options call it.
+    /// </summary>
+    public static Action? ReloadAll { get; set; }
+
+    internal static void ForgetCatalogue() => _catalogTask = null;
+
+    /// <summary>Fetch the catalogue again for this chain.</summary>
+    public void Refetch() { _pluginsRequested = false; EnsurePluginsLoaded(); }
+
+    internal DaemonClient Client => _client;
+
     /// <summary>Whether the catalog has arrived for this chain.</summary>
     public bool CatalogReady => PluginChoices.Count > 0;
 

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -50,6 +50,57 @@ public sealed class OptionsViewModel : ViewModelBase
         finally { _applying = false; }
     }
 
+    // --- plugins ---
+
+    private string _pluginDirectories = "Plugins are looked for in the home and system plugin directories.";
+    /// <summary>Where installs go, once the daemon has said.</summary>
+    public string PluginDirectories { get => _pluginDirectories; private set => Set(ref _pluginDirectories, value); }
+
+    private string _windowsPlugins = "Windows plugins: checking for yabridge…";
+    /// <summary>yabridge and Wine as found, and how many folders are bridged.</summary>
+    public string WindowsPlugins { get => _windowsPlugins; private set => Set(ref _windowsPlugins, value); }
+
+    private bool _canSyncWindows;
+    public bool CanSyncWindows { get => _canSyncWindows; private set => Set(ref _canSyncWindows, value); }
+
+    /// <summary>Ask the daemon where plugins go and what is there to bridge Windows ones.</summary>
+    public async System.Threading.Tasks.Task LoadPluginSetupAsync()
+    {
+        System.Text.Json.Nodes.JsonNode? setup = await _client.RequestPluginSetupAsync(TimeSpan.FromSeconds(10));
+        Avalonia.Threading.Dispatcher.UIThread.Post(() => ApplyPluginSetup(setup));
+    }
+
+    internal void ApplyPluginSetup(System.Text.Json.Nodes.JsonNode? setup)
+    {
+        if (setup is null)
+        {
+            WindowsPlugins = "Windows plugins: the daemon did not answer.";
+            CanSyncWindows = false;
+            return;
+        }
+        string lv2 = setup["lv2Directory"]?.GetValue<string>() ?? "~/.lv2";
+        string clap = setup["clapDirectory"]?.GetValue<string>() ?? "~/.clap";
+        string vst3 = setup["vst3Directory"]?.GetValue<string>() ?? "~/.vst3";
+        bool host = setup["hostInstalled"]?.GetValue<bool>() ?? true;
+        PluginDirectories = $"Plugins are looked for in {lv2}, {clap} and {vst3} and the system plugin directories."
+            + (host ? "" : " The native plugin host is not installed beside the daemon, so CLAP and VST3 plugins cannot run.");
+        string? yabridge = setup["yabridge"]?.GetValue<string>();
+        bool wine = setup["wine"]?.GetValue<bool>() ?? false;
+        int folders = (setup["windowsDirectories"] as System.Text.Json.Nodes.JsonArray)?.Count ?? 0;
+        WindowsPlugins = WindowsLine(yabridge, wine, folders);
+        CanSyncWindows = yabridge is not null && wine;
+    }
+
+    /// <summary>One line on Windows plugins, from what the daemon found.</summary>
+    internal static string WindowsLine(string? yabridge, bool wine, int folders)
+    {
+        if (yabridge is null && !wine) return "Windows plugins: yabridge and Wine are not installed. Install both from your distribution, then install a Windows VST3 or CLAP plugin here.";
+        if (yabridge is null) return "Windows plugins: Wine is installed, yabridge is not. Install yabridge from your distribution, then install a Windows VST3 or CLAP plugin here.";
+        if (!wine) return $"Windows plugins: yabridge {yabridge} is installed, Wine is not. Install Wine from your distribution.";
+        string bridged = folders switch { 0 => "no folder bridged yet", 1 => "1 folder bridged", _ => $"{folders} folders bridged" };
+        return $"Windows plugins: yabridge {yabridge} and Wine are installed, {bridged}. Run a plugin's installer with Wine, then install the folder it created.";
+    }
+
     // --- startup behaviour ---
 
     private bool _checkForUpdates;

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -94,6 +94,30 @@
       </StackPanel>
     </Border>
 
+    <Border Classes="card">
+      <StackPanel Spacing="6">
+        <TextBlock Text="PLUGINS" Classes="h"/>
+        <TextBlock Text="{Binding PluginDirectories}" FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
+        <TextBlock Text="Pick a plugin you downloaded and OpenXLR puts it in place: a .clap or .vst3 file, a .vst3 or .lv2 folder, or a folder holding plugins."
+                   FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <Button Name="InstallFile" Content="Install file…" Padding="14,5" Click="OnInstallPluginFile"/>
+          <Button Name="InstallFolder" Content="Install folder…" Padding="14,5" Click="OnInstallPluginFolder"/>
+          <Button Name="Rescan" Content="Rescan" Padding="14,5" Click="OnRescanPlugins"
+                  ToolTip.Tip="Read the plugin directories again, for plugins installed by other means"/>
+        </StackPanel>
+        <TextBlock Text="{Binding WindowsPlugins}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="0,4,0,0"/>
+        <Grid ColumnDefinitions="Auto,8,Auto,10,*">
+          <Button Name="SyncWindows" Content="Sync Windows plugins" Padding="14,5" Click="OnSyncWindowsPlugins"
+                  IsEnabled="{Binding CanSyncWindows}"
+                  ToolTip.Tip="Bridge again every folder yabridge knows, for Windows plugins installed since"/>
+          <Button Grid.Column="2" Content="Manual" Padding="10,5" Click="OnPluginsManual"
+                  ToolTip.Tip="Open the manual section on installing plugins"/>
+          <TextBlock Grid.Column="4" Name="PluginStatus" FontSize="11" Foreground="#8b93a7" VerticalAlignment="Center" TextWrapping="Wrap"/>
+        </Grid>
+      </StackPanel>
+    </Border>
+
     <Border Classes="card" IsVisible="{Binding Main.ShowResetDefaults}">
       <StackPanel Spacing="6">
         <TextBlock Text="INTERFACE" Classes="h"/>

--- a/src/OpenXLR.UI/OptionsWindow.axaml.cs
+++ b/src/OpenXLR.UI/OptionsWindow.axaml.cs
@@ -14,7 +14,53 @@ public partial class OptionsWindow : Window
     public OptionsWindow(OptionsViewModel vm) : this()
     {
         DataContext = vm;
+        Opened += async (_, _) => await vm.LoadPluginSetupAsync();
     }
+
+    // Plugins: the same install flow as the picker, plus yabridge's sync and a rescan.
+    private async void OnInstallPluginFile(object? sender, RoutedEventArgs e)
+        => await InstallPluginsAsync(await PluginInstall.PickFilesAsync(this));
+
+    private async void OnInstallPluginFolder(object? sender, RoutedEventArgs e)
+        => await InstallPluginsAsync(await PluginInstall.PickFolderAsync(this));
+
+    private async System.Threading.Tasks.Task InstallPluginsAsync(System.Collections.Generic.IReadOnlyList<string> paths)
+    {
+        if (paths.Count == 0 || DataContext is not OptionsViewModel vm) return;
+        await PluginStepAsync(() => PluginInstall.InstallAsync(vm.Client, paths), "Installing…", vm);
+    }
+
+    private async void OnSyncWindowsPlugins(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not OptionsViewModel vm) return;
+        await PluginStepAsync(async () => PluginInstall.Describe(
+            await vm.Client.SyncWindowsPluginsAsync(TimeSpan.FromMinutes(4)), "the sync"), "Bridging Windows plugins…", vm);
+    }
+
+    private async void OnRescanPlugins(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not OptionsViewModel vm) return;
+        await PluginStepAsync(async () => PluginInstall.Describe(
+            await vm.Client.RescanPluginsAsync(TimeSpan.FromMinutes(4)), "the scan"), "Scanning…", vm);
+    }
+
+    private async System.Threading.Tasks.Task PluginStepAsync(Func<System.Threading.Tasks.Task<string>> step, string busy, OptionsViewModel vm)
+    {
+        InstallFile.IsEnabled = InstallFolder.IsEnabled = Rescan.IsEnabled = false;
+        bool sync = SyncWindows.IsEnabled;
+        SyncWindows.IsEnabled = false;
+        PluginStatus.Text = busy;
+        try { PluginStatus.Text = await step(); }
+        catch (Exception ex) { PluginStatus.Text = ex.Message; }
+        finally
+        {
+            InstallFile.IsEnabled = InstallFolder.IsEnabled = Rescan.IsEnabled = true;
+            SyncWindows.IsEnabled = sync;
+            await vm.LoadPluginSetupAsync();
+        }
+    }
+
+    private void OnPluginsManual(object? sender, RoutedEventArgs e) => ExternalLink.Open(PluginInstall.Manual);
 
     private async void OnCollectDiagnostics(object? sender, RoutedEventArgs e)
     {

--- a/src/OpenXLR.UI/PluginInstall.cs
+++ b/src/OpenXLR.UI/PluginInstall.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+
+namespace OpenXLR.UI;
+
+/// <summary>
+/// Installing a plugin from the desktop: the user picks a file or a
+/// folder, the daemon puts it where the catalogues look (or hands a
+/// Windows plugin to yabridge), and every open chain fetches the
+/// catalogue again. Shared by the picker and the Options window.
+/// </summary>
+public static class PluginInstall
+{
+    /// <summary>A bundle of two hundred plugins takes a quarter of a minute to describe; yabridge's sync is quick.</summary>
+    private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(4);
+
+    public const string Manual = "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#install-plugins";
+
+    /// <summary>Let the user pick plugin files: .clap, a single-file .vst3, or a Windows plugin.</summary>
+    public static async Task<IReadOnlyList<string>> PickFilesAsync(Window owner)
+    {
+        IStorageFolder? start = await owner.StorageProvider.TryGetWellKnownFolderAsync(WellKnownFolder.Downloads);
+        IReadOnlyList<IStorageFile> files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Install plugin files",
+            AllowMultiple = true,
+            SuggestedStartLocation = start,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("Plugins") { Patterns = ["*.clap", "*.vst3", "*.dll"] },
+                FilePickerFileTypes.All,
+            ],
+        });
+        return files.Select(LocalPath).OfType<string>().ToList();
+    }
+
+    /// <summary>Let the user pick a folder: a .vst3 or .lv2 bundle, or a folder holding plugins.</summary>
+    public static async Task<IReadOnlyList<string>> PickFolderAsync(Window owner)
+    {
+        IStorageFolder? start = await owner.StorageProvider.TryGetWellKnownFolderAsync(WellKnownFolder.Downloads);
+        IReadOnlyList<IStorageFolder> folders = await owner.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Install a plugin folder",
+            AllowMultiple = true,
+            SuggestedStartLocation = start,
+        });
+        return folders.Select(LocalPath).OfType<string>().ToList();
+    }
+
+    private static string? LocalPath(IStorageItem item)
+    {
+        try { return item.TryGetLocalPath(); }
+        catch (Exception) { return null; }
+    }
+
+    /// <summary>
+    /// Install each path in turn and say how it went in a sentence or two.
+    /// Then every chain fetches the catalogue again.
+    /// </summary>
+    public static async Task<string> InstallAsync(DaemonClient client, IReadOnlyList<string> paths)
+    {
+        var lines = new List<string>();
+        int added = 0;
+        foreach (string path in paths)
+        {
+            JsonNode? reply = await client.InstallPluginAsync(path, InstallTimeout);
+            if (reply is null) { lines.Add($"No answer from the daemon for {System.IO.Path.GetFileName(path.TrimEnd('/'))}."); continue; }
+            lines.Add(reply["message"]?.GetValue<string>() ?? "");
+            added += reply["added"]?.GetValue<int>() ?? 0;
+        }
+        Reload();
+        return Summarise(lines, added);
+    }
+
+    /// <summary>Report the outcome of a sync or rescan the same way.</summary>
+    public static string Describe(JsonNode? reply, string what)
+    {
+        if (reply is null) return $"No answer from the daemon; {what} may still be running.";
+        Reload();
+        int added = reply["added"]?.GetValue<int>() ?? 0;
+        int total = reply["total"]?.GetValue<int>() ?? 0;
+        string message = reply["message"]?.GetValue<string>() ?? "";
+        string gained = added switch { 0 => $"{total} plugins in the catalogue, nothing new.", 1 => "1 plugin new in the catalogue.", _ => $"{added} plugins new in the catalogue." };
+        return message.Length == 0 ? gained : $"{message} {gained}";
+    }
+
+    private static string Summarise(List<string> lines, int added)
+    {
+        string text = string.Join(" ", lines.Where(l => l.Length > 0));
+        if (added > 0) text += added == 1 ? " 1 plugin new in the picker." : $" {added} plugins new in the picker.";
+        return text.Trim();
+    }
+
+    private static void Reload() => Dispatcher.UIThread.Post(() => InsertsViewModel.ReloadAll?.Invoke());
+}

--- a/src/OpenXLR.UI/PluginPickerWindow.axaml
+++ b/src/OpenXLR.UI/PluginPickerWindow.axaml
@@ -28,10 +28,20 @@
                     IsCheckedChanged="OnFormatToggled" ToolTip.Tip="Show VST3 plugins"/>
     </Grid>
     <TextBlock DockPanel.Dock="Top" Text="{Binding Note}" Classes="h" FontSize="11" Margin="0,0,0,6"/>
-    <Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,Auto,Auto" Margin="0,10,0,0">
-      <Button Grid.Column="1" Name="AddButton" Content="Add" Padding="18,6" Margin="0,0,8,0" IsEnabled="False" Click="OnAdd"/>
-      <Button Grid.Column="2" Content="Cancel" Padding="18,6" Click="OnCancel"/>
-    </Grid>
+    <!-- installing: a file (.clap, .vst3, a Windows plugin) or a folder (a .vst3
+         or .lv2 bundle, or a folder of plugins); the daemon puts it in place -->
+    <StackPanel DockPanel.Dock="Bottom" Spacing="8" Margin="0,10,0,0">
+      <TextBlock Name="InstallStatus" Classes="h" FontSize="11" TextWrapping="Wrap"
+                 IsVisible="{Binding #InstallStatus.Text, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+      <Grid ColumnDefinitions="Auto,6,Auto,*,Auto,8,Auto">
+        <Button Name="InstallFile" Content="Install file…" Padding="12,6" Click="OnInstallFile"
+                ToolTip.Tip="Install a .clap or .vst3 file, or a Windows plugin through yabridge"/>
+        <Button Grid.Column="2" Name="InstallFolder" Content="Install folder…" Padding="12,6" Click="OnInstallFolder"
+                ToolTip.Tip="Install a .vst3 or .lv2 bundle, or every plugin in a folder"/>
+        <Button Grid.Column="4" Name="AddButton" Content="Add" Padding="18,6" IsEnabled="False" Click="OnAdd"/>
+        <Button Grid.Column="6" Content="Cancel" Padding="18,6" Click="OnCancel"/>
+      </Grid>
+    </StackPanel>
     <ListBox Name="List" Background="#1d2027" CornerRadius="8" Padding="4"
              SelectionChanged="OnSelectionChanged" DoubleTapped="OnDoubleTapped">
       <ListBox.ItemTemplate>

--- a/src/OpenXLR.UI/PluginPickerWindow.axaml.cs
+++ b/src/OpenXLR.UI/PluginPickerWindow.axaml.cs
@@ -77,4 +77,20 @@ public partial class PluginPickerWindow : Window
     }
 
     private void OnCancel(object? sender, RoutedEventArgs e) => Close(null);
+
+    private async void OnInstallFile(object? sender, RoutedEventArgs e)
+        => await InstallAsync(await PluginInstall.PickFilesAsync(this));
+
+    private async void OnInstallFolder(object? sender, RoutedEventArgs e)
+        => await InstallAsync(await PluginInstall.PickFolderAsync(this));
+
+    private async System.Threading.Tasks.Task InstallAsync(IReadOnlyList<string> paths)
+    {
+        if (paths.Count == 0 || DataContext is not InsertsViewModel vm) return;
+        InstallFile.IsEnabled = InstallFolder.IsEnabled = false;
+        InstallStatus.Text = "Installing…";
+        try { InstallStatus.Text = await PluginInstall.InstallAsync(vm.Client, paths); }
+        catch (Exception ex) { InstallStatus.Text = ex.Message; }
+        finally { InstallFile.IsEnabled = InstallFolder.IsEnabled = true; }
+    }
 }

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -59,6 +59,12 @@ public sealed class MainViewModel : ViewModelBase
         });
         _client.ErrorReceived += msg => Dispatcher.UIThread.Post(() => Status = msg);
         _client.MetersReceived += levels => Dispatcher.UIThread.Post(() => ApplyMeters(levels));
+        InsertsViewModel.ReloadAll = () =>
+        {
+            InsertsViewModel.ForgetCatalogue();
+            Inserts.Refetch(); Inserts2.Refetch();
+            foreach (MixViewModel mv in Mixes) mv.Inserts.Refetch();
+        };
     }
 
     // --- connection / device identity ---


### PR DESCRIPTION
Installing a plugin no longer means knowing where each format keeps its bundles. "Install file…" and "Install folder…" appear in the plugin picker and in a new Options card: pick a `.clap` or `.vst3` file, a `.vst3` or `.lv2` folder, or a folder holding several, and the daemon puts it where it looks. A Windows VST3 or CLAP plugin has its folder added to yabridge and synced, so it arrives as an ordinary bundle.

What cannot be installed is answered in a sentence that says what to do instead: extract the archive, run the installer with Wine first, or that VST2 is not a format OpenXLR loads.

After each install the daemon reads its catalogues again and says how many plugins it gained, and every open chain fetches the list, so the plugin is in the picker a moment later. The Options card names the directories, says whether yabridge and Wine are installed and how many folders they bridge, and carries a rescan for plugins installed by other means.

## Protocol

`getPluginSetup`, `installPlugin`, `syncWindowsPlugins` and `rescanPlugins`, answered with `pluginSetup` and `pluginInstall` messages. Documented in `docs/api.md`.

## Three fixes this rested on

- **A bundle's description is read as a stream.** The largest installed set describes two hundred plugins in seven megabytes. Parsing that into a tree exhausted the daemon's bounded heap, the scan was abandoned, and the whole VST3 list vanished, which is why that list came and went between starts. On this desk the catalogue is now the same on every read.
- **Messages go out as the bytes that go on the wire.** Building a six megabyte catalogue as a string first held it twice over, and that second copy is what ran the heap out while sending it.
- **The size a plugin takes is measured, not guessed.** The old estimate ran a fifth under the truth, so the budget that keeps a message inside what a client will read did not hold. The catalogue is also dropped and the heap swept before a rescan builds the next one, and freed native memory is given back, so rescanning is not a way to grow the daemon.

## Verified on the desk

- Installing a CLAP file, a folder of plugins, and the refusals for an archive, an installer, a missing path and a Windows plugin without yabridge.
- Ten rescans in a row with a full catalogue fetch each time: same 346 plugins every time, memory settling at 350 MB instead of climbing past a gigabyte into a crash.
- The catalogue message is 7.2 MB against the 8 MiB a client reads.
- The Options card live, including a rescan reporting "346 plugins in the catalogue, nothing new."

288 tests pass, 17 of them new.