### PR TITLE
Inserts: plugin editors, and what Wine does to bridged ones

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -145,7 +145,10 @@ help: an archive to extract, a Windows installer to run with Wine first,
 a VST2 file. The catalogues are read again afterwards, and every open
 chain fetches the list, so the plugin is in the picker a moment later.
 The Options window says where plugins go, whether yabridge and Wine are
-installed and how many folders they bridge. It offers the plugin folders
+installed and how many folders they bridge, and it names the pair of
+versions, yabridge up to 5.1.1 with Wine 9.22 or newer, that leaves a
+bridged plugin's own editor deaf to the mouse, since the plugin is still
+worth using through the controls OpenXLR builds for it. It offers the plugin folders
 found in Wine's own drive, which file dialogs hide, so the first Windows
 plugin is one press rather than a hunt; the ones after it, installed into
 a folder already bridged, take the sync beside it.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -336,6 +336,29 @@ picked straight out of Downloads would hand yabridge your whole Downloads
 folder. VST2 `.dll` files are left out either way, since OpenXLR cannot
 load VST2.
 
+<a name="windows-editor-input"></a>
+**A Windows plugin's own editor ignores the mouse.** The plugin plays, its
+interface is drawn and it follows anything you change from OpenXLR, but
+clicking its knobs does nothing, wherever you click. This is a known fault
+in yabridge with Wine 9.22 and newer, not something OpenXLR can fix.
+
+Wine changed how it tracks where a window is in 9.22. A plugin editor is
+embedded in a window belonging to its host, and Wine never learns where
+that window really is, so it keeps believing the window sits in the very
+corner of the screen. Every click arrives offset by the distance between
+those two positions, which for a window anywhere else on a desktop lands
+far outside the plugin, and Wine drops it before the plugin sees it. The
+Options window says so when it sees a pair of versions with the fault:
+yabridge up to 5.1.1 with Wine 9.22 or newer. yabridge tracks the fix in
+[issue 409](https://github.com/robbert-vdh/yabridge/issues/409).
+
+Meanwhile the plugin is still usable: Controls in the insert row opens a
+window OpenXLR builds from the plugin's own parameters, and those work,
+bridged or not. To get the plugin's own editor back, either build yabridge
+from its `new-wine10-embedding` branch, which carries the fix and which
+people on Wine 11 report working, or install Wine 9.21, the last version
+yabridge 5.1.1 was built against.
+
 <a name="memlock"></a>
 **"Low memory locking limit".** yabridge prints this when it starts, in
 the daemon's log:
@@ -547,17 +570,22 @@ this way: its row shows no switch, and the cog opens its editor whenever
 the plugin is running.
 
 The editor draws on an X11 display, which means XWayland on a Wayland
-desktop, and the daemon has to know about it. A user service that started
-before the desktop published its display does not, and the fix is one
-import and a restart, from a terminal inside the graphical session:
+desktop, and the daemon has to know about it. A user service started
+before the desktop published its display has none of its own, so OpenXLR
+asks systemd's user manager, where the session puts it, whenever it starts
+a plugin. That covers a daemon that came up early and one left running
+across a logout.
+
+If an editor still answers "no X display", the session never handed its
+display over. Give it to the manager yourself, from a terminal inside the
+graphical session, and restart the daemon:
 
 ```sh
 systemctl --user import-environment DISPLAY XAUTHORITY
 systemctl --user restart openxlr-daemon.service
 ```
 
-The restart interrupts audio briefly. Repeat it after a graphical login
-that assigns a new display.
+The restart interrupts audio briefly.
 
 Trouble with an editor never costs you the sound. If the X server goes
 away while an editor is open, the editor closes and the plugin keeps

--- a/native/README.md
+++ b/native/README.md
@@ -58,10 +58,13 @@ The whole point is that an editor cannot cost you the microphone.
 ## Session environment
 
 The editor needs an X11 display, so XWayland on a Wayland desktop. The helper
-inherits the daemon's environment and does not go looking for a session. A
-user service that started before the desktop published its display has none,
-which shows up as an editor that will not open. From a terminal inside the
-graphical session:
+inherits the environment the daemon starts it with. A daemon with no `DISPLAY`
+of its own, one started before the desktop published it or left running across
+a logout, asks systemd's user manager for the session's display and passes
+that on, so an editor usually opens without anyone doing anything.
+
+Where even the manager has no display, an editor answers "no X display" and
+the session has to hand it over. From a terminal inside the graphical session:
 
 ```sh
 systemctl --user import-environment DISPLAY XAUTHORITY

--- a/native/clap.c
+++ b/native/clap.c
@@ -642,6 +642,7 @@ const Backend clap_backend = {
     .editor_close = clap_editor_close,
     .editor_idle = clap_editor_idle,
     .editor_lost = clap_editor_lost,
+    .editor_focus = NULL,   // CLAP has no call for it
     .editor_resized = NULL,
     .main_thread = clap_main_thread,
     .unload = clap_unload,

--- a/native/host.c
+++ b/native/host.c
@@ -98,8 +98,11 @@ void host_resize_editor(Host *h, unsigned width, unsigned height) {
   if (!h->display || !h->window || width < 1 || height < 1 ||
       width > 16384 || height > 16384)
     return;
+  h->asked_width = width;
+  h->asked_height = height;
   if (x_escape_armed) {
     XResizeWindow(h->display, h->window, width, height);
+    if (h->child) XResizeWindow(h->display, h->child, width, height);
     return;
   }
   if (sigsetjmp(x_escape, 0)) {
@@ -109,6 +112,7 @@ void host_resize_editor(Host *h, unsigned width, unsigned height) {
   }
   x_escape_armed = 1;
   XResizeWindow(h->display, h->window, width, height);
+  if (h->child) XResizeWindow(h->display, h->child, width, height);
   XFlush(h->display);
   x_escape_armed = 0;
 }
@@ -335,7 +339,7 @@ static bool open_ui(Host *h) {
     h->close_message = XInternAtom(h->display, "WM_DELETE_WINDOW", False);
     XSetWMProtocols(h->display, h->window, &h->close_message, 1);
     XSelectInput(h->display, h->window,
-                 StructureNotifyMask | SubstructureNotifyMask);
+                 StructureNotifyMask | SubstructureNotifyMask | FocusChangeMask);
     h->editor_open = h->backend->editor_open(h);
     if (h->editor_open) {
       fit_to_child(h);  // before mapping, so the frame never opens wrong
@@ -367,6 +371,11 @@ static void pump_editor(Host *h) {
       close_ui(h);
       return;
     }
+    // Whether the frame holds the keyboard focus. The plugin is told, since
+    // one running under Wine will not take the mouse until it knows.
+    if ((event.type == FocusIn || event.type == FocusOut) &&
+        event.xfocus.window == h->window && h->backend->editor_focus)
+      h->backend->editor_focus(h, event.type == FocusIn);
     // A plugin that builds its window after the editor opens is found when
     // that window appears.
     if (!h->child && (event.type == MapNotify || event.type == CreateNotify))
@@ -387,7 +396,13 @@ static void pump_editor(Host *h) {
                (attributes.width != c->width || attributes.height != c->height)) {
         XResizeWindow(h->display, h->child, (unsigned)c->width,
                       (unsigned)c->height);
-        if (h->backend->editor_resized && c->width > 0 && c->height > 0)
+        // Only a resize the user made is news. Answering the plugin's own
+        // request with the size it asked for sets the two of them chasing
+        // each other, a few pixels at a time, until the window fills the
+        // screen and its controls are nowhere near where they are drawn.
+        bool asked = (unsigned)c->width == h->asked_width &&
+                     (unsigned)c->height == h->asked_height;
+        if (!asked && h->backend->editor_resized && c->width > 0 && c->height > 0)
           h->backend->editor_resized(h, (unsigned)c->width, (unsigned)c->height);
       }
     }
@@ -416,10 +431,15 @@ static bool set_control(Host *h, const char *symbol, float value) {
 static void command(Host *h, char *line) {
   char symbol[MAX_SYMBOL + 1], extra;
   float value;
-  if (!strcmp(line, "show"))
-    puts(open_ui(h) ? "ui opened"
-                    : "ui unavailable: the plugin has no editor this host can "
-                      "show, or the display could not be opened");
+  if (!strcmp(line, "show")) {
+    // Two different disappointments, and the user can act on only one.
+    if (!h->has_editor)
+      puts("ui unavailable: this plugin has no editor the host can show");
+    else
+      puts(open_ui(h) ? "ui opened"
+                      : "ui unavailable: no X display; the daemon has none "
+                        "from your desktop session");
+  }
   else if (!strcmp(line, "hide"))
     close_ui(h);
   else if (!strcmp(line, "quit"))

--- a/native/host.h
+++ b/native/host.h
@@ -48,6 +48,10 @@ typedef struct {
   void (*editor_close)(Host *h);
   bool (*editor_idle)(Host *h);  // true when the editor asked to close
   void (*editor_lost)(Host *h);  // the display is gone: forget, touch nothing
+  // The frame gained or lost the keyboard focus. A plugin that runs under
+  // Wine treats its window as inactive until it is told, and an inactive
+  // window ignores the mouse.
+  void (*editor_focus)(Host *h, bool focused);
   // The user resized the frame; the plugin may want to lay out again.
   void (*editor_resized)(Host *h, unsigned width, unsigned height);
   // Each tick, outside the guard: whatever the plugin asked for meanwhile.
@@ -95,6 +99,10 @@ struct Host {
   Window window, child;
   Atom close_message;
   bool editor_open;
+  // The size the plugin last asked the frame to be. A frame that reaches it
+  // is not news to the plugin, and telling it anyway starts the two of them
+  // resizing each other a few pixels at a time.
+  unsigned asked_width, asked_height;
   // The command pipe
   char input[16384];
   size_t input_size;

--- a/native/lv2.c
+++ b/native/lv2.c
@@ -593,6 +593,7 @@ const Backend lv2_backend = {
     .editor_close = lv2_editor_close,
     .editor_idle = lv2_editor_idle,
     .editor_lost = lv2_editor_lost,
+    .editor_focus = NULL,   // an LV2 UI is not told; X gives it the mouse itself
     .editor_resized = NULL,
     .main_thread = NULL,
     .unload = lv2_unload,

--- a/native/vst3.cpp
+++ b/native/vst3.cpp
@@ -1166,6 +1166,12 @@ bool vst3_editor_open(Host *h) {
   return true;
 }
 
+void vst3_editor_focus(Host *h, bool focused) {
+  Vst3 *v = of(h);
+  if (v->view)
+    v->view->onFocus(focused);
+}
+
 void vst3_editor_close(Host *h) {
   Vst3 *v = of(h);
   if (!v->view)
@@ -1205,6 +1211,7 @@ extern "C" const Backend vst3_backend = {
     vst3_editor_close,
     vst3_editor_idle,
     vst3_editor_lost,
+    vst3_editor_focus,
     vst3_editor_resized,
     vst3_main_thread,
     vst3_unload,

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -50,6 +50,48 @@ internal sealed class NativePluginHost : IDisposable
     public IReadOnlyDictionary<string, double> Meters => new Dictionary<string, double>(_meters);
     public static string Executable => Path.Combine(AppContext.BaseDirectory, "openxlr-lv2-host");
 
+    /// <summary>
+    /// The desktop's display, for a daemon that has none of its own. A user
+    /// service that started before the session, or one left running across a
+    /// logout, has no DISPLAY, and a plugin's editor cannot open without one.
+    /// The session hands its display to systemd's user manager when it
+    /// starts, so that is where it is asked for.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> SessionDisplay()
+    {
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY")))
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        string? environment = null;
+        try
+        {
+            ProcessResult result = ProcessRunner.Run("systemctl", ["--user", "show-environment"], TimeSpan.FromSeconds(3));
+            if (result.ExitCode == 0) environment = System.Text.Encoding.UTF8.GetString(result.Stdout);
+        }
+        catch (Exception) { /* no systemd, or none of it running: nothing to learn */ }
+        return DisplayIn(environment);
+    }
+
+    /// <summary>
+    /// DISPLAY and the cookie file beside it, out of what a manager reports.
+    /// A cookie without a display is no use, so neither is passed on.
+    /// </summary>
+    internal static Dictionary<string, string> DisplayIn(string? environment)
+    {
+        var found = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string line in (environment ?? "").Split('\n'))
+        {
+            int equals = line.IndexOf('=');
+            if (equals <= 0) continue;
+            string name = line[..equals].Trim();
+            if (name is not ("DISPLAY" or "XAUTHORITY")) continue;
+            string value = line[(equals + 1)..].Trim();
+            if (value.Length > 1 && value[0] == '"' && value[^1] == '"') value = value[1..^1];
+            if (value.Length > 0) found[name] = value;
+        }
+        if (!found.ContainsKey("DISPLAY")) found.Clear();
+        return found;
+    }
+
     /// <summary>Whether the optional helper was built and installed beside the daemon.</summary>
     public static bool HostInstalled => File.Exists(Executable);
     /// <summary>
@@ -99,6 +141,8 @@ internal sealed class NativePluginHost : IDisposable
             start.ArgumentList.Add(argument);
         foreach ((string symbol, double value) in insert.Params)
             start.ArgumentList.Add($"{symbol}={value.ToString("R", CultureInfo.InvariantCulture)}");
+        foreach ((string name, string value) in SessionDisplay())
+            start.Environment[name] = value;
         Process = Process.Start(start) ?? throw new InvalidOperationException("Could not start the native LV2 host.");
         _outputReader = ReadOutputAsync();
         _errorReader = ReadErrorsAsync();

--- a/src/OpenXLR.Core/Mixing/PluginInstaller.cs
+++ b/src/OpenXLR.Core/Mixing/PluginInstaller.cs
@@ -31,7 +31,17 @@ public sealed record PluginSetup(
     string Lv2Directory, string ClapDirectory, string Vst3Directory,
     string? YabridgeVersion, bool Wine,
     IReadOnlyList<string> WindowsDirectories,
-    IReadOnlyList<string> WineFolders);
+    IReadOnlyList<string> WineFolders)
+{
+    /// <summary>Wine's version as it reports it, or null when Wine is not installed.</summary>
+    public string? WineVersion { get; init; }
+
+    /// <summary>
+    /// What a user should know before opening a bridged plugin's own editor
+    /// with this pair of versions, or null when there is nothing to say.
+    /// </summary>
+    public string? WindowsEditorNote { get; init; }
+}
 
 /// <summary>
 /// How an install went, in words the user can read. The destinations are
@@ -404,6 +414,39 @@ public sealed class PluginInstaller
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return []; }
     }
 
+    /// <summary>
+    /// Whether a bridged plugin's own editor will ignore the mouse. Since
+    /// Wine 9.22 the position a plugin's window believes it has and the one
+    /// it actually has are not the same, and every click arrives offset by
+    /// the distance between them, which for a window anywhere but the very
+    /// corner of the screen is far outside the plugin. yabridge has a fix in
+    /// progress; released yabridge, up to 5.1.1, does not carry it.
+    /// </summary>
+    internal static bool EditorsIgnoreTheMouse(string? yabridgeVersion, string? wineVersion)
+        => yabridgeVersion is not null   // nothing is bridged without it
+           && AtLeast(wineVersion, 9, 22) && !AtLeast(yabridgeVersion, 5, 2);
+
+    /// <summary>A version string such as "wine-11.17" or "5.1.1" against a floor.</summary>
+    internal static bool AtLeast(string? version, int major, int minor)
+    {
+        if (version is null) return false;
+        var digits = new List<int>();
+        int index = 0;
+        while (index < version.Length && digits.Count < 2)
+        {
+            if (!char.IsAsciiDigit(version[index])) { index++; continue; }
+            int start = index;
+            while (index < version.Length && char.IsAsciiDigit(version[index])) index++;
+            digits.Add(int.Parse(version.AsSpan(start, index - start)));
+            // Only a run of digits separated by a dot is the rest of a version.
+            if (index >= version.Length || version[index] != '.') break;
+            index++;
+        }
+        if (digits.Count == 0) return false;
+        if (digits[0] != major) return digits[0] > major;
+        return digits.Count > 1 && digits[1] >= minor;
+    }
+
     /// <summary>What is there: the directories, the host, yabridge and Wine.</summary>
     public PluginSetup Setup()
     {
@@ -419,6 +462,16 @@ public sealed class PluginInstaller
             }
             else version = "installed";
         }
+        string? wineVersion = null;
+        if (_wine is not null)
+        {
+            try
+            {
+                ProcessResult result = ProcessRunner.Run(_wine, ["--version"], TimeSpan.FromSeconds(10), cLocale: false);
+                if (result.ExitCode == 0) wineVersion = Encoding.UTF8.GetString(result.Stdout).Trim().Split('\n')[0].Trim();
+            }
+            catch (Exception) { /* Wine that will not say is Wine we know nothing about */ }
+        }
         IReadOnlyList<string> bridged = WindowsDirectories();
         var known = bridged.Select(d => Path.GetFullPath(d).TrimEnd('/')).ToHashSet(StringComparer.Ordinal);
         // Only the ones still to bridge: a folder already handed over needs
@@ -426,7 +479,13 @@ public sealed class PluginInstaller
         IReadOnlyList<string> wine = _wine is null || _yabridgectl is null
             ? []
             : [.. WinePluginFolders().Where(f => !known.Contains(Path.GetFullPath(f).TrimEnd('/')))];
-        return new(_hostInstalled, Shorten(_lv2), Shorten(_clap), Shorten(_vst3), version, _wine is not null, bridged, wine);
+        return new(_hostInstalled, Shorten(_lv2), Shorten(_clap), Shorten(_vst3), version, _wine is not null, bridged, wine)
+        {
+            WineVersion = wineVersion,
+            WindowsEditorNote = EditorsIgnoreTheMouse(version, wineVersion)
+                ? $"A Windows plugin's own editor ignores the mouse with yabridge {version} and {wineVersion}: since Wine 9.22 its clicks arrive somewhere else entirely. The plugin plays, and its controls window here works. The manual has the two ways to fix the editor."
+                : null,
+        };
     }
 
     private ProcessResult? Run(params string[] arguments)

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -98,6 +98,9 @@ public sealed record PluginSetupMessage(PluginSetup Setup)
     [JsonPropertyName("windowsDirectories")] public IReadOnlyList<string> WindowsDirectories => Setup.WindowsDirectories;
     /// <summary>Wine's own plugin folders that hold a plugin and are not bridged yet.</summary>
     [JsonPropertyName("wineFolders")] public IReadOnlyList<string> WineFolders => Setup.WineFolders;
+    [JsonPropertyName("wineVersion")] public string? WineVersion => Setup.WineVersion;
+    /// <summary>What to know before opening a bridged plugin's own editor, or null.</summary>
+    [JsonPropertyName("windowsEditorNote")] public string? WindowsEditorNote => Setup.WindowsEditorNote;
     [JsonIgnore] public PluginSetup Setup { get; } = Setup;
 }
 

--- a/src/OpenXLR.Tests/NativeLv2HostTests.cs
+++ b/src/OpenXLR.Tests/NativeLv2HostTests.cs
@@ -220,4 +220,30 @@ public sealed class NativeLv2HostTests
         Assert.False(insert.NativeHost);
         Assert.Contains("\"nativeHost\":false", JsonSerializer.Serialize(insert.ToPayload()));
     }
+
+    [Fact]
+    public void TheDisplayIsTakenFromWhatTheManagerReports()
+    {
+        // What `systemctl --user show-environment` prints for a session.
+        const string environment = """
+            DISPLAY=:0
+            LANG=en_GB.UTF-8
+            QT_WAYLAND_RECONNECT=1
+            WAYLAND_DISPLAY=wayland-0
+            XAUTHORITY=/run/user/1000/xauth_vNMFGK
+            """;
+        Dictionary<string, string> found = NativePluginHost.DisplayIn(environment);
+        Assert.Equal(":0", found["DISPLAY"]);
+        Assert.Equal("/run/user/1000/xauth_vNMFGK", found["XAUTHORITY"]);
+        Assert.Equal(2, found.Count);   // nothing else travels
+
+        // A quoted value, as systemd writes one that needs escaping.
+        Assert.Equal(":1", NativePluginHost.DisplayIn("DISPLAY=\":1\"")["DISPLAY"]);
+
+        // A cookie on its own says nothing about where to draw.
+        Assert.Empty(NativePluginHost.DisplayIn("XAUTHORITY=/run/user/1000/xauth_a"));
+        Assert.Empty(NativePluginHost.DisplayIn("DISPLAY="));
+        Assert.Empty(NativePluginHost.DisplayIn(null));
+        Assert.Empty(NativePluginHost.DisplayIn("Failed to connect to bus"));
+    }
 }

--- a/src/OpenXLR.Tests/PluginInstallerTests.cs
+++ b/src/OpenXLR.Tests/PluginInstallerTests.cs
@@ -335,6 +335,31 @@ public sealed class PluginInstallerTests : IDisposable
     }
 
     [Fact]
+    public void TheVersionsThatLeaveABridgedEditorDeafAreRecognised()
+    {
+        // Wine 9.22 changed how a plugin window's position is tracked, and
+        // released yabridge does not carry the fix, so every click lands far
+        // from where it was aimed.
+        Assert.True(PluginInstaller.EditorsIgnoreTheMouse("5.1.1", "wine-11.17"));
+        Assert.True(PluginInstaller.EditorsIgnoreTheMouse("5.1.1", "wine-9.22 (Staging)"));
+        Assert.True(PluginInstaller.EditorsIgnoreTheMouse("5.0.4", "wine-10.0"));
+
+        Assert.False(PluginInstaller.EditorsIgnoreTheMouse("5.1.1", "wine-9.21"));
+        Assert.False(PluginInstaller.EditorsIgnoreTheMouse("5.1.1", "wine-8.21"));
+        Assert.False(PluginInstaller.EditorsIgnoreTheMouse("5.2.0", "wine-11.17"));   // the fix, once released
+        Assert.False(PluginInstaller.EditorsIgnoreTheMouse("6.0.0", "wine-11.17"));
+        Assert.False(PluginInstaller.EditorsIgnoreTheMouse(null, "wine-11.17"));      // no yabridge, no bridging
+        Assert.False(PluginInstaller.EditorsIgnoreTheMouse("5.1.1", null));
+
+        // Whatever a version looks like, only its first two numbers count.
+        Assert.True(PluginInstaller.AtLeast("wine-11.17", 9, 22));
+        Assert.True(PluginInstaller.AtLeast("yabridgectl 5.1.1", 5, 1));
+        Assert.False(PluginInstaller.AtLeast("yabridgectl 5.1.1", 5, 2));
+        Assert.False(PluginInstaller.AtLeast("installed", 5, 2));
+        Assert.False(PluginInstaller.AtLeast("", 1, 0));
+    }
+
+    [Fact]
     public void TheSetupNamesTheDirectoriesAndWhatIsMissing()
     {
         PluginSetup setup = Installer().Setup();

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -70,6 +70,12 @@ public sealed class OptionsViewModel : ViewModelBase
     /// <summary>What the button offers, named after what it will bridge.</summary>
     public string BridgeWineLabel { get => _bridgeWineLabel; private set => Set(ref _bridgeWineLabel, value); }
 
+    private string? _windowsEditorNote;
+    /// <summary>What to know before opening a bridged plugin's own editor, or null.</summary>
+    public string? WindowsEditorNote { get => _windowsEditorNote; private set { if (Set(ref _windowsEditorNote, value)) Raise(nameof(HasWindowsEditorNote)); } }
+
+    public bool HasWindowsEditorNote => !string.IsNullOrEmpty(_windowsEditorNote);
+
     private bool _canBridgeWine;
     /// <summary>
     /// Whether Wine holds plugins nobody has bridged yet. The button spares
@@ -99,6 +105,7 @@ public sealed class OptionsViewModel : ViewModelBase
         bool host = setup["hostInstalled"]?.GetValue<bool>() ?? true;
         PluginDirectories = $"Plugins are looked for in {lv2}, {clap} and {vst3} and the system plugin directories."
             + (host ? "" : " The native plugin host is not installed beside the daemon, so CLAP and VST3 plugins cannot run.");
+        WindowsEditorNote = setup["windowsEditorNote"]?.GetValue<string>();
         string? yabridge = setup["yabridge"]?.GetValue<string>();
         bool wine = setup["wine"]?.GetValue<bool>() ?? false;
         int folders = (setup["windowsDirectories"] as System.Text.Json.Nodes.JsonArray)?.Count ?? 0;

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -107,6 +107,10 @@
                   ToolTip.Tip="Read the plugin directories again, for plugins installed by other means"/>
         </StackPanel>
         <TextBlock Text="{Binding WindowsPlugins}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="0,4,0,0"/>
+        <!-- A pair of versions that leaves a bridged plugin's own editor deaf
+             to the mouse. Worth saying before the user spends an evening on it. -->
+        <TextBlock Text="{Binding WindowsEditorNote}" IsVisible="{Binding HasWindowsEditorNote}"
+                   FontSize="11" Foreground="#e0b050" TextWrapping="Wrap"/>
         <!-- Wine keeps its plugins under a dot directory a file dialog hides,
              so what is found there is offered rather than browsed to. -->
         <Button Name="BridgeWine" Content="{Binding BridgeWineLabel}" Padding="14,5" HorizontalAlignment="Left"


### PR DESCRIPTION
Four things, found while chasing a Windows plugin whose editor would not take clicks.

## The cog did nothing after a logout

The daemon passes its own environment to a plugin, and a systemd user service that started before the desktop published its display, or was left running across a logout, has no `DISPLAY` to pass. The plugin played, no editor appeared, and the cure was an import and a restart the user had to know about.

The session hands its display to systemd's user manager, so a daemon without one now asks there. Verified with the daemon's own `DISPLAY` unset through a drop-in: the plugin still received one and its editor opened.

## The frame and the plugin were resizing each other

A plugin asks for a size, the frame takes it, and the frame's own configure notification was answered by telling the plugin the size it had just asked for. With a window manager that adjusts a size by a pixel or two that repeats: on this desk an 820 by 435 editor grew to 1283 by 677 within seconds. A size the plugin asked for is no longer news to it.

## A plugin is told when its frame has the focus

`IPlugView::onFocus`, which is what a VST3 editor expects and what one hosted under Wine waits for. Confirmed reaching the plugin in yabridge's own trace.

## Wine 9.22 broke input to bridged editors, and users should be told

Since Wine 9.22, an embedded plugin window never learns its real position, so every click arrives offset by the window's distance from the corner of the screen and is dropped before the plugin sees it. Released yabridge does not carry the fix. The plugin renders, follows the host and plays audio, and ignores the mouse entirely, wherever you click.

This is [yabridge issue 409](https://github.com/robbert-vdh/yabridge/issues/409), with the root cause spelled out in [pull request 489](https://github.com/robbert-vdh/yabridge/pull/489), and it matches what I measured here: Wine believed its window was at 0,0 while X had it at 4489,3348.

Nothing in OpenXLR can fix it, so it says so instead. The Options card names the pair of versions when it sees one, points out that the plugin is still usable through the controls OpenXLR builds from its parameters, and the manual carries the two ways out under a `windows-editor-input` anchor.

294 tests pass, 2 of them new.