### PR TITLE
Devices: give a dock its own gain back even when the lock is on

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -51,7 +51,10 @@ For devices without the hardware version, the PipeWire layer provides:
 - Gain lock: the daemon rejects every gain change while the lock is set,
   from any client, and stores the lock per device in `gainlock.json`.
   Shown only for devices without a physical gain dial, which would
-  bypass it.
+  bypass it. Giving a device its own settings back when it connects is
+  not a change and goes through: a dock that forgets its settings would
+  otherwise come up at whatever gain its firmware chooses, which is the
+  one thing the lock is there to prevent.
 
 These controls appear only when the active device lacks the hardware
 version, so a signal is never filtered twice.

--- a/docs/hardware-support.md
+++ b/docs/hardware-support.md
@@ -45,7 +45,7 @@ expose, reached over the original Wave XLR's protocol dialect.
 | Mute, headphone volume | verified | standard ALSA controls |
 | Low cut 80 / 120 Hz | software | PipeWire high-pass in the mic path; response measured with test tones as second-order |
 | ClipGuard | software | post-ADC hard limiter at -3 dB, measured with test tones; needs `swh-plugins` and cannot repair analogue/ADC clipping. If the plugin is missing, the control is disabled and the current mic route remains live |
-| Gain lock | software | the daemon rejects all gain changes while set; the dock has no physical dial to bypass it |
+| Gain lock | software | the daemon rejects all gain changes while set; the dock has no physical dial to bypass it. The gain the dock is given back on connect is not a change and is written even when locked, since the dock forgets it at every power cycle |
 | Phantom power | verified | byte 6 of the dock's config block over the original Wave XLR's protocol dialect. Identified by [openwave PR #8](https://github.com/rikkichy/openwave/pull/8) on the MK.1 against its 48V LED; confirmed here with a condenser microphone on the dock's XLR. Wave Link does not write it for the dock |
 | Low impedance | verified | byte 33 of the same config block, verified by listening on the dock's headphone jack |
 | Device info block (0x000A) | read | 51 bytes; carries the unit's USB serial in ASCII from offset 35, so the diagnostics exporter masks it in the hex dump |

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -669,6 +669,15 @@ WirePlumber rule that keeps the dock's capture source always active
 `packaging/` into `~/.config/wireplumber/wireplumber.conf.d/` and
 restart WirePlumber.
 
+A second cause, when the microphone is silent only after a reboot: the
+dock forgets its gain at every power cycle and comes back at the gain its
+firmware chooses, which is lower than most people set. OpenXLR gives the
+gain back when the dock connects, even when the gain lock is on, from
+0.1.30 onwards. On an older version, take the lock off and set the gain
+again. A gate or an expander in the insert chain, tuned at the gain you
+meant to have, stays shut at a lower one and passes nothing at all, which
+is what makes the microphone sound dead rather than quiet.
+
 <a name="daemon-not-starting"></a>
 ### 5.3 Daemon does not start after an upgrade, or after a reboot
 

--- a/src/OpenXLR.Daemon/DeviceManager.cs
+++ b/src/OpenXLR.Daemon/DeviceManager.cs
@@ -415,7 +415,7 @@ public sealed class DeviceManager : BackgroundService
             catch (Exception ex) { last = null; _log.LogWarning("loading last settings of {dev}: {msg}", id, ex.Message); }
             _restorePending = false;
             if (last is null) return null;
-            string? err = ApplyProfile(last);
+            string? err = ApplyProfile(last, restoring: true);
             NoteChangedLocked();
             return err is null ? $"restored the last settings of {id}" : $"restoring the last settings of {id}: {err}";
         }
@@ -687,19 +687,30 @@ public sealed class DeviceManager : BackgroundService
     /// on purpose: they follow the mixer's monitor-output selection (synced
     /// every sweep), which the profile's mixer half restores instead.
     /// </summary>
