### PR TITLE
UI: the inserts are not LV2 only any more

### DIFF
--- a/src/OpenXLR.UI/FlowWindow.axaml.cs
+++ b/src/OpenXLR.UI/FlowWindow.axaml.cs
@@ -78,7 +78,7 @@ public partial class FlowWindow : Window
 
         // Filter chains in the path. An input chain sits between the jack and
         // its channel: the built-in low cut and ClipGuard (XLR 1 only, when
-        // switched on) followed by the LV2 inserts. A mix chain sits between
+        // switched on) followed by the plugin inserts. A mix chain sits between
         // the mix and everything it feeds. Chains with nothing in them are
         // not drawn, and the columns appear only when a chain exists.
         var inputChains = new List<ChainNode>();

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -94,7 +94,7 @@ public sealed class InsertsViewModel : ViewModelBase
     {
         if (_pluginsRequested) return;
         _pluginsRequested = true;
-        Note = "Scanning LV2 plugins…";
+        Note = "Scanning plugins…";
         JsonNode? plugins = await CatalogAsync(_client);
         Dispatcher.UIThread.Post(() =>
         {
@@ -120,7 +120,7 @@ public sealed class InsertsViewModel : ViewModelBase
             }
             string width = _channels == 1 ? "mono" : "stereo";
             Note = PluginChoices.Count == 0
-                ? $"No {width} plugins found (install e.g. lsp-plugins-lv2 or x42-plugins)"
+                ? $"No {width} plugins found. Install some, or add one with the buttons below"
                 : $"{PluginChoices.Count} {width} plugins available";
         });
     }

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -282,13 +282,13 @@
                      VerticalAlignment="Center" HorizontalAlignment="Right"/>
         </Grid>
 
-        <!-- XLR 1 plugin inserts: LV2 plugins in the mic path, after the
+        <!-- XLR 1 plugin inserts: plugins in the mic path, after the
              software low cut and ClipGuard, heard by every mix. The picker
              and each plugin's controls open in their own windows. -->
         <StackPanel Spacing="4" Margin="0,4,0,0" IsVisible="{Binding HasMixer}">
           <Grid ColumnDefinitions="90,*,Auto">
             <TextBlock Text="Inserts" Classes="h" VerticalAlignment="Center"
-                       ToolTip.Tip="LV2 plugins processing XLR 1 before it reaches the mixes"/>
+                       ToolTip.Tip="Plugins processing XLR 1 before it reaches the mixes"/>
             <TextBlock Grid.Column="1" Text="{Binding Inserts.Summary}" Classes="h" FontSize="11" VerticalAlignment="Center"/>
             <Button Grid.Column="2" Content="Add plugin…" Padding="12,3" FontSize="12" MinHeight="0" Click="OnAddInsert"/>
           </Grid>
@@ -343,7 +343,7 @@
         <StackPanel Spacing="4" Margin="0,4,0,0" IsVisible="{Binding HasMixer}">
           <Grid ColumnDefinitions="90,*,Auto">
             <TextBlock Text="Inserts" Classes="h" VerticalAlignment="Center"
-                       ToolTip.Tip="LV2 plugins processing XLR 2 before it reaches the mixes"/>
+                       ToolTip.Tip="Plugins processing XLR 2 before it reaches the mixes"/>
             <TextBlock Grid.Column="1" Text="{Binding Inserts2.Summary}" Classes="h" FontSize="11" VerticalAlignment="Center"/>
             <Button Grid.Column="2" Content="Add plugin…" Padding="12,3" FontSize="12" MinHeight="0" Tag="xlr2" Click="OnAddInsert"/>
           </Grid>
@@ -563,7 +563,7 @@
                   <ToggleButton Content="Mute mix" Classes="mute" IsChecked="{Binding Muted, Mode=TwoWay}"/>
                   <Button Content="{Binding Inserts.ButtonText}" HorizontalAlignment="Stretch"
                           HorizontalContentAlignment="Center" Padding="8,4" FontSize="12" Click="OnMixInserts"
-                          ToolTip.Tip="Stereo LV2 plugins processing this mix before it reaches its outputs"/>
+                          ToolTip.Tip="Stereo plugins processing this mix before it reaches its outputs"/>
                   <!-- the chain at a glance: LED, name, bypass, controls; adding,
                        ordering and removing live in the chain window -->
                   <ItemsControl ItemsSource="{Binding Inserts.Items}" IsVisible="{Binding Inserts.HasItems}">

--- a/src/OpenXLR.UI/MixInsertsWindow.axaml
+++ b/src/OpenXLR.UI/MixInsertsWindow.axaml
@@ -19,7 +19,7 @@
     <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,10">
       <StackPanel>
         <TextBlock Text="{Binding Title}" FontSize="16" FontWeight="Bold" Foreground="#e6e9f0"/>
-        <TextBlock Text="Stereo LV2 plugins, in order, before this mix reaches its outputs" Classes="h" FontSize="11"/>
+        <TextBlock Text="Stereo plugins, in order, before this mix reaches its outputs" Classes="h" FontSize="11"/>
       </StackPanel>
       <Button Grid.Column="1" Content="Add plugin…" Padding="12,4" VerticalAlignment="Top" Click="OnAddInsert"/>
     </Grid>


### PR DESCRIPTION
The mix inserts window still says "Stereo LV2 plugins, in order, before this mix reaches its outputs", and the strip tooltips say the same. That was true when LV2 was the only format an insert could hold. Inserts now take LV2, CLAP and VST3, and the picker badges each plugin with its own format, so naming one format in the text around it is wrong wherever it appears.

Changed in four places: the mix inserts window's line, the two XLR strip tooltips, and the mix strip tooltip.

The picker's line for an empty catalogue also named two LV2 packages to install. It points at the install buttons underneath it instead, which is now the shorter way to get a plugin.

Wording only, no behaviour. 294 tests pass.