### PR TITLE
Manual: the Wine and yabridge setup, per distribution

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -133,7 +133,8 @@ code itself: the host describes each bundle in a process of its own, so a
 plugin that misbehaves while being asked about its ports costs that
 bundle and nothing else, and what it learns is kept until the bundle
 changes. Windows VST3 plugins come through yabridge, which presents them
-as ordinary bundles under `~/.vst3`. VST2 plugins are not supported.
+as ordinary bundles under `~/.vst3`; the manual has the Wine and yabridge
+setup for each distribution. VST2 plugins are not supported.
 
 Installing a plugin is a pick in the picker or in Options: a file or a
 folder the user downloaded. The daemon works out what it is from its

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -228,14 +228,65 @@ other means, or copied into `/usr/lib/clap`, `/usr/lib/vst3` or
 restart (`LV2_PATH`, `CLAP_PATH` and `VST3_PATH` override the places
 searched).
 
-Windows VST3 and CLAP plugins run through
+<a name="windows-plugins"></a>
+**Windows VST3 and CLAP plugins.** They run through
 [yabridge](https://github.com/robbert-vdh/yabridge), which wraps each one
-in a bundle that OpenXLR loads like any other. Install `yabridge` and
-`wine` from your distribution (Arch has both; Fedora has yabridge in the
-`patrickl/yabridge` Copr; on Debian and Ubuntu, unpack the release
-archive from its GitHub page into `~/.local/share/yabridge` and put
-`yabridgectl` on your PATH). Then run the plugin's Windows installer with
-Wine:
+in a bundle that OpenXLR loads like any other. Two things have to be
+installed first: Wine, which runs the plugin, and yabridge, which bridges
+it. The Options window says which of the two it can see.
+
+Arch, and anything built on it such as Manjaro, EndeavourOS and CachyOS,
+has both in its own repositories:
+
+```sh
+sudo pacman -S wine yabridge yabridgectl
+```
+
+NixOS has both as well. Add `wine`, `yabridge` and `yabridgectl` to your
+packages, or try them first with:
+
+```sh
+nix shell nixpkgs#wine nixpkgs#yabridge nixpkgs#yabridgectl
+```
+
+Fedora has Wine but not yabridge; the community repositories that carried
+it have gone stale. Install Wine from Fedora and yabridge from its own
+release:
+
+```sh
+sudo dnf install wine
+```
+
+Debian, Ubuntu, Linux Mint and Pop!_OS also need yabridge from its own
+release. Their own `wine` package works; yabridge's author recommends
+Wine Staging from the [WineHQ repositories](https://wiki.winehq.org/Download)
+if a plugin misbehaves:
+
+```sh
+sudo apt install wine
+```
+
+On those, and on any distribution without a package, take the tarball
+from yabridge's [releases page](https://github.com/robbert-vdh/yabridge/releases)
+and unpack it into `~/.local/share`, which is where its own instructions
+put it. With 5.1.1, the current release:
+
+```sh
+tar -C ~/.local/share -xavf ~/Downloads/yabridge-5.1.1.tar.gz
+```
+
+OpenXLR looks there, so nothing else is needed for it: close the Options
+window and open it again, and the card will say that yabridge is
+installed. To run `yabridgectl` yourself as well, add its directory to
+your PATH:
+
+```sh
+echo 'export PATH="$PATH:$HOME/.local/share/yabridge"' >> ~/.bashrc
+```
+
+With fish, `fish_add_path ~/.local/share/yabridge` does the same.
+
+With both in place, run the plugin's Windows installer with Wine:
 
 ```sh
 wine ~/Downloads/PluginSetup.exe
@@ -248,6 +299,10 @@ Options window says how many folders are bridged; "Sync Windows plugins"
 bridges again after another installer has run. A plugin that comes as a
 bare Windows `.vst3` or `.clap` file works the same way when picked as a
 file. VST2 `.dll` files are left out, since OpenXLR cannot load VST2.
+
+Wine keeps its Windows drive in `~/.wine` unless `WINEPREFIX` says
+otherwise, and a plugin installed into another prefix works the same way:
+point "Install folder…" at wherever the installer put its VST3 folder.
 
 The picker marks each plugin with its format, since the same plugin often
 ships in more than one, and its LV2, CLAP and VST3 buttons narrow the list

--- a/src/OpenXLR.Core/Mixing/PluginInstaller.cs
+++ b/src/OpenXLR.Core/Mixing/PluginInstaller.cs
@@ -73,13 +73,21 @@ public sealed class PluginInstaller
     private static string HomeDirectory(string name)
         => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), name);
 
-    /// <summary>A tool on PATH, or under ~/.local/bin where a tarball install puts it.</summary>
+    /// <summary>
+    /// A tool on PATH, or where a user installs one by hand. The daemon is a
+    /// user service and its PATH is systemd's, not the one a login shell
+    /// builds, so the places a tarball install puts a tool are looked in
+    /// whether or not the user added them to a shell profile: yabridge's own
+    /// instructions unpack it into ~/.local/share/yabridge.
+    /// </summary>
     internal static string? OnPath(string name)
     {
         var directories = new List<string>();
         string? path = Environment.GetEnvironmentVariable("PATH");
         if (!string.IsNullOrEmpty(path)) directories.AddRange(path.Split(':', StringSplitOptions.RemoveEmptyEntries));
         directories.Add(HomeDirectory(Path.Combine(".local", "bin")));
+        directories.Add(HomeDirectory(Path.Combine(".local", "share", "yabridge")));
+        directories.Add("/usr/local/bin");
         foreach (string directory in directories)
         {
             string candidate = Path.Combine(directory, name);

--- a/src/OpenXLR.Tests/PluginInstallerTests.cs
+++ b/src/OpenXLR.Tests/PluginInstallerTests.cs
@@ -265,6 +265,25 @@ public sealed class PluginInstallerTests : IDisposable
     }
 
     [Fact]
+    public void AToolIsFoundWhereItIsInstalledByHand()
+    {
+        // The daemon is a user service: its PATH is systemd's, not a login
+        // shell's, so a tarball install has to be found without one.
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string tarball = Path.Combine(home, ".local", "share", "yabridge");
+        string name = "openxlr-test-tool-" + Guid.NewGuid().ToString("N");
+        Assert.Null(PluginInstaller.OnPath(name));
+        Directory.CreateDirectory(tarball);
+        string tool = Path.Combine(tarball, name);
+        try
+        {
+            File.WriteAllText(tool, "#!/bin/sh\n");
+            Assert.Equal(tool, PluginInstaller.OnPath(name));
+        }
+        finally { File.Delete(tool); }
+    }
+
+    [Fact]
     public void TheSetupNamesTheDirectoriesAndWhatIsMissing()
     {
         PluginSetup setup = Installer().Setup();

--- a/src/OpenXLR.UI/PluginInstall.cs
+++ b/src/OpenXLR.UI/PluginInstall.cs
@@ -20,7 +20,12 @@ public static class PluginInstall
     /// <summary>A bundle of two hundred plugins takes a quarter of a minute to describe; yabridge's sync is quick.</summary>
     private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(4);
 
-    public const string Manual = "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#install-plugins";
+    /// <summary>
+    /// The manual on Windows plugins: the button sits beside the yabridge
+    /// row, and that is the part of installing a plugin that needs reading.
+    /// Installing plugins in general is the paragraph above it.
+    /// </summary>
+    public const string Manual = "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#windows-plugins";
 
     /// <summary>Let the user pick plugin files: .clap, a single-file .vst3, or a Windows plugin.</summary>
     public static async Task<IReadOnlyList<string>> PickFilesAsync(Window owner)


### PR DESCRIPTION
The Options card says when yabridge or Wine is missing, but not how to install either, and the manual named a Fedora Copr that no longer exists. The manual's Windows plugin part now carries the commands for each distribution, under a `windows-plugins` anchor the Options card links to.

- **Arch and what is built on it** (Manjaro, EndeavourOS, CachyOS): `wine`, `yabridge` and `yabridgectl` are all in the repositories.
- **NixOS**: all three are in nixpkgs, with a `nix shell` line to try them first.
- **Fedora**: Wine from the repositories, yabridge from its own release. The community Coprs that carried it are gone; `patrickl/yabridge` and `patrickl/yabridge-stable` no longer exist, and the ones that remain last built for Fedora 40 and failed.
- **Debian, Ubuntu, Mint, Pop!_OS**: their own `wine`, with Wine Staging from WineHQ noted as the author's recommendation, and yabridge from its own release.
- **Anything else**: the tarball into `~/.local/share`.

## A tarball install is now actually found

The daemon is a systemd user service, so its PATH is systemd's, not the one a login shell builds from a profile. A `yabridgectl` unpacked into `~/.local/share/yabridge`, which is what yabridge's own instructions say to do, was invisible to it no matter what the user added to `.bashrc`, which would have made the Fedora and Debian instructions useless. That directory and `/usr/local/bin` are now looked in alongside PATH and `~/.local/bin`.

Verified on this desk with a stand-in `yabridgectl` in the tarball location: the daemon reported it as installed with its version, added a Windows plugin's folder, ran the sync, and listed the folder as bridged. 289 tests pass.