### PR TITLE
Inserts: improve VST3 editor resizing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            g++ libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev
+            g++ libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev xvfb xauth
           make -C native
           test -x native/openxlr-lv2-host
+          xvfb-run -a make -C native test-editor
 
       - name: Lint shell scripts
         run: shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ src/*/bin/
 src/*/obj/
 native/openxlr-lv2-host
 native/*.o
+native/tests/*.o
+native/tests/editor
 # nix build output symlink
 result
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -569,6 +569,11 @@ A CLAP or VST3 plugin has no shared chain to go back to, so it always runs
 this way: its row shows no switch, and the cog opens its editor whenever
 the plugin is running.
 
+Dragging a VST3 editor's border follows the sizes the plugin supports, so
+an editor with size increments may move in steps. The plugin draws its own
+contents; a Windows editor running through Wine can still briefly expose
+an unpainted edge while it redraws during a drag.
+
 The editor draws on an X11 display, which means XWayland on a Wayland
 desktop, and the daemon has to know about it. A user service started
 before the desktop published its display has none of its own, so OpenXLR

--- a/native/Makefile
+++ b/native/Makefile
@@ -22,6 +22,15 @@ openxlr-lv2-host: $(OBJECTS)
 %.o: %.cpp $(HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
-.PHONY: clean
+tests/editor.o: tests/editor.c host.c $(HEADERS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+tests/editor: tests/editor.o lv2.o clap.o vst3.o
+	$(CXX) $^ -o $@ $(LDFLAGS) $(LDLIBS)
+
+.PHONY: test-editor clean
+test-editor: tests/editor
+	./tests/editor
+
 clean:
-	rm -f openxlr-lv2-host $(OBJECTS)
+	rm -f openxlr-lv2-host $(OBJECTS) tests/editor tests/editor.o

--- a/native/README.md
+++ b/native/README.md
@@ -26,6 +26,14 @@ It needs a C11 compiler, make, pkg-config and the development files for
 PipeWire, lilv, LV2 and X11; the libraries it links are already runtime
 dependencies of every package.
 
+`make -C native test-editor` runs the host's resize regression tests on
+`DISPLAY`, using a small test editor and a separate X connection. On a
+machine without a desktop, run `xvfb-run -a make -C native test-editor`.
+These tests need neither a plugin installation nor a running PipeWire
+server. They cover event delivery without idle polling, coalesced sizes,
+drag reversal, size constraints, the Wine coordinate nudge and display
+cleanup. Real plugin repainting and mouse input still need desktop testing.
+
 ## What it does
 
 - One process per insert, holding one plugin instance and its editor.
@@ -117,6 +125,14 @@ plugin is assumed to have one and the host finds out when asked. The
 interface headers are vendored under `vst3/` (MIT, VST 3.8.1); only their
 inline parts are used, so nothing of the SDK is compiled. Windows VST3
 plugins arrive through yabridge as ordinary bundles.
+
+Editor X events wake the main loop directly; the 30 Hz tick remains for
+idle work and the Wine coordinate workaround. During a frame resize, the
+VST3 backend checks the plugin's size constraints before notifying its
+view, and the embedding window follows after that callback. Consecutive
+duplicate sizes are skipped, but reversing a drag delivers the old size
+again. Plugin resize requests and child-window echoes remain suppressed
+while the user is resizing the frame.
 
 State and presets, and VST2, are separate work. Changing an insert's host
 rebuilds its chain; nothing here swaps a plugin without a gap.

--- a/native/host.c
+++ b/native/host.c
@@ -79,12 +79,22 @@ void host_control_moved_rt(Host *h, Control *c, float value) {
 // gone. What the plugin built inside the window cannot be cleaned up through
 // a dead connection, so it stays until this process exits.
 static void forget_ui(Host *h) {
+  if (h->editor_source) {
+    pw_loop_destroy_source(host_loop(h), h->editor_source);
+    h->editor_source = NULL;
+  }
   if (h->editor_open && h->backend->editor_lost)
     h->backend->editor_lost(h);
   h->editor_open = false;
   h->display = NULL;
   h->window = 0;
   h->child = 0;
+  h->notified_width = h->notified_height = 0;
+  h->self_width = h->self_height = 0;
+  h->child_width = h->child_height = 0;
+  h->settle_ticks = h->settle_width = h->settle_height = 0;
+  h->frame_x = h->frame_y = 0;
+  h->dragged_at = (struct timespec){0};
 }
 
 void host_editor_lost(Host *h) {
@@ -94,7 +104,7 @@ void host_editor_lost(Host *h) {
 
 // A backend's own callbacks (a plugin's timer, say) reach these outside any
 // guard, so each one arms its own unless a caller already has.
-static bool told_lately(Host *h, unsigned width, unsigned height);
+static bool same_editor_size(Host *h, unsigned width, unsigned height);
 static bool dragging(Host *h);
 
 void host_resize_editor(Host *h, unsigned width, unsigned height) {
@@ -262,15 +272,21 @@ static void fit_to_child(Host *h) {
     XSelectInput(h->display, h->child, StructureNotifyMask);
     XWindowAttributes attributes;
     if (XGetWindowAttributes(h->display, h->child, &attributes) &&
-        attributes.width > 0 && attributes.height > 0)
-      XResizeWindow(h->display, h->window, (unsigned)attributes.width,
-                    (unsigned)attributes.height);
+        attributes.width > 0 && attributes.height > 0) {
+      h->self_width = (unsigned)attributes.width;
+      h->self_height = (unsigned)attributes.height;
+      XResizeWindow(h->display, h->window, h->self_width, h->self_height);
+    }
   }
   if (children)
     XFree(children);
 }
 
 static void close_ui(Host *h) {
+  if (h->editor_source) {
+    pw_loop_destroy_source(host_loop(h), h->editor_source);
+    h->editor_source = NULL;
+  }
   if (!h->display) {
     forget_ui(h);
     return;
@@ -303,8 +319,10 @@ static bool raise_ui(Host *h) {
 }
 
 // Open the window and hand it to the backend. Every X call of the editor's
-// life happens here, in raise_ui, in the tick or in a backend's guarded
-// callback.
+// life happens here, in raise_ui, in the event pump or in a backend's guarded
+// callback. Watch the X connection so a drag need not wait for the idle tick.
+static void editor_events(void *data, int fd, uint32_t mask);
+
 static bool open_ui(Host *h) {
   if (h->editor_open)
     return raise_ui(h);
@@ -346,6 +364,9 @@ static bool open_ui(Host *h) {
       fit_to_child(h);  // before mapping, so the frame never opens wrong
       XMapRaised(h->display, h->window);
       XFlush(h->display);
+      h->editor_source = pw_loop_add_io(host_loop(h), ConnectionNumber(h->display),
+                                        SPA_IO_IN | SPA_IO_HUP | SPA_IO_ERR,
+                                        false, editor_events, h);
       h->settle_ticks = 6;   // once it is on screen, teach it where that is
     }
   }
@@ -368,34 +389,18 @@ static bool dragging(Host *h) {
   return since < 400;
 }
 
-// Whether the plugin has been told this size in the last second, which means
-// the two of them are going round rather than the user dragging: a drag
-// passes through a size once, a loop keeps coming back to it. Telling it
-// again is what keeps the loop alive, so this is where it ends.
-static bool told_lately(Host *h, unsigned width, unsigned height) {
-  struct timespec now;
-  clock_gettime(CLOCK_MONOTONIC, &now);
-  bool seen = false;
-  for (unsigned i = 0; i < 8; ++i) {
-    if (h->recent_sizes[i].width != width || h->recent_sizes[i].height != height)
-      continue;
-    long age = (now.tv_sec - h->recent_sizes[i].at.tv_sec) * 1000 +
-               (now.tv_nsec - h->recent_sizes[i].at.tv_nsec) / 1000000;
-    if (age < 1000)
-      seen = true;
-  }
-  if (!seen) {
-    h->recent_sizes[h->recent_next].width = width;
-    h->recent_sizes[h->recent_next].height = height;
-    h->recent_sizes[h->recent_next].at = now;
-    h->recent_next = (h->recent_next + 1) % 8;
-  }
+// X reports moves and echoes as well as new sizes. Only skip the last size:
+// returning to an earlier size is normal when the user reverses a drag.
+static bool same_editor_size(Host *h, unsigned width, unsigned height) {
+  bool seen = h->notified_width == width && h->notified_height == height;
+  h->notified_width = width;
+  h->notified_height = height;
   return seen;
 }
 
 // One pass of the editor: its events and the backend's idle work. Losing
 // the display here costs the editor and nothing else.
-static void pump_editor(Host *h) {
+static void pump_editor(Host *h, bool idle) {
   if (sigsetjmp(x_escape, 0)) {
     x_escape_armed = 0;
     host_editor_lost(h);
@@ -456,22 +461,37 @@ static void pump_editor(Host *h) {
         (plugin_width != h->child_width || plugin_height != h->child_height) &&
         XGetWindowAttributes(h->display, h->window, &attributes) &&
         ((unsigned)attributes.width != plugin_width ||
-         (unsigned)attributes.height != plugin_height))
+         (unsigned)attributes.height != plugin_height)) {
+      h->self_width = plugin_width;
+      h->self_height = plugin_height;
       XResizeWindow(h->display, h->window, plugin_width, plugin_height);
+    }
     if (frame_resized) {
+      bool user_size = frame_width != h->self_width || frame_height != h->self_height;
+      if (user_size)
+        clock_gettime(CLOCK_MONOTONIC, &h->dragged_at);
+      if (user_size && h->backend->editor_constrain) {
+        unsigned width = frame_width, height = frame_height;
+        h->backend->editor_constrain(h, &width, &height);
+        if (width > 0 && height > 0 && width <= 16384 && height <= 16384 &&
+            (width != frame_width || height != frame_height)) {
+          frame_width = h->self_width = width;
+          frame_height = h->self_height = height;
+          XResizeWindow(h->display, h->window, width, height);
+        }
+      }
+      // Let the plugin lay out before enlarging its embedding window, which
+      // otherwise exposes pixels the plugin has not drawn yet.
+      if (h->backend->editor_resized &&
+          !same_editor_size(h, frame_width, frame_height))
+        h->backend->editor_resized(h, frame_width, frame_height);
       if (XGetWindowAttributes(h->display, h->child, &attributes) &&
           ((unsigned)attributes.width != frame_width ||
            (unsigned)attributes.height != frame_height)) {
         XResizeWindow(h->display, h->child, frame_width, frame_height);
-        h->child_width = frame_width;
-        h->child_height = frame_height;
       }
-      // A size the frame did not ask for is the user's doing.
-      if (frame_width != h->self_width || frame_height != h->self_height)
-        clock_gettime(CLOCK_MONOTONIC, &h->dragged_at);
-      if (h->backend->editor_resized &&
-          !told_lately(h, frame_width, frame_height))
-        h->backend->editor_resized(h, frame_width, frame_height);
+      h->child_width = frame_width;
+      h->child_height = frame_height;
     }
   }
   // A window that has just opened or moved has to change size once for a
@@ -480,8 +500,10 @@ static void pump_editor(Host *h) {
   // the screen. A pixel smaller, then back a moment later, teaches it. The
   // two halves are ticks apart so the plugin has laid itself out in between,
   // and it costs a plugin that needed none of this one relayout.
-  if (h->settle_ticks > 0 && --h->settle_ticks == 0) {
+  if (idle && h->settle_ticks > 0 && --h->settle_ticks == 0) {
     if (h->settle_height > 0) {
+      h->self_width = h->settle_width;
+      h->self_height = h->settle_height;
       XResizeWindow(h->display, h->window, h->settle_width, h->settle_height);
       XFlush(h->display);
       h->settle_height = 0;
@@ -491,16 +513,29 @@ static void pump_editor(Host *h) {
           attributes.width > 1 && attributes.height > 1) {
         h->settle_width = (unsigned)attributes.width;
         h->settle_height = (unsigned)attributes.height;
+        h->self_width = h->settle_width;
+        h->self_height = h->settle_height - 1;
         XResizeWindow(h->display, h->window, h->settle_width, h->settle_height - 1);
         XFlush(h->display);
         h->settle_ticks = 4;   // put it back once the plugin has caught up
       }
     }
   }
-  bool finished = h->backend->editor_idle && h->backend->editor_idle(h);
+  bool finished = idle && h->backend->editor_idle && h->backend->editor_idle(h);
+  XFlush(h->display);
   x_escape_armed = 0;
   if (finished)
     close_ui(h);
+}
+
+static void editor_events(void *data, int fd, uint32_t mask) {
+  Host *h = data;
+  if (mask & (SPA_IO_HUP | SPA_IO_ERR)) {
+    host_editor_lost(h);
+    return;
+  }
+  if (h->editor_open)
+    pump_editor(h, false);
 }
 
 // --- the command pipe -------------------------------------------------------
@@ -598,7 +633,7 @@ static void tick(void *data, uint64_t expirations) {
   if (h->backend->main_thread)
     h->backend->main_thread(h);
   if (h->editor_open)
-    pump_editor(h);
+    pump_editor(h, true);
 }
 
 static void stop(void *data, int signal) {

--- a/native/host.h
+++ b/native/host.h
@@ -54,6 +54,8 @@ typedef struct {
   void (*editor_focus)(Host *h, bool focused);
   // The user resized the frame; the plugin may want to lay out again.
   void (*editor_resized)(Host *h, unsigned width, unsigned height);
+  // Adjust a user-requested size before resizing the frame or the editor.
+  void (*editor_constrain)(Host *h, unsigned *width, unsigned *height);
   // Each tick, outside the guard: whatever the plugin asked for meanwhile.
   void (*main_thread)(Host *h);
   void (*unload)(Host *h);
@@ -96,6 +98,7 @@ struct Host {
   _Atomic bool audio_thread_known;
   // The editor's window
   Display *display;
+  struct spa_source *editor_source;
   Window window, child;
   Atom close_message;
   bool editor_open;
@@ -107,12 +110,8 @@ struct Host {
   unsigned settle_ticks;
   int frame_x, frame_y;  // where the frame was, to notice that it moved
   unsigned settle_width, settle_height;  // the size to put back afterwards
-  // The last few sizes the plugin was told, with when. A plugin that answers
-  // a size by asking for another one, which the frame then reports back to
-  // it, would go round for ever; a size it was told a moment ago is that
-  // going round, not the user dragging, so it is not worth telling again.
-  struct { unsigned width, height; struct timespec at; } recent_sizes[8];
-  unsigned recent_next;
+  // Ignore consecutive duplicates, but deliver A -> B -> A during a drag.
+  unsigned notified_width, notified_height;
   // When the frame last changed size for a reason of its own, meaning the
   // user is dragging it. While that is going on the plugin's own requests
   // are left unanswered: two things pulling one window in different

--- a/native/tests/editor.c
+++ b/native/tests/editor.c
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Exercise the actual host event loop with a plugin on a separate X connection.
+#define main host_program_main
+#include "../host.c"
+#undef main
+#include <assert.h>
+
+static Display *plugin_display;
+static Window plugin_window;
+static unsigned resize_calls, idle_calls, constrain_calls, width_seen, height_seen;
+static bool constrain_sizes, answer_resize;
+
+static bool test_open(Host *h) {
+  plugin_display = XOpenDisplay(NULL);
+  assert(plugin_display);
+  XSetWindowAttributes attributes = {.override_redirect = True};
+  XChangeWindowAttributes(h->display, h->window, CWOverrideRedirect, &attributes);
+  XSync(h->display, False);
+  plugin_window = XCreateSimpleWindow(plugin_display, h->window,
+                                      0, 0, 64, 48, 0, 0, 0);
+  XMapWindow(plugin_display, plugin_window);
+  XSync(plugin_display, False);
+  return true;
+}
+
+static void test_close(Host *h) {
+  XDestroyWindow(plugin_display, plugin_window);
+  XCloseDisplay(plugin_display);
+  plugin_display = NULL;
+}
+
+static void test_resize(Host *h, unsigned width, unsigned height) {
+  ++resize_calls;
+  width_seen = width;
+  height_seen = height;
+  // Simulate a bridged plugin laying out on its own connection.
+  XResizeWindow(plugin_display, plugin_window, width, height);
+  XSync(plugin_display, False);
+  if (answer_resize)
+    host_resize_editor(h, width + 1, height + 1);
+}
+
+static void test_constrain(Host *h, unsigned *width, unsigned *height) {
+  ++constrain_calls;
+  if (constrain_sizes) {
+    *width -= *width % 2;
+    *height -= *height % 2;
+  }
+}
+
+static bool test_idle(Host *h) {
+  ++idle_calls;
+  return false;
+}
+
+static const Backend test_backend = {
+    .name = "resize test", .editor_open = test_open, .editor_close = test_close,
+    .editor_idle = test_idle, .editor_resized = test_resize,
+    .editor_constrain = test_constrain};
+
+static void drain(Host *h) {
+  // No host timer is installed. Only readiness of the real X connection can
+  // deliver these events. The old 30 Hz polling path cannot pass this test.
+  for (unsigned i = 0; i < 20; ++i)
+    pw_loop_iterate(host_loop(h), 1);
+}
+
+static void resize_to(Host *h, unsigned width, unsigned height) {
+  XResizeWindow(plugin_display, h->window, width, height);
+  XSync(plugin_display, False);
+  drain(h);
+}
+
+static void assert_size(Host *h, unsigned width, unsigned height) {
+  XWindowAttributes frame, child;
+  assert(XGetWindowAttributes(plugin_display, h->window, &frame));
+  assert(XGetWindowAttributes(plugin_display, plugin_window, &child));
+  assert((unsigned)frame.width == width && (unsigned)frame.height == height);
+  assert((unsigned)child.width == width && (unsigned)child.height == height);
+  assert(width_seen == width && height_seen == height);
+}
+
+int main(void) {
+  pw_init(NULL, NULL);
+  Host h = {.backend = &test_backend, .has_editor = true,
+            .node_name = "openxlr-editor-test"};
+  h.loop = pw_main_loop_new(NULL);
+  assert(h.loop);
+  pw_loop_enter(host_loop(&h));
+  assert(open_ui(&h));
+  drain(&h);
+  assert_size(&h, 64, 48);
+
+  unsigned calls = resize_calls;
+  unsigned settle = h.settle_ticks;
+  resize_to(&h, 100, 80);
+  assert(resize_calls == calls + 1);
+  assert_size(&h, 100, 80);
+  assert(idle_calls == 0 && h.settle_ticks == settle);
+  puts("PASS: X events resize the editor without an idle tick");
+
+  resize_to(&h, 110, 90);
+  calls = resize_calls;
+  resize_to(&h, 100, 80);
+  assert(resize_calls == calls + 1);
+  assert_size(&h, 100, 80);
+  puts("PASS: reversing a drag delivers a previously visited size");
+
+  calls = resize_calls;
+  for (unsigned i = 0; i < 8; ++i)
+    XResizeWindow(plugin_display, h.window, 120 + i, 100 + i);
+  XSync(plugin_display, False);
+  drain(&h);
+  assert(resize_calls == calls + 1);
+  assert_size(&h, 127, 107);
+  puts("PASS: a queued resize burst delivers only its final size");
+
+  constrain_sizes = true;
+  answer_resize = true;
+  resize_to(&h, 141, 121);
+  assert_size(&h, 140, 120);
+  calls = resize_calls;
+  drain(&h);
+  assert(resize_calls == calls);
+  puts("PASS: constraints keep both windows aligned without resize feedback");
+  answer_resize = false;
+
+  // The Wine coordinate workaround must still deliver its one-pixel nudge,
+  // even when that temporary size violates the plugin's size constraints.
+  unsigned constraints = constrain_calls;
+  h.settle_ticks = 1;
+  pump_editor(&h, true);
+  drain(&h);
+  assert_size(&h, 140, 119);
+  assert(constrain_calls == constraints);
+  h.settle_ticks = 1;
+  pump_editor(&h, true);
+  drain(&h);
+  assert_size(&h, 140, 120);
+  puts("PASS: the coordinate nudge and restore survive size constraints");
+
+  close_ui(&h);
+  assert(!h.editor_source && !h.display && !h.editor_open);
+  assert(open_ui(&h));
+  drain(&h);
+  assert_size(&h, 64, 48);
+  Display *host_display = h.display;
+  Window host_window_id = h.window;
+  editor_events(&h, ConnectionNumber(h.display), SPA_IO_HUP);
+  assert(!h.editor_source && !h.display && !h.editor_open);
+  // A synthetic hangup leaves these test connections alive for cleanup.
+  test_close(&h);
+  XDestroyWindow(host_display, host_window_id);
+  XCloseDisplay(host_display);
+  pw_loop_leave(host_loop(&h));
+  pw_main_loop_destroy(h.loop);
+  pw_deinit();
+  puts("PASS: closing, reopening and losing a display remove its event source");
+  return 0;
+}

--- a/native/vst3.cpp
+++ b/native/vst3.cpp
@@ -1190,6 +1190,18 @@ void vst3_editor_lost(Host *h) {
 
 bool vst3_editor_idle(Host *) { return false; }
 
+void vst3_editor_constrain(Host *h, unsigned *width, unsigned *height) {
+  Vst3 *v = of(h);
+  if (!v->view)
+    return;
+  ViewRect rect(0, 0, (int32)*width, (int32)*height);
+  if (v->view->checkSizeConstraint(&rect) == kResultOk &&
+      rect.getWidth() > 0 && rect.getHeight() > 0) {
+    *width = (unsigned)rect.getWidth();
+    *height = (unsigned)rect.getHeight();
+  }
+}
+
 void vst3_editor_resized(Host *h, unsigned width, unsigned height) {
   Vst3 *v = of(h);
   if (!v->view)
@@ -1213,6 +1225,7 @@ extern "C" const Backend vst3_backend = {
     vst3_editor_lost,
     vst3_editor_focus,
     vst3_editor_resized,
+    vst3_editor_constrain,
     vst3_main_thread,
     vst3_unload,
 };


### PR DESCRIPTION
Dragging a plugin editor border waited for the 30 Hz idle tick, and the frame could use dimensions the VST3 editor did not support. Resize events now wake the main loop directly, apply the plugin's size constraints, and notify its view before enlarging the embedding window. Returning to an earlier size during a drag is delivered again. The Wine coordinate nudge retains its timing and bypasses constraints for its temporary one-pixel change.

Native regression tests cover event delivery without idle polling, queued resize coalescing, drag reversal, constraints, resize feedback, the coordinate nudge, and editor close/reopen/display-loss cleanup. CI runs them under Xvfb. The manual documents plugin size increments and the remaining repaint limitation.

Validation:
- Locked restore and Release build with the native host enabled: zero warnings and errors.
- All 294 .NET tests and five plugin tests passed.
- Native editor regression tests passed; disabling event delivery in a separate negative-control build caused the test to fail.
- Plugin syntax and manifest, ShellCheck, version consistency, locked restore policy, OpenAPI, RPM spec, and diff checks passed.
- Scripted desktop resize captures exercised installed TDR Nova and Valhalla Supermassive through yabridge. Embedded-window lag was reduced. Nova had no white strips in the final capture; Supermassive still flashes intermittently while repainting, so this does not claim to eliminate every white flash.

No audio-device hardware acceptance or manual mouse-input acceptance was performed for this change. Existing live plugin processes were left running.