-    public string? ApplyProfile(DeviceState p)
+    /// <summary>
+    /// Write a saved state to the device. <paramref name="restoring"/> marks
+    /// the settings a device that forgets its own is being given back on
+    /// connect, which includes its gain even when the gain lock is set: the
+    /// lock is there to keep the gain where the user put it, and refusing to
+    /// restore it leaves the hardware at whatever its firmware powers up
+    /// with, which is the one outcome the lock exists to prevent. A profile
+    /// loaded by hand is a change like any other and the lock still refuses.
+    /// </summary>
+    public string? ApplyProfile(DeviceState p, bool restoring = false)
     {
         lock (_gate)
         {
             if (_device is null || !_device.Connected) return "no device connected";
             DeviceState s = _last ?? Stamp(_device.ReadState());
             DeviceCapabilities c = _device.Capabilities;
-            bool gainBlocked = GainIsLocked &&
+            bool lockApplies = GainIsLocked && !restoring;
+            bool gainBlocked = lockApplies &&
                 (c.Gain && s.GainDb != p.GainDb ||
                  c.Gain && c.XlrInputs > 1 && s.Gain2Db != p.Gain2Db);
+            bool gainRestored = GainIsLocked && restoring && c.Gain && s.GainDb != p.GainDb;
             try
             {
-                if (c.Gain && !GainIsLocked && s.GainDb != p.GainDb) _device.SetGainDb(p.GainDb);
+                if (c.Gain && !lockApplies && s.GainDb != p.GainDb) _device.SetGainDb(p.GainDb);
                 if (c.Mute && s.Mute != p.Mute) _device.SetMute(p.Mute);
                 if (c.LowCut && s.LowCut != p.LowCut) _device.SetLowCut(p.LowCut);
                 if (c.Expander && s.Expander != p.Expander) _device.SetExpander(p.Expander);
@@ -708,7 +719,7 @@ public sealed class DeviceManager : BackgroundService
                 if (c.Phantom && s.Phantom != p.Phantom) { _device.SetPhantom(p.Phantom); _phantomWroteAt = DateTime.UtcNow; }
                 if (c.ClipGuard && s.ClipGuard != p.ClipGuard) _device.SetClipGuard(p.ClipGuard);
                 if (c.Compressor && s.Compressor != p.Compressor) _device.SetCompressor(p.Compressor);
-                if (c.Gain && c.XlrInputs > 1 && !GainIsLocked && s.Gain2Db != p.Gain2Db) _device.SetGain2Db(p.Gain2Db);
+                if (c.Gain && c.XlrInputs > 1 && !lockApplies && s.Gain2Db != p.Gain2Db) _device.SetGain2Db(p.Gain2Db);
                 if (c.Mute && c.XlrInputs > 1 && s.Mute2 != p.Mute2) _device.SetMute2(p.Mute2);
                 if (c.LowCut && c.XlrInputs > 1 && s.LowCut2 != p.LowCut2) _device.SetLowCut2(p.LowCut2);
                 if (c.Expander && c.XlrInputs > 1 && s.Expander2 != p.Expander2) _device.SetExpander2(p.Expander2);
@@ -734,6 +745,7 @@ public sealed class DeviceManager : BackgroundService
             // Not an error: the profile loaded and the state was broadcast.
             // The lock is visible to every client in the state itself.
             if (gainBlocked) _log.LogInformation("profile loaded; gain left unchanged because the gain lock is active");
+            if (gainRestored) _log.LogInformation("gain restored to {db} dB; the lock keeps it there rather than at the firmware's own", p.GainDb);
             return null;
         }
     }

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -281,11 +281,11 @@ public sealed class WebSocketHub
     /// block the mixer scene (and the other way round). The mixer half is
     /// skipped when this run has no submixer. Null on success.
     /// </summary>
-    private string? ApplyNamedProfile(string devId, string name)
+    private string? ApplyNamedProfile(string devId, string name, bool restoring = false)
     {
         OpenXLR.Core.Profile? p = OpenXLR.Core.ProfileStore.Load(devId, name);
         if (p is null) return $"no profile named '{name}'";
-        string? devErr = p.Device is null ? null : _devices.ApplyProfile(p.Device);
+        string? devErr = p.Device is null ? null : _devices.ApplyProfile(p.Device, restoring);
         string? mixErr = p.Mixer is null || !_mixer.SubmixerEnabled ? null : _mixer.ApplyScene(p.Mixer);
         if (devErr is null && mixErr is null) _activeProfile[devId] = name;
         return devErr ?? mixErr;
@@ -342,7 +342,9 @@ public sealed class WebSocketHub
         while (_mixer.SubmixerEnabled && !_mixer.Built && Environment.TickCount64 < deadline && !_stopping.IsCancellationRequested)
             await Task.Delay(250, _stopping).ContinueWith(_ => { }, TaskScheduler.Default);
         if (_stopping.IsCancellationRequested || ActiveDeviceId() != devId) { _devices.MarkRestored(); return; }
-        string? err = ApplyNamedProfile(devId, name);
+        // The device just connected and is being given its settings back,
+        // gain included: see ApplyProfile.
+        string? err = ApplyNamedProfile(devId, name, restoring: true);
         _devices.MarkRestored();
         if (err is null) _log.LogInformation("recalled profile '{name}' on connect of {dev}", name, devId);
         else _log.LogWarning("recall of profile '{name}' on connect of {dev}: {err}", name, devId, err);

--- a/src/OpenXLR.Tests/GainLockRestoreTests.cs
+++ b/src/OpenXLR.Tests/GainLockRestoreTests.cs
@@ -1,0 +1,124 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
+using OpenXLR.Core;
+using OpenXLR.Core.Devices;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+// The manager keeps gain locks and last settings under the configuration
+// directory, which these tests redirect.
+[Collection("xdg-config")]
+public sealed class GainLockRestoreTests
+{
+    /// <summary>
+    /// A dock that forgets its settings when it loses power: it comes back at
+    /// the gain its firmware chooses, whatever it was set to before.
+    /// </summary>
+    private sealed class ForgetfulDock : IAudioDevice
+    {
+        public int FirmwareGainDb = 43;
+        public readonly List<int> GainWrites = [];
+        public void Dispose() { }
+        public DeviceInfo Info { get; } = new("Elgato", "XLR Dock", 0x0fd9, 0x00a6);
+        public DeviceCapabilities Capabilities { get; } = new() { Gain = true, Mute = true, Phantom = true, RetainsSettings = false };
+        public bool Connected { get; private set; }
+        public void Connect() => Connected = true;
+        public void Disconnect() => Connected = false;
+        public DeviceState ReadState() => new() { GainDb = FirmwareGainDb };
+        public void SetGainDb(int db) { GainWrites.Add(db); FirmwareGainDb = db; }
+        public void SetMute(bool on) { } public void SetLowCut(bool on) { }
+        public void SetExpander(bool on) { } public void SetVoiceTune(bool on) { } public void SetVoiceTuneStrength(int v) { }
+        public void SetHpVolumeDb(double db) { } public void SetLowImpedance(bool on) { } public void SetCrossfade(int v) { }
+        public void SetPhantom(bool on) { } public void SetClipGuard(bool on) { } public void SetCompressor(bool on) { }
+    }
+
+    private static void WithConfigDir(Action<string> body)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "openxlr-test-" + Guid.NewGuid().ToString("N"));
+        string? previous = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", dir);
+        try { body(dir); }
+        finally
+        {
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", previous);
+            try { Directory.Delete(dir, recursive: true); } catch (IOException) { }
+        }
+    }
+
+    private static DeviceManager Connected(ForgetfulDock dock)
+    {
+        var manager = new DeviceManager(NullLogger<DeviceManager>.Instance,
+            new ConfigurationBuilder().Build(), () => [dock]);
+        manager.SweepOnce();
+        return manager;
+    }
+
+    [Fact]
+    public void TheLockedGainIsGivenBackToADockThatForgotIt()
+    {
+        WithConfigDir(_ =>
+        {
+            // What the user set and locked, saved as the last settings seen.
+            DeviceStateStore.SaveLast("0fd9:00a6", new DeviceState { GainDb = 55 });
+            var dock = new ForgetfulDock();          // powers up at 43 dB
+            DeviceManager manager = Connected(dock);
+            Assert.Null(manager.Apply("gainLock", JsonDocument.Parse("true").RootElement));
+
+            string? status = manager.RestoreLastState();
+
+            Assert.NotNull(status);
+            Assert.Equal([55], dock.GainWrites);      // the lock did not eat the restore
+            Assert.Equal(55, manager.Snapshot().State!.GainDb);
+        });
+    }
+
+    [Fact]
+    public void TheLockStillRefusesAGainChangeFromAClient()
+    {
+        WithConfigDir(_ =>
+        {
+            var dock = new ForgetfulDock { FirmwareGainDb = 55 };
+            DeviceManager manager = Connected(dock);
+            Assert.Null(manager.Apply("gainLock", JsonDocument.Parse("true").RootElement));
+
+            string? error = manager.Apply("gain", JsonDocument.Parse("20").RootElement);
+
+            Assert.Equal("gain is locked", error);
+            Assert.Empty(dock.GainWrites);
+            Assert.Equal(55, manager.Snapshot().State!.GainDb);
+        });
+    }
+
+    [Fact]
+    public void AProfileLoadedByHandStillLeavesALockedGainAlone()
+    {
+        WithConfigDir(_ =>
+        {
+            var dock = new ForgetfulDock { FirmwareGainDb = 55 };
+            DeviceManager manager = Connected(dock);
+            Assert.Null(manager.Apply("gainLock", JsonDocument.Parse("true").RootElement));
+
+            Assert.Null(manager.ApplyProfile(new DeviceState { GainDb = 20 }));
+
+            Assert.Empty(dock.GainWrites);
+            Assert.Equal(55, manager.Snapshot().State!.GainDb);
+        });
+    }
+
+    [Fact]
+    public void WithoutTheLockNothingAboutRestoringChanges()
+    {
+        WithConfigDir(_ =>
+        {
+            DeviceStateStore.SaveLast("0fd9:00a6", new DeviceState { GainDb = 55 });
+            var dock = new ForgetfulDock();
+            DeviceManager manager = Connected(dock);
+
+            manager.RestoreLastState();
+
+            Assert.Equal([55], dock.GainWrites);
+        });
+    }
+}


