### PR TITLE
Inserts: respect LSP editor bounds and fixed VST3 sizes

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -569,10 +569,14 @@ A CLAP or VST3 plugin has no shared chain to go back to, so it always runs
 this way: its row shows no switch, and the cog opens its editor whenever
 the plugin is running.
 
-Dragging a VST3 editor's border follows the sizes the plugin supports, so
-an editor with size increments may move in steps. The plugin draws its own
-contents; a Windows editor running through Wine can still briefly expose
-an unpainted edge while it redraws during a drag.
+Dragging an editor's border respects the plugin's minimum and maximum
+dimensions, so shrinking an LSP editor stops before its controls are cut
+off. A VST3 editor also decides whether its border can be resized. TDR Nova
+disables border resizing; use its own "User Interface Scale" menu to make
+it larger. Editors that allow resizing may move in steps if the plugin
+requires size increments. The plugin draws its own contents; a Windows
+editor running through Wine can still briefly expose an unpainted edge
+while it redraws during a drag.
 
 The editor draws on an X11 display, which means XWayland on a Wayland
 desktop, and the daemon has to know about it. A user service started

--- a/native/README.md
+++ b/native/README.md
@@ -31,8 +31,10 @@ dependencies of every package.
 machine without a desktop, run `xvfb-run -a make -C native test-editor`.
 These tests need neither a plugin installation nor a running PipeWire
 server. They cover event delivery without idle polling, coalesced sizes,
-drag reversal, size constraints, the Wine coordinate nudge and display
-cleanup. Real plugin repainting and mouse input still need desktop testing.
+drag reversal, size constraints, changes to child-window size bounds,
+fixed-size editors and plugin-driven scaling, the Wine coordinate nudge
+and display cleanup. Real plugin repainting and mouse input still need
+desktop testing.
 
 ## What it does
 
@@ -105,6 +107,10 @@ That is what reverbs and convolvers ask for, and without it they could not be
 hosted at all.
 
 For the editor: instance access, parent, resize and the idle interface.
+The host calls a UI's LV2 resize interface when present and forwards the
+child window's minimum and maximum dimensions to the outer window. Changed
+size hints are read again, so a plugin's scaling controls can update them.
+LV2 editors do not receive the Wine coordinate nudge.
 
 For CLAP: parameters, the audio ports, the X11 editor, timers, file
 descriptors, thread checks and a log. The same binary describes a CLAP
@@ -129,7 +135,10 @@ plugins arrive through yabridge as ordinary bundles.
 Editor X events wake the main loop directly; the 30 Hz tick remains for
 idle work and the Wine coordinate workaround. During a frame resize, the
 VST3 backend checks the plugin's size constraints before notifying its
-view, and the embedding window follows after that callback. Consecutive
+view, and the embedding window follows after that callback. A VST3 view
+that refuses border resizing gets equal minimum and maximum dimensions;
+its own resize requests update those bounds, so plugin-driven UI scaling
+still works. Consecutive
 duplicate sizes are skipped, but reversing a drag delivers the old size
 again. Plugin resize requests and child-window echoes remain suppressed
 while the user is resizing the frame.

--- a/native/clap.c
+++ b/native/clap.c
@@ -646,6 +646,7 @@ const Backend clap_backend = {
     .editor_resized = NULL,
     .main_thread = clap_main_thread,
     .unload = clap_unload,
+    .editor_coordinate_nudge = true,
 };
 
 // --- the scanner ------------------------------------------------------------

