### PR TITLE
Inserts: avoid LSP editor freezes during large resizes

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -578,6 +578,13 @@ requires size increments. The plugin draws its own contents; a Windows
 editor running through Wine can still briefly expose an unpainted edge
 while it redraws during a drag.
 
+LSP editors use software rendering by default. Their OpenGL renderer can
+stop repainting after a continuous drag to a large size, requiring the
+editor to be closed and reopened. To test OpenGL again, start the daemon
+with `LSP_WS_LIB_GLXSURFACE=1` in its environment. An explicit renderer
+setting takes precedence over the default. This setting controls LSP's
+editor rendering; it does not change audio processing.
+
 The editor draws on an X11 display, which means XWayland on a Wayland
 desktop, and the daemon has to know about it. A user service started
 before the desktop published its display has none of its own, so OpenXLR

--- a/native/README.md
+++ b/native/README.md
@@ -36,6 +36,13 @@ fixed-size editors and plugin-driven scaling, the Wine coordinate nudge
 and display cleanup. Real plugin repainting and mouse input still need
 desktop testing.
 
+`python3 native/tests/lsp-editor.py` is an opt-in desktop regression using
+an isolated LSP Gate Mono LV2 instance. It needs python-xlib, the installed
+plugin, a running PipeWire server and a display large enough for the tested
+sizes. It drags the editor to large sizes and back, checking that changed
+parameters still repaint. `--host PATH` selects another build; `--opengl`
+tests the explicit OpenGL override. It creates no audio links.
+
 ## What it does
 
 - One process per insert, holding one plugin instance and its editor.
@@ -111,6 +118,12 @@ The host calls a UI's LV2 resize interface when present and forwards the
 child window's minimum and maximum dimensions to the outer window. Changed
 size hints are read again, so a plugin's scaling controls can update them.
 LV2 editors do not receive the Wine coordinate nudge.
+
+Before loading a plugin, the helper defaults `LSP_WS_LIB_GLXSURFACE` to `0`
+unless the user already set it. LSP's software renderer avoids the repaint
+freeze reproduced with its OpenGL renderer during large continuous resizes.
+The setting is specific to LSP and applies to its editors in every hosted
+format. Set it to `1` in the daemon environment to test OpenGL again.
 
 For CLAP: parameters, the audio ports, the X11 editor, timers, file
 descriptors, thread checks and a log. The same binary describes a CLAP

--- a/native/host.c
+++ b/native/host.c
@@ -726,6 +726,13 @@ static const Backend *backend_named(const char *name) {
   return NULL;
 }
 
