### PR TITLE
Manual: say when the PATH line applies, and when it does not

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -275,16 +275,28 @@ put it. With 5.1.1, the current release:
 tar -C ~/.local/share -xavf ~/Downloads/yabridge-5.1.1.tar.gz
 ```
 
-OpenXLR looks there, so nothing else is needed for it: close the Options
-window and open it again, and the card will say that yabridge is
-installed. To run `yabridgectl` yourself as well, add its directory to
-your PATH:
+That leaves `~/.local/share/yabridge/yabridgectl`, which is where OpenXLR
+looks, so nothing else is needed for it: close the Options window and open
+it again, and the card will say that yabridge is installed.
+
+Putting that directory on your PATH is worth it only to run `yabridgectl`
+yourself, and only after the tarball is unpacked: fish refuses a path that
+is not there, and a PATH entry pointing at nothing does no good either
+way. With fish:
+
+```sh
+fish_add_path ~/.local/share/yabridge
+```
+
+With bash, and a new terminal afterwards:
 
 ```sh
 echo 'export PATH="$PATH:$HOME/.local/share/yabridge"' >> ~/.bashrc
 ```
 
-With fish, `fish_add_path ~/.local/share/yabridge` does the same.
+Run neither on Arch or NixOS: their packages put `yabridgectl` where every
+shell already looks, and `fish_add_path` answers "Skipping non-existent
+path" because nothing was unpacked there.
 
 With both in place, run the plugin's Windows installer with Wine:
 


### PR DESCRIPTION
The fish line sat under the tarball instructions with nothing marking it as part of them, so running it on a machine with a distribution package answers:

```
Skipping non-existent path: /home/…/.local/share/yabridge
No paths to add, not setting anything.
```

The paragraph now says the step belongs to a tarball install, comes after unpacking, and is not for Arch or NixOS, whose packages put `yabridgectl` where every shell already looks. fish goes first, since fish is the shell that refuses a path that is not there, and each shell gets its own line.

Also names the file the tarball leaves behind, `~/.local/share/yabridge/yabridgectl`, which is the path OpenXLR looks for. Confirmed against the 5.1.1 release: the archive has a single `yabridge/` directory with `yabridgectl` in it, so `tar -C ~/.local/share` puts it exactly there.