--- a/native/host.c
+++ b/native/host.c
@@ -106,6 +106,11 @@ void host_editor_lost(Host *h) {
 // guard, so each one arms its own unless a caller already has.
 static bool same_editor_size(Host *h, unsigned width, unsigned height);
 static bool dragging(Host *h);
+static void update_editor_hints(Host *h);
+
+void host_set_editor_resizable(Host *h, bool resizable) {
+  h->editor_resizable = resizable;
+}
 
 void host_resize_editor(Host *h, unsigned width, unsigned height) {
   if (!h->display || !h->window || width < 1 || height < 1 ||
@@ -114,6 +119,8 @@ void host_resize_editor(Host *h, unsigned width, unsigned height) {
   h->self_width = width;
   h->self_height = height;
   if (x_escape_armed) {
+    if (!h->editor_resizable)
+      update_editor_hints(h);
     XResizeWindow(h->display, h->window, width, height);
     return;
   }
@@ -123,6 +130,8 @@ void host_resize_editor(Host *h, unsigned width, unsigned height) {
     return;
   }
   x_escape_armed = 1;
+  if (!h->editor_resizable)
+    update_editor_hints(h);
   XResizeWindow(h->display, h->window, width, height);
   XFlush(h->display);
   x_escape_armed = 0;
@@ -259,6 +268,40 @@ static const struct pw_filter_events filter_events = {
 
 // --- the editor's window ----------------------------------------------------
 
+// A window manager only reads the outer window's hints. Embedded editors
+// such as LSP put their limits on the child, so copy the size bounds and
+// also enforce them for resize requests that bypass the window manager.
+static void update_editor_hints(Host *h) {
+  XSizeHints child = {0}, hints = {0};
+  long supplied;
+  h->editor_min_width = h->editor_min_height = 1;
+  h->editor_max_width = h->editor_max_height = 16384;
+  if (h->child && XGetWMNormalHints(h->display, h->child, &child, &supplied)) {
+    if ((child.flags & PMinSize) && child.min_width > 0 && child.min_height > 0 &&
+        child.min_width <= 16384 && child.min_height <= 16384) {
+      h->editor_min_width = (unsigned)child.min_width;
+      h->editor_min_height = (unsigned)child.min_height;
+    }
+    if ((child.flags & PMaxSize) && child.max_width >= (int)h->editor_min_width &&
+        child.max_height >= (int)h->editor_min_height) {
+      if (child.max_width < 16384)
+        h->editor_max_width = (unsigned)child.max_width;
+      if (child.max_height < 16384)
+        h->editor_max_height = (unsigned)child.max_height;
+    }
+  }
+  if (!h->editor_resizable && h->self_width && h->self_height) {
+    h->editor_min_width = h->editor_max_width = h->self_width;
+    h->editor_min_height = h->editor_max_height = h->self_height;
+  }
+  hints.flags = PMinSize | PMaxSize;
+  hints.min_width = (int)h->editor_min_width;
+  hints.min_height = (int)h->editor_min_height;
+  hints.max_width = (int)h->editor_max_width;
+  hints.max_height = (int)h->editor_max_height;
+  XSetWMNormalHints(h->display, h->window, &hints);
+}
+
 // A plugin builds its interface in a window of its own inside ours, at
 // whatever size it wants, and many never call the host's resize. Take the
 // size from that window, and watch it so later changes follow.
@@ -269,12 +312,13 @@ static void fit_to_child(Host *h) {
     return;
   if (count > 0) {
     h->child = children[count - 1];
-    XSelectInput(h->display, h->child, StructureNotifyMask);
+    XSelectInput(h->display, h->child, StructureNotifyMask | PropertyChangeMask);
     XWindowAttributes attributes;
     if (XGetWindowAttributes(h->display, h->child, &attributes) &&
         attributes.width > 0 && attributes.height > 0) {
       h->self_width = (unsigned)attributes.width;
       h->self_height = (unsigned)attributes.height;
+      update_editor_hints(h);
       XResizeWindow(h->display, h->window, h->self_width, h->self_height);
     }
   }
@@ -334,6 +378,7 @@ static bool open_ui(Host *h) {
     return false;
   }
   x_escape_armed = 1;
+  h->editor_resizable = true;
   h->display = XOpenDisplay(NULL);
   if (h->display) {
     h->window = XCreateSimpleWindow(h->display, DefaultRootWindow(h->display),
@@ -367,7 +412,8 @@ static bool open_ui(Host *h) {
       h->editor_source = pw_loop_add_io(host_loop(h), ConnectionNumber(h->display),
                                         SPA_IO_IN | SPA_IO_HUP | SPA_IO_ERR,
                                         false, editor_events, h);
-      h->settle_ticks = 6;   // once it is on screen, teach it where that is
+      if (h->backend->editor_coordinate_nudge)
+        h->settle_ticks = 6;   // once it is on screen, teach it where that is
     }
   }
   x_escape_armed = 0;
@@ -427,13 +473,17 @@ static void pump_editor(Host *h, bool idle) {
     // that window appears.
     if (!h->child && (event.type == MapNotify || event.type == CreateNotify))
       fit_to_child(h);
+    if (event.type == PropertyNotify && event.xproperty.window == h->child &&
+        event.xproperty.atom == XA_WM_NORMAL_HINTS)
+      update_editor_hints(h);
     // The window moved. Where a plugin thinks it is decides where it thinks
     // the pointer is, so it is taught the new place the only way it listens.
     if (event.type == ConfigureNotify && event.xconfigure.window == h->window &&
         (event.xconfigure.x != h->frame_x || event.xconfigure.y != h->frame_y)) {
       h->frame_x = event.xconfigure.x;
       h->frame_y = event.xconfigure.y;
-      h->settle_ticks = 9;
+      if (h->backend->editor_coordinate_nudge)
+        h->settle_ticks = 9;
     }
     // Sizes are noted here and settled once the queue is empty. Dragging a
     // corner fills the queue with them, and telling a plugin about every
@@ -464,15 +514,21 @@ static void pump_editor(Host *h, bool idle) {
          (unsigned)attributes.height != plugin_height)) {
       h->self_width = plugin_width;
       h->self_height = plugin_height;
+      update_editor_hints(h);
       XResizeWindow(h->display, h->window, plugin_width, plugin_height);
     }
     if (frame_resized) {
       bool user_size = frame_width != h->self_width || frame_height != h->self_height;
-      if (user_size)
+      if (user_size && h->editor_resizable)
         clock_gettime(CLOCK_MONOTONIC, &h->dragged_at);
-      if (user_size && h->backend->editor_constrain) {
+      if (user_size) {
         unsigned width = frame_width, height = frame_height;
-        h->backend->editor_constrain(h, &width, &height);
+        if (width < h->editor_min_width) width = h->editor_min_width;
+        if (height < h->editor_min_height) height = h->editor_min_height;
+        if (width > h->editor_max_width) width = h->editor_max_width;
+        if (height > h->editor_max_height) height = h->editor_max_height;
+        if (h->editor_resizable && h->backend->editor_constrain)
+          h->backend->editor_constrain(h, &width, &height);
         if (width > 0 && height > 0 && width <= 16384 && height <= 16384 &&
             (width != frame_width || height != frame_height)) {
           frame_width = h->self_width = width;
@@ -504,6 +560,8 @@ static void pump_editor(Host *h, bool idle) {
     if (h->settle_height > 0) {
       h->self_width = h->settle_width;
       h->self_height = h->settle_height;
+      if (!h->editor_resizable)
+        update_editor_hints(h);
       XResizeWindow(h->display, h->window, h->settle_width, h->settle_height);
       XFlush(h->display);
       h->settle_height = 0;
@@ -515,6 +573,8 @@ static void pump_editor(Host *h, bool idle) {
         h->settle_height = (unsigned)attributes.height;
         h->self_width = h->settle_width;
         h->self_height = h->settle_height - 1;
+        if (!h->editor_resizable)
+          update_editor_hints(h);
         XResizeWindow(h->display, h->window, h->settle_width, h->settle_height - 1);
         XFlush(h->display);
         h->settle_ticks = 4;   // put it back once the plugin has caught up

--- a/native/host.h
+++ b/native/host.h
@@ -59,6 +59,8 @@ typedef struct {
   // Each tick, outside the guard: whatever the plugin asked for meanwhile.
   void (*main_thread)(Host *h);
   void (*unload)(Host *h);
+  // These formats can arrive through Wine and need the coordinate nudge.
+  bool editor_coordinate_nudge;
 } Backend;
 
 #ifndef __cplusplus
@@ -102,6 +104,9 @@ struct Host {
   Window window, child;
   Atom close_message;
   bool editor_open;
+  bool editor_resizable;
+  unsigned editor_min_width, editor_min_height;
+  unsigned editor_max_width, editor_max_height;
   // A plugin bridged from Windows learns where its window is when the window
   // changes size, and not when it opens or moves. Until it has learnt, its
   // clicks land as far from the pointer as the window is from the corner of
@@ -142,6 +147,7 @@ void host_control_moved(Host *h, Control *c, float value);
 // The editor moved a control on the audio thread: apply it; the tick tells.
 void host_control_moved_rt(Host *h, Control *c, float value);
 void host_resize_editor(Host *h, unsigned width, unsigned height);
+void host_set_editor_resizable(Host *h, bool resizable);
 void host_show_editor(Host *h, bool show);
 // The display went away under a backend's own callback: drop the editor.
 void host_editor_lost(Host *h);

--- a/native/lv2.c
+++ b/native/lv2.c
@@ -123,6 +123,7 @@ typedef struct {
   void *ui_library;
   const LV2UI_Descriptor *ui_descriptor;
   const LV2UI_Idle_Interface *idle;
+  const LV2UI_Resize *ui_resize;
   LV2UI_Handle ui;
   LV2UI_Resize resize;
 } Lv2;
@@ -541,10 +542,14 @@ static bool lv2_editor_open(Host *h) {
     l->ui = l->ui_descriptor->instantiate(
         l->ui_descriptor, lilv_node_as_uri(lilv_plugin_get_uri(l->plugin)),
         bundle, ui_write, l, &widget, features);
-    if (l->ui)
+    if (l->ui) {
       l->idle = l->ui_descriptor->extension_data
                     ? l->ui_descriptor->extension_data(LV2_UI__idleInterface)
                     : NULL;
+      l->ui_resize = l->ui_descriptor->extension_data
+                         ? l->ui_descriptor->extension_data(LV2_UI__resize)
+                         : NULL;
+    }
   }
   lilv_free(binary);
   lilv_free(bundle);
@@ -558,12 +563,20 @@ static void lv2_editor_close(Host *h) {
     l->ui_descriptor->cleanup(l->ui);
   l->ui = NULL;
   l->idle = NULL;
+  l->ui_resize = NULL;
 }
 
 static void lv2_editor_lost(Host *h) {
   Lv2 *l = h->impl;
   l->ui = NULL;
   l->idle = NULL;
+  l->ui_resize = NULL;
+}
+
+static void lv2_editor_resized(Host *h, unsigned width, unsigned height) {
+  Lv2 *l = h->impl;
+  if (l->ui && l->ui_resize && l->ui_resize->ui_resize)
+    l->ui_resize->ui_resize(l->ui, (int)width, (int)height);
 }
 
 static bool lv2_editor_idle(Host *h) {
@@ -594,7 +607,7 @@ const Backend lv2_backend = {
     .editor_idle = lv2_editor_idle,
     .editor_lost = lv2_editor_lost,
     .editor_focus = NULL,   // an LV2 UI is not told; X gives it the mouse itself
-    .editor_resized = NULL,
+    .editor_resized = lv2_editor_resized,
     .main_thread = NULL,
     .unload = lv2_unload,
 };

--- a/native/tests/editor.c
+++ b/native/tests/editor.c
@@ -9,6 +9,7 @@ static Display *plugin_display;
 static Window plugin_window;
 static unsigned resize_calls, idle_calls, constrain_calls, width_seen, height_seen;
 static bool constrain_sizes, answer_resize;
+static bool fixed_editor;
 
 static bool test_open(Host *h) {
   plugin_display = XOpenDisplay(NULL);
@@ -20,6 +21,7 @@ static bool test_open(Host *h) {
                                       0, 0, 64, 48, 0, 0, 0);
   XMapWindow(plugin_display, plugin_window);
   XSync(plugin_display, False);
+  host_set_editor_resizable(h, !fixed_editor);
   return true;
 }
 
@@ -56,7 +58,7 @@ static bool test_idle(Host *h) {
 static const Backend test_backend = {
     .name = "resize test", .editor_open = test_open, .editor_close = test_close,
     .editor_idle = test_idle, .editor_resized = test_resize,
-    .editor_constrain = test_constrain};
+    .editor_constrain = test_constrain, .editor_coordinate_nudge = true};
 
 static void drain(Host *h) {
   // No host timer is installed. Only readiness of the real X connection can
@@ -78,6 +80,16 @@ static void assert_size(Host *h, unsigned width, unsigned height) {
   assert((unsigned)frame.width == width && (unsigned)frame.height == height);
   assert((unsigned)child.width == width && (unsigned)child.height == height);
   assert(width_seen == width && height_seen == height);
+}
+
+static void assert_bounds(Host *h, int min_width, int min_height,
+                          int max_width, int max_height) {
+  XSizeHints hints;
+  long supplied;
+  assert(XGetWMNormalHints(plugin_display, h->window, &hints, &supplied));
+  assert((hints.flags & (PMinSize | PMaxSize)) == (PMinSize | PMaxSize));
+  assert(hints.min_width == min_width && hints.min_height == min_height);
+  assert(hints.max_width == max_width && hints.max_height == max_height);
 }
 
 int main(void) {
@@ -141,6 +153,73 @@ int main(void) {
 
   close_ui(&h);
   assert(!h.editor_source && !h.display && !h.editor_open);
+
+  // A native LV2 editor publishes its bounds on its child window. The WM
+  // only sees our frame, and direct X resize requests bypass the WM entirely.
+  Backend native_backend = test_backend;
+  native_backend.editor_coordinate_nudge = false;
+  h.backend = &native_backend;
+  constrain_sizes = false;
+  assert(open_ui(&h));
+  drain(&h);
+  assert(h.settle_ticks == 0);
+  XSizeHints hints = {.flags = PMinSize | PMaxSize,
+                      .min_width = 64, .min_height = 48,
+                      .max_width = 160, .max_height = 120};
+  XSetWMNormalHints(plugin_display, plugin_window, &hints);
+  XSync(plugin_display, False);
+  drain(&h);
+  assert_bounds(&h, 64, 48, 160, 120);
+  resize_to(&h, 32, 24);
+  assert_size(&h, 64, 48);
+  resize_to(&h, 200, 180);
+  assert_size(&h, 160, 120);
+  puts("PASS: child size bounds reach the frame and prevent clipped controls");
+
+  hints.min_width = 80;
+  hints.min_height = 60;
+  hints.max_width = 240;
+  hints.max_height = 180;
+  XSetWMNormalHints(plugin_display, plugin_window, &hints);
+  XSync(plugin_display, False);
+  drain(&h);
+  assert_bounds(&h, 80, 60, 240, 180);
+  resize_to(&h, 64, 48);
+  assert_size(&h, 80, 60);
+  XMoveWindow(plugin_display, h.window, 10, 10);
+  XSync(plugin_display, False);
+  drain(&h);
+  for (unsigned i = 0; i < 15; ++i)
+    pump_editor(&h, true);
+  assert(h.settle_ticks == 0 && h.settle_height == 0);
+  assert_size(&h, 80, 60);
+  puts("PASS: bounds refresh after scaling and native editors get no Wine nudge");
+  close_ui(&h);
+
+  // Fixed-size VST3 editors still resize through their own scaling controls.
+  h.backend = &test_backend;
+  fixed_editor = true;
+  assert(open_ui(&h));
+  drain(&h);
+  assert_bounds(&h, 64, 48, 64, 48);
+  resize_to(&h, 100, 80);
+  assert_size(&h, 64, 48);
+  host_resize_editor(&h, 128, 96);
+  drain(&h);
+  assert_bounds(&h, 128, 96, 128, 96);
+  assert_size(&h, 128, 96);
+  h.settle_ticks = 1;
+  pump_editor(&h, true);
+  drain(&h);
+  assert_size(&h, 128, 95);
+  h.settle_ticks = 1;
+  pump_editor(&h, true);
+  drain(&h);
+  assert_size(&h, 128, 96);
+  assert_bounds(&h, 128, 96, 128, 96);
+  puts("PASS: fixed editors reject border resizing but accept plugin scaling");
+  close_ui(&h);
+  fixed_editor = false;
   assert(open_ui(&h));
   drain(&h);
   assert_size(&h, 64, 48);

--- a/native/vst3.cpp
+++ b/native/vst3.cpp
@@ -1163,6 +1163,7 @@ bool vst3_editor_open(Host *h) {
     v->view = nullptr;
     return false;
   }
+  host_set_editor_resizable(h, v->view->canResize() == kResultTrue);
   return true;
 }
 
@@ -1228,6 +1229,7 @@ extern "C" const Backend vst3_backend = {
     vst3_editor_constrain,
     vst3_main_thread,
     vst3_unload,
+    true,
 };
 
 // --- the scanner ------------------------------------------------------------


### PR DESCRIPTION
Shrinking LSP Gate Mono below its declared 944 x 535 minimum clipped its controls because the outer frame ignored the child window's size hints. The frame now advertises and enforces the child's minimum and maximum dimensions, including later hint changes. The LV2 backend calls the editor's resize interface, and LV2 editors no longer receive the Wine coordinate nudge.

The installed TDR Nova VST3 reports canResize=false and returns 830 x 598 for all tested requested sizes at its current scale. The host now gives fixed-size VST3 editors matching minimum and maximum bounds, while plugin-initiated scaling updates those bounds. This removes the misleading freely resizable border.

Validation:
- Reproduced LSP clipping in a separate instance of the same LV2 plugin used on XLR1. The original capture at 500 x 300 cut off the controls; the new host stops at 944 x 535 with all controls visible.
- Queried Nova's actual canResize and checkSizeConstraint responses, including requests up to 4000 x 4000. Its official manual documents User Interface Scale as the supported scaling control: https://docs.tokyodawn.net/nova-manual/ .
- Native regression tests cover forwarded bounds, changed hints, minimum/maximum enforcement, absence of a Wine nudge for native editors, and fixed-size editors accepting plugin-driven scaling. Existing resize regressions also pass.
- Locked restore and native-enabled Release build passed with zero warnings or errors. All 294 .NET tests, five plugin tests, native tests, syntax/manifest checks, ShellCheck, version, locked-restore, OpenAPI, RPM and diff checks passed locally.

The desktop probes exercised real plugin windows. Manual mouse-input acceptance and audio-device hardware acceptance were not performed. Supermassive's previously documented intermittent repaint flash remains outside this fix.