+static bool configure_editor_environment(void) {
+  // LSP's OpenGL editor can stop repainting after continuous large resizes.
+  // Its software renderer stays responsive. Only LSP reads this setting;
+  // keep an explicit choice supplied by the user.
+  return setenv("LSP_WS_LIB_GLXSURFACE", "0", 0) == 0;
+}
+
 int main(int argc, char **argv) {
   if (argc == 3 && !strcmp(argv[1], "scan-clap"))
     return clap_scan(argv[2]);
@@ -755,6 +762,11 @@ int main(int argc, char **argv) {
   if (channels < 1 || channels > MAX_CHANNELS || h.rate < 8000 ||
       h.rate > 384000)
     return 2;
+  // Set the renderer before loading plugin code or starting audio threads.
+  if (!configure_editor_environment()) {
+    perror("editor renderer environment");
+    return 1;
+  }
   setvbuf(stdout, NULL, _IOLBF, 0);
   XSetErrorHandler(report_x_error);
   XSetIOErrorHandler(lost_x_connection);

--- a/native/tests/editor.c
+++ b/native/tests/editor.c
@@ -93,6 +93,21 @@ static void assert_bounds(Host *h, int min_width, int min_height,
 }
 
 int main(void) {
+  const char *renderer = getenv("LSP_WS_LIB_GLXSURFACE");
+  char *saved_renderer = renderer ? strdup(renderer) : NULL;
+  assert(!renderer || saved_renderer);
+  assert(unsetenv("LSP_WS_LIB_GLXSURFACE") == 0);
+  assert(configure_editor_environment());
+  assert(!strcmp(getenv("LSP_WS_LIB_GLXSURFACE"), "0"));
+  assert(setenv("LSP_WS_LIB_GLXSURFACE", "1", 1) == 0);
+  assert(configure_editor_environment());
+  assert(!strcmp(getenv("LSP_WS_LIB_GLXSURFACE"), "1"));
+  if (saved_renderer) {
+    assert(setenv("LSP_WS_LIB_GLXSURFACE", saved_renderer, 1) == 0);
+    free(saved_renderer);
+  } else
+    assert(unsetenv("LSP_WS_LIB_GLXSURFACE") == 0);
+  puts("PASS: LSP rendering defaults to software and preserves an explicit override");
   pw_init(NULL, NULL);
   Host h = {.backend = &test_backend, .has_editor = true,
             .node_name = "openxlr-editor-test"};

--- a/native/tests/lsp-editor.py
+++ b/native/tests/lsp-editor.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""Opt-in desktop regression: LSP Gate must repaint after large resize drags.
+
+Requires python-xlib, LSP Gate Mono LV2, DISPLAY and a running PipeWire server.
+The isolated instance has no audio links and never changes the user's chain.
+"""
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+
+from Xlib import X, display, error
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=str(Path(__file__).resolve().parents[1] / "openxlr-lv2-host"))
+    parser.add_argument("--opengl", action="store_true", help="test an explicit OpenGL override")
+    parser.add_argument("--position", nargs=2, type=int, default=(0, 0), metavar=("X", "Y"),
+                        help="place the test window on a chosen monitor")
+    args = parser.parse_args()
+    node = f"openxlr-lsp-resize-test-{os.getpid()}"
+    env = os.environ.copy()
+    env.pop("LSP_WS_LIB_GLXSURFACE", None)
+    if args.opengl:
+        env["LSP_WS_LIB_GLXSURFACE"] = "1"
+
+    with tempfile.TemporaryFile(mode="w+") as log:
+        process = subprocess.Popen(
+            [args.host, "lv2", "http://lsp-plug.in/plugins/lv2/gate_mono", node, "1", "48000"],
+            stdin=subprocess.PIPE, stdout=log, stderr=log, text=True, env=env,
+        )
+        connection = None
+        try:
+            connection = display.Display()
+            root = connection.screen().root
+            atom = connection.intern_atom("_OPENXLR_NODE")
+
+            def command(line):
+                process.stdin.write(line + "\n")
+                process.stdin.flush()
+
+            def find(window):
+                try:
+                    prop = window.get_full_property(atom, X.AnyPropertyType)
+                    if prop and prop.value == node.encode():
+                        return window
+                    for child in window.query_tree().children:
+                        found = find(child)
+                        if found is not None:
+                            return found
+                except error.BadWindow:
+                    pass  # An unrelated desktop window closed during discovery.
+                return None
+
+            command("show")
+            window = None
+            for _ in range(100):
+                time.sleep(0.1)
+                window = find(root)
+                if window is not None or process.poll() is not None:
+                    break
+            assert window is not None, "LSP editor did not open"
+            window.configure(x=args.position[0], y=args.position[1])
+            connection.sync()
+            time.sleep(1)
+            original = window.get_geometry()
+
+            def repaint(label):
+                geometry = window.get_geometry()
+
+                def pixels():
+                    return window.get_image(0, 0, geometry.width, geometry.height, X.ZPixmap, 0xffffffff).data
+
+                command("set g_out 1")
+                time.sleep(0.35)
+                first = pixels()
+                command("set g_out 0.25")
+                time.sleep(0.35)
+                assert first != pixels(), f"LSP stopped repainting {label}"
+                print(f"PASS: parameter repaints {label}", flush=True)
+
+            repaint("at its initial size")
+            for width, height in [(2400, 1600), (4000, 2200), (6000, 2400), (original.width, original.height)]:
+                start = window.get_geometry()
+                for step in range(1, 181):
+                    window.configure(
+                        width=round(start.width + (width - start.width) * step / 180),
+                        height=round(start.height + (height - start.height) * step / 180),
+                    )
+                    connection.flush()
+                    time.sleep(0.008)
+                connection.sync()
+                time.sleep(0.4)
+                repaint(f"after dragging to {width} x {height}")
+        except Exception:
+            log.seek(0)
+            print(log.read()[-4000:])
+            raise
+        finally:
+            if process.poll() is None:
+                try:
+                    process.stdin.write("quit\n")
+                    process.stdin.flush()
+                    process.wait(timeout=4)
+                except (BrokenPipeError, subprocess.TimeoutExpired):
+                    process.kill()
+                    process.wait()
+            process.stdin.close()
+            if connection is not None:
+                connection.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
LSP Gate Mono 1.2.35 stops repainting after continuous large resize drags on the tested desktop. Shrinking it again does not recover the controls, while reopening the editor does. The same sequence works with LSP's software renderer.

The helper now defaults `LSP_WS_LIB_GLXSURFACE=0` before loading plugin code or starting audio threads. An existing environment value is preserved, so users can opt back into OpenGL. This is an LSP-specific rendering setting and does not change the other plugins' control paths or audio processing.

Validation:
- Added an opt-in desktop regression that runs an isolated LSP Gate Mono instance, drags its editor through large sizes, and verifies changed parameters still repaint. The old helper failed at 4000 x 2200. The new helper passed at 2400 x 1600, 4000 x 2200, 6000 x 2400, and after returning to its original size. The test removes inherited renderer settings, so the pass verifies the built-in default.
- Native tests verify the software default and preservation of an explicit OpenGL override. Existing editor regressions also pass.
- Locked restore and native-enabled Release build passed with zero warnings and errors. All 294 .NET tests, five plugin tests, syntax/manifest checks, ShellCheck, version, locked restore, OpenAPI, RPM and diff checks passed.
- Nova and Supermassive parameter-update checks passed before and after resizing and moving with the equivalent local renderer setting. The user confirmed that both respond normally to the mouse. Automated Wine mouse checks were inconclusive, so this does not claim fresh automated mouse acceptance for those editors.

The real-plugin desktop regression needs an installed LSP plugin, python-xlib, PipeWire and a sufficiently large display; it is opt-in rather than part of headless CI. The ordinary native tests continue to run in CI under Xvfb.