### PR DESCRIPTION
Reported as two symptoms: after a reboot the gain reads 43 dB instead of the configured 55, and there is no microphone input at all, with replugging no help. Diagnosed from the reporter's diagnostics archive; both symptoms have one cause.

## What happens

An XLR Dock keeps no settings, so the daemon writes its last state, or its recall-on-connect profile, whenever it connects. The gain lock made that skip the gain, and the log said so:

```
recalled profile 'Carina' on connect of 0fd9:00a6
profile loaded; gain left unchanged because the gain lock is active
```

So the dock stayed at the 43 dB its firmware powers up with, while the window, the profile and the saved state all said 55. Every replug ran the same sequence.

## Why that silences the microphone

Her chain starts with an LSP gate whose threshold sits near -25 dBFS, tuned at the gain she meant to have. I rebuilt her exact chain, low cut, gate, compressor, with her own parameter values, and fed it a tone:

| input | output |
|---|---|
| -23.0 dBFS, a microphone at 55 dB gain | -25.5 dBFS, passes |
| -35.1 dBFS, the same at 43 dB gain | silence |

A gate that never opens is not a quiet microphone, it is a dead one, which is exactly what was reported.

## The fix

The lock is there to keep the gain where the user put it. Refusing to restore it produced the one outcome it exists to prevent. Settings a device is given back on connect are now written whole, gain included, whether or not the lock is on. Everything else about the lock is unchanged: a client setting the gain is still refused, and so is a profile loaded by hand.

Four regression tests at the DeviceManager seam, with a fake dock that powers up at 43 dB. The first one fails against the old rule (`Expected: [55], Actual: []`) and passes with the fix. 298 tests pass.

Documented in the gain lock's description, the hardware support table, and a troubleshooting entry for a microphone that is silent only after a reboot.