### PR TITLE
Docs: revise guides for current mixer and plugin support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,15 +44,24 @@ tools/check-version.sh
 tools/check-locked-restore.sh
 tools/check-openapi.py docs/openapi-v1.json
 tools/check-spec.py packaging/rpm/openxlr.spec
-make -C native  # the plugin host; needs a C and C++ compiler and the PipeWire, lilv, LV2 and X11 headers
+make -C native  # C/C++, PipeWire, lilv, LV2 and X11 development headers
+xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
 ```
 
-CI runs exactly these; the build treats warnings as errors, so a build
+These cover the main CI build and tests; the workflow also checks packaged
+service inputs. The build treats warnings as errors, so a build
 counts as clean only with `0 Error(s)` and `0 Warning(s)`.
 After a package change, regenerate the lock files with a plain
 `dotnet restore src/OpenXLR.slnx` and the Nix dependency list with
 `nix build .#openxlr.passthru.fetch-deps -o /tmp/fd && /tmp/fd packaging/nix/deps.json`,
 and commit both.
+
+The native-enabled application build uses `-p:EnableNativeLv2Host=true`.
+Keep that flag when rebuilding a local installation that uses CLAP, VST3
+or native LV2 editors. Desktop acceptance checks must include plugin
+controls, resizing, moving and reopening editors; Xvfb tests do not replace
+those checks. The optional Windows bridge has a separate artifact workflow
+and [package checks](packaging/yabridge/README.md).
 
 ## Where things are
 
@@ -64,7 +73,8 @@ and commit both.
   the two files both need are compiled in as linked sources.
 - `plugin/com.emaspa.openxlr.sdPlugin`: the OpenDeck plugin
   (`plugin.mjs`) and its property inspectors; tests in `plugin/tests`.
-- `packaging/`: unit, udev rule, WirePlumber rules, RPM spec, Nix,
+- `native/`: C/C++ LV2, CLAP and VST3 host, editor regression tests.
+- `packaging/`: optional yabridge companion, unit, udev rule, WirePlumber rules, RPM spec, Nix,
   PPA script; `debian/` for the .deb.
 
 ## Rules the code already follows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ tools/check-version.sh                          # the five version locations agr
 tools/check-locked-restore.sh                   # every packaging path restores locked
 tools/check-openapi.py docs/openapi-v1.json     # the HTTP API document keeps its shape
 tools/check-spec.py packaging/rpm/openxlr.spec  # every installed file is in %files
-make -C native  # the plugin host; needs a C and C++ compiler and the PipeWire, lilv, LV2 and X11 headers
+make -C native  # C/C++, PipeWire, lilv, LV2 and X11 development headers
+xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
 ```
 
 If you add or change a NuGet package, regenerate the lock files with a
@@ -53,6 +54,13 @@ commit across all five files.
 Real hardware is the final test. Say in the pull request what you ran
 it on, or that you could not; the maintainer tests on a Wave XLR Pro
 and both XLR Dock modules before merging.
+
+The native-enabled application build uses `-p:EnableNativeLv2Host=true`.
+Keep that flag when rebuilding a local installation that uses CLAP, VST3
+or native LV2 editors. Desktop acceptance checks must include plugin
+controls, resizing, moving and reopening editors; Xvfb tests do not replace
+those checks. The optional Windows bridge has a separate artifact workflow
+and [package checks](packaging/yabridge/README.md).
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Buy me a coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-emaspa-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/emaspa)
 [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/emaspa)
 
-Native Linux control suite for Elgato XLR interfaces: full hardware
+Native Linux control suite for Elgato XLR interfaces: hardware
 control over reverse-engineered USB protocols, a Wave Link style
 PipeWire submixer with per-application channels, virtual microphones,
 LV2, CLAP and VST3 plugin inserts, multi-output monitoring, a dedicated mix for a
@@ -20,11 +20,15 @@ Deck control.
 
 ![OpenXLR mixer](docs/screenshot-mixer-0125.png)
 
+Mixer screenshot from 0.1.25. This README and the linked guides describe
+current `main`; for a released build, read the docs at its release tag.
+Changes merged after a release are available from source until the next release.
+
 Elgato ships no Linux software. These devices enumerate as
 class-compliant USB audio interfaces, so audio flows out of the box.
-Gain, DSP, phantom power, output routing and the hardware mixer only
-answer to vendor protocols, which this project reverse engineered from
-USB captures of Wave Link and reimplemented from scratch.
+Controls beyond standard USB audio use device-specific protocols, decoded
+from Wave Link USB captures and prior open-source protocol work. OpenXLR
+uses those mappings alongside ALSA controls where available.
 
 Not affiliated with or endorsed by Elgato. Built by protocol analysis on
 the author's own hardware.
@@ -33,13 +37,13 @@ the author's own hardware.
 
 | Device | USB id | Status |
 |---|---|---|
-| Wave XLR Pro | 0fd9:00b4 | full support, verified on hardware |
+| Wave XLR Pro | 0fd9:00b4 | mapped controls verified on hardware; hardware EQ and the full mix matrix remain unmapped |
 | XLR Dock (Stream Deck+ module) | 0fd9:00a6 | gain, mute, headphone volume, 48V phantom power, low impedance; verified on hardware |
-| Wave XLR | 0fd9:007d | gain, mute, headphone volume, low impedance, 48V phantom power; verified on hardware by community testers |
+| Wave XLR | 0fd9:007d | gain, mute, headphone volume and low impedance verified by community testers; phantom power implemented, awaiting an OpenXLR hardware check |
 | Wave XLR MK.2 | 0fd9:00b6 | gain, mute, phantom power, DSP, ClipGuard, compressor, headphone volume, crossfade; verified on hardware by a community tester |
-| XLR Dock MK.2 (Stream Deck+ module) | 0fd9:00c7 | same controls as the Wave XLR MK.2; every control verified on hardware |
+| XLR Dock MK.2 (Stream Deck+ module) | 0fd9:00c7 | same exposed controls as the Wave XLR MK.2, verified on hardware |
 
-The UI shows only the controls the connected device has, and a picker
+The UI shows the controls OpenXLR exposes for the connected device, and a picker
 in the header switches between several attached interfaces. The
 per-control state of every device is in
 [docs/hardware-support.md](docs/hardware-support.md). Own an untested
@@ -54,8 +58,11 @@ Collect diagnostics).
   volumes with low-impedance mode, the mic/PC crossfade, and the
   physical output routing (HP1, HP2, Line Out, USB Aux). The other
   devices expose the subset their protocol has; see the table above.
-  Devices without onboard DSP get a software low cut, ClipGuard and
-  gain lock in the PipeWire layer instead.
+  Where a hardware low cut or ClipGuard control is unavailable, OpenXLR
+  offers software processing in PipeWire. Gain lock is a daemon policy
+  for devices without physical gain controls. Hardware EQ, ducking, mix
+  maximizer and channel booster are not exposed; plugin effects run on
+  the computer, separate from the device's onboard processing.
 - **Submixer** built from PipeWire nodes (null sinks, remap sources,
   filter chains), no kernel modules. Channels for the hardware inputs
   and for application groups; mixes for what you hear (Monitor A and
@@ -67,19 +74,23 @@ Collect diagnostics).
   window or the API. Per-send levels and mutes, level meters, the
   monitor mixes on several outputs at once.
 - **Inserts**: LV2, CLAP and VST3 plugin chains on each XLR input and each mix, with a
-  plugin picker, generated control windows and bypass LEDs.
+  plugin picker, generated controls, bypass and native plugin editors.
+  Windows VST3 and CLAP plugins use Wine and yabridge; an optional
+  OpenXLR companion supplies the Wine editor input fix and private wrappers.
 - **Application routing**: audio clients are detected from their
   PipeWire registration and routed to a channel by name rules, with the
   assignment remembered per app; an app can also be left to the
   desktop's own routing. Electron apps are identified by their process
-  binary rather than the "Chromium" name they report.
+  binary rather than the "Chromium" name they report. Missing stream
+  metadata falls back to the owning client, and Windows executable names
+  share an identity with their Wine/Proton client so saved routing persists.
 - **Profiles**: named scenes holding the hardware settings and the
   whole submix (levels, mutes, outputs, insert chains), saved per device
   and recalled from the UI, the API or a Stream Deck key. One profile
   per device can be recalled on connect, so an interface comes up in a
-  known scene at login or after a power cycle. Interfaces without
-  settings memory (Wave XLR, the first XLR Dock) come back as they
-  were left even without a profile, with a reset to firmware defaults.
+  known scene at login or after a power cycle. OpenXLR also restores the
+  last settings on the original Wave XLR and first XLR Dock without a
+  profile, with a reset to the defaults recorded after a power cycle.
 - **OpenDeck plugin**: key and dial actions for every switch, mute,
   level and insert, rendered with level meters and status LEDs. It is a
   client of the daemon's API, so it reflects changes made in the UI or
@@ -87,8 +98,9 @@ Collect diagnostics).
 - **Daemon and UI**: the daemon owns the device and the graph, keeps
   running with the window closed, re-asserts the chosen default sink
   and source once a second, and serves a WebSocket API and a versioned
-  HTTP API (`/api/v1`) on 127.0.0.1:37890. The UI has a routing graph
-  view, a tray icon and a diagnostics archive exporter.
+  HTTP API (`/api/v1`) on 127.0.0.1:37890. The UI has a Flow window with
+  selectable signal paths through inputs, channels, mixes and outputs,
+  a tray icon and a diagnostics archive exporter.
 - **Optional update notice**: the UI can check the upstream GitHub release
   feed for a newer stable release. Startup checks are off by default and,
   when enabled, run at most once per day. Nothing is installed automatically.
@@ -158,49 +170,65 @@ run `sudo dnf install ./openxlr-*.x86_64.rpm`.
 enables the daemon itself; after a rebuild, `openxlr` is in the
 application menu.
 
+Add `inputs.openxlr.url = "github:emaspa/openxlr";` to your system flake,
+then include these entries in its `nixosSystem.modules` list:
+
 ```nix
-{
-  inputs.openxlr.url = "github:emaspa/openxlr";
-  # in your NixOS configuration:
-  imports = [ openxlr.nixosModules.default ];
-  services.openxlr.enable = true;
-}
+openxlr.nixosModules.default
+{ services.openxlr.enable = true; }
 ```
+
+Here `openxlr` is the input passed to the flake's `outputs` function. The
+[module options](packaging/nix/module.nix) configure LV2 plugins, software
+ClipGuard and the optional Windows bridge.
 
 On every distribution, replug the interface once after installing so
 the udev rule applies. For the Stream Deck, install
 `com.emaspa.openxlr.sdPlugin.zip` from the release with OpenDeck's
 install-from-file, or copy the folder the package puts in
 `/usr/share/openxlr/` into `~/.config/opendeck/plugins/`. Inserts show
-whatever LV2 plugins are installed (`lsp-plugins-lv2` is the set used
+compatible LV2, CLAP and VST3 plugins (`lsp-plugins-lv2` is the set used
 during development); the software ClipGuard for the XLR Dock needs
 `swh-plugins`. The NixOS module wires both up itself. The packages also
 raise pipewire-pulse's open-file limit with a systemd drop-in, which
 applies at the next login or after `systemctl --user restart
 pipewire-pulse`; a source install needs the same file before growing the
-layout ([manual, section 5.8](docs/manual.md#open-files)).
+layout ([manual: open-file limit](docs/manual.md#open-files)).
 
 ### Build from source
 
-Needs the .NET 10 SDK, PipeWire with its CLI tools, libusb, and lilv
-(package names per distribution in
-[docs/install-from-source.md](docs/install-from-source.md)).
+Needs the .NET 10 SDK, PipeWire tools, libusb, lilv, a C/C++ compiler
+and the native host's development headers. Install the prerequisites in
+[the source guide](docs/install-from-source.md) first. From the repository root:
 
 ```sh
 git clone https://github.com/emaspa/openxlr.git
-cd openxlr/src
-dotnet build -c Release
-OPENXLR_BUILD_MIXER=1 ./OpenXLR.Daemon/bin/Release/net10.0/OpenXLR.Daemon   # terminal 1
-./OpenXLR.UI/bin/Release/net10.0/OpenXLR.UI                                 # terminal 2
+cd openxlr
+dotnet restore src/OpenXLR.slnx --locked-mode
+dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror -p:EnableNativeLv2Host=true
+OPENXLR_BUILD_MIXER=1 ./src/OpenXLR.Daemon/bin/Release/net10.0/OpenXLR.Daemon
 ```
 
-Device access needs the udev rule from `packaging/70-openxlr.rules`
-installed under `/etc/udev/rules.d/` and a replug. The XLR Dock also
-needs the WirePlumber rule from `packaging/`. Running the daemon as a
-user service, updating and uninstalling:
-[docs/install-from-source.md](docs/install-from-source.md).
+In a second terminal, from the same repository root:
+
+```sh
+./src/OpenXLR.UI/bin/Release/net10.0/OpenXLR.UI
+```
+
+Device access needs the tracked udev rule and a replug. The source guide
+also covers WirePlumber rules, the open-file limit, the user service,
+updating and uninstalling. Keep the native build flag on subsequent builds
+to retain CLAP, VST3 and plugin editors.
+
+For Windows plugins, see [the manual](docs/manual.md#windows-plugins) and
+[the companion package guide](packaging/yabridge/README.md). The companion
+has a separate build workflow; its CI artifacts are not automatically
+published to the OpenXLR release or distribution repositories.
 
 ## Documentation
+
+[Documentation index](docs/README.md): user guides, developer references and
+historical protocol research.
 
 - [Manual](docs/manual.md): first run, the concepts behind the mixer,
   step-by-step tasks, the Stream Deck plugin, troubleshooting

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -9,6 +9,7 @@ After installing:
 
 Stream Deck control via OpenDeck:
 
+    mkdir -p ~/.config/opendeck/plugins
     cp -r /usr/share/openxlr/com.emaspa.openxlr.sdPlugin \
         ~/.config/opendeck/plugins/
 
@@ -18,6 +19,13 @@ standard LADSPA path. Without that optional package the ClipGuard control
 is disabled; all other controls and the existing microphone route continue
 to work.
 
-Inserts (per-channel and per-mix plugin chains) offer whatever LV2
-plugins are installed in /usr/lib/lv2 or ~/.lv2; lsp-plugins-lv2 is a
-good first set.
+Inserts on XLR inputs and mixes support LV2, CLAP and VST3. The package
+includes the native helper for CLAP/VST3 and plugin editors. Install
+compatible plugins separately; lsp-plugins-lv2 supplies LV2 effects.
+Windows VST3/CLAP additionally need Wine and yabridge. The optional
+openxlr-yabridge companion has a separate build/artifact workflow and
+private wrappers; it is not automatically installed with openxlr.
+
+Manual and bridge setup:
+https://github.com/emaspa/openxlr/blob/main/docs/manual.md#windows-plugins
+For matching release documentation, select the installed version's tag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# Documentation
+
+These guides describe the code on `main`. For a released package, select
+its tag on GitHub to read matching documentation. The app's Manual links
+open `main`, so they can describe changes newer than the installed release.
+
+## Using OpenXLR
+
+- [Project README](../README.md): supported devices, packages and quick start.
+- [Manual](manual.md): mixer tasks, application routing, plugins, profiles,
+  Flow, Stream Deck, troubleshooting and local files.
+- [Features](features.md): supported behaviour by area.
+- [Hardware support](hardware-support.md): mapped controls, verification
+  records and unmapped hardware features.
+- [Source installation](install-from-source.md): prerequisites, native build,
+  service setup, updates, uninstall and environment variables.
+- [Windows bridge](../packaging/yabridge/README.md): companion availability,
+  private wrappers, package builds and rollback.
+- [Experimental UCM profile](../packaging/ucm/README.md): optional Pro channel
+  split outside the submixer.
+- [OpenDeck patch](../packaging/opendeck-patches/README.md): optional key-image
+  quality improvement for the older host version.
+
+## Developing and integrating
+
+- [Contributing](../CONTRIBUTING.md) and [agent instructions](../AGENTS.md).
+- [Roadmap](roadmap.md): implemented work and remaining priorities.
+- [Architecture](architecture.md) and [source orientation](../src/README.md).
+- [WebSocket API and state](api.md), [HTTP API](http-api.md),
+  [OpenAPI document](openapi-v1.json) and [saved mixer layout](mixer-layout.md).
+- [Native plugin host](../native/README.md): backend contracts, editor
+  behaviour, tracing and regression checks.
+
+## Protocol evidence and historical research
+
+These records retain dated observations and provisional labels. Use the
+hardware support table for current support claims.
+
+- [USB capture guide](usb-capture.md): new captures for unmapped MK.1 controls.
+- [Pro protocol notebook](wave-xlr-pro-protocol.md): chronological captures
+  and corrections; later verified mappings supersede early guesses.
+- [Pro capture plan](wave-xlr-pro-capture-plan.md): completed capture procedure.
+- [Linux audio research](wave-xlr-linux-audio-stack-research.md): August 2026
+  survey and original design decisions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ port alone does not hand them the mixer. The window and the OpenDeck
 plugin read the file themselves; a script does the same:
 
 ```sh
-TOKEN=$(cat "${XDG_RUNTIME_DIR:-$HOME/.config}/openxlr/token")
+TOKEN=$(cat "${XDG_RUNTIME_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}}/openxlr/token")
 printf '{"cmd":"auth","token":"%s"}\n{"cmd":"getState"}\n' "$TOKEN" | websocat ws://127.0.0.1:37890/ws
 ```
 
@@ -47,8 +47,9 @@ Messages from the daemon, each a JSON object with a `type` field:
 | Type | When | Content |
 |---|---|---|
 | `state` | on connect and on every change | `daemonVersion`, device state, capabilities, mixer state, the device list, the app registry, profile names, `activeProfile` (the profile last recalled or saved for the active device; not cleared by later manual changes), `recallOnConnect` (the profile recalled when the device connects, or null), `warning` (one sentence the user should see, or null: mixer settings that cannot be written to disk, which the daemon keeps retrying with backoff, or a device set aside after three hung USB transfers in one run). In the mixer state, each channel carries `hardware` (true for the fixed input channels), `renamedSinceStart` says a virtual microphone was renamed since the daemon started (its PipeWire device keeps the old name until a restart), and `layoutWarning` is a sentence for the layout editor when pipewire-pulse nears its open-file limit, or null |
+| `diagnostics` | in answer to `getDiagnostics` | `blocks`, mapping vendor block names to hex strings or read errors |
 | `meters` | 15 Hz while the mixer is built | live stereo levels per channel and mix |
-| `plugins` | in answer to `listPlugins` | the installed LV2 plugins with their controls; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
+| `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, `windowsDirectories` (the folders yabridge bridges) and `wineFolders` (Wine's own plugin folders that hold a plugin and are not bridged yet, offered as one press since a file dialog hides them) |
 | `pluginInstall` | in answer to `installPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
 | `error` | when a command without a `requestId` is rejected | `message` |
@@ -83,14 +84,14 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setMonitorFeed` | `device`, `mix` | what feeds one selected output: `monitor` (Monitor A), `monitor2` (Monitor B), or both summed as `monitor+monitor2` (Monitor A+B); the Pro's own jacks follow one feed together. The state's `monitorFeeds` lists the exceptions from the first mix in the same form. An error when the feed names anything but distinct monitor mixes, or the output is not selected |
 | `setAuxPortEnabled` | `value` | send the Aux mix to the USB Aux port |
 | `setOutputVolume` | `value` | volume of the selected monitor devices |
-| `listPlugins` | none | the installed LV2 plugins, answered with a `plugins` message |
+| `listPlugins` | none | the installed LV2, CLAP and VST3 plugins, answered with a `plugins` message |
 | `getPluginSetup` | none | where plugins are installed and what bridges Windows ones, answered with a `pluginSetup` message |
 | `installPlugin` | `path` | install what is at an absolute path the user picked: a `.clap` or single-file `.vst3` is copied into `~/.clap` or `~/.vst3`, a `.vst3` or `.lv2` directory into `~/.vst3` or `~/.lv2`, a plain directory installs every plugin inside it, and a Windows VST3 or CLAP plugin has its directory added to yabridge and synced. Archives, installers and VST2 files are refused with a message that says what to do. The catalogues are read again before the `pluginInstall` answer |
 | `syncWindowsPlugins` | none | run yabridge's sync over the folders it knows, then read the catalogues again; answered with `pluginInstall` |
 | `rescanPlugins` | none | read the plugin directories again, for plugins installed by other means; answered with `pluginInstall` |
 | `setInserts` | `channel`, `inserts[]` | replace a chain; `channel` is `xlr1`, `xlr2` or `mix:<id>`, each insert is `{id, kind, plugin, label?, bypass?, params?}` where `kind` is `"lv2"` with the plugin URI, `"clap"` with the plugin's id, or `"vst3"` with the class id as 32 hex digits; a CLAP or VST3 insert always runs in the native host, so its `nativeHost` reads true whatever was sent |
 | `setInsertBypass` | `channel`, `insertId`, `value` | bypass one insert |
-| `setInsertParam` | `channel`, `insertId`, `symbol`, `value` | one plugin control, by its LV2 port symbol |
+| `setInsertParam` | `channel`, `insertId`, `symbol`, `value` | one plugin control, by the catalogue's `symbol` (LV2 port symbol or decimal CLAP/VST3 parameter id); use catalogue ranges and scale points |
 | `showInsertUi` | `channel`, `insertId` | open an enabled insert's native editor when the optional host is installed |
 | `assignApp` | `identity`, `channel`, `label?` | route an app (creates a registry entry if unseen); `channel: "ignore"` stops managing it, its streams go back to the system default output and stay wherever the desktop routes them |
 | `assignStream` | `streamId`, `channel` | route one live stream by its PipeWire id; also remembered for the app; `ignore` works here too |
@@ -99,7 +100,7 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setActiveDevice` | `device` | switch to another attached interface (`vvvv:pppp`) |
 | `saveProfile` / `loadProfile` / `deleteProfile` | `name` | named scenes, scoped to the active device |
 | `setRecallOnConnect` | `name` | the profile recalled whenever the active device connects fresh (daemon start, replug, switch to it); empty clears it. With none chosen, a device whose capabilities say `retainsSettings: false` gets the last settings the daemon saw on it instead |
-| `resetDevice` | none | write the firmware defaults back to a device without settings memory and forget its last settings (an error until the daemon has seen the device connect after a power cycle once); on the Wave XLR Pro, which keeps its own settings, write OpenXLR's baseline instead: gain 30 dB on both inputs, every processing stage and phantom off, headphones and aux level at half, the crossfade fully on PC, routing untouched, refused while the gain lock is on. The capabilities say `builtInDefaults` when a model has a baseline |
+| `resetDevice` | none | write the recorded defaults back to a device using connect-time restoration and forget its last settings (an error until the daemon has seen the device connect after a power cycle once); on the Wave XLR Pro, which keeps its own settings, write OpenXLR's baseline instead: gain 30 dB on both inputs, every processing stage and phantom off, headphones and aux level at half, the crossfade fully on PC, routing untouched, refused while the gain lock is on. The capabilities say `builtInDefaults` when a model has a baseline |
 | `getDiagnostics` | none | vendor block dump for bug reports |
 
 Application identities use playback-node metadata, falling back to the
@@ -112,13 +113,17 @@ loading conflicting old and normalized overrides, the normalized key wins.
 `pluginSetup` also reports `bridgeProvider` (`openxlr` or `system`),
 `bridgeDirectory` (the selected companion directory, or null), and
 `windowsPluginDirectory` (OpenXLR's private wrapper root, or null).
+`wine` is a boolean; `wineVersion` is a string or null. `windowsEditorNote`
+is a user-facing compatibility message or null. With provider `openxlr`,
+`yabridge` is the companion package version.
 The `openxlr` provider includes the pinned Wine input fix. Its directory
 registry and generated wrappers are separate from the system controller.
 
-Insert definitions optionally carry `nativeHost: true` to select the native
-LV2 helper for that insert. Missing or false keeps PipeWire filter-chain, even
+LV2 insert definitions optionally carry `nativeHost: true` to select the native
+helper for that insert. Missing or false keeps LV2 in PipeWire filter-chain, even
 when the helper is installed. Unsupported native selections are rejected.
 Changing this choice via `setInserts` rebuilds the chain and can interrupt audio.
+Only exposed parameter values are persisted, not opaque plugin state or presets.
 
 The OpenDeck plugin in `plugin/` is a client of this API; the command
 handler is `WebSocketHub.cs` and the message shapes are in
@@ -135,8 +140,8 @@ All under `~/.config/openxlr/` (or `$XDG_CONFIG_HOME/openxlr/`):
 - `profiles/<vid-pid>/<name>.json`: the named scenes, one file each
 - `profiles/<vid-pid>/recall-on-connect`: the name of the profile
   recalled when that device connects, when one is chosen
-- `devices/<vid-pid>/last-state.json`: for a device without settings
-  memory, the hardware settings the daemon last saw, written a second
+- `devices/<vid-pid>/last-state.json`: for a device using connect-time
+  restoration (`retainsSettings: false`), the hardware settings the daemon last saw, written a second
   after a change and restored on every fresh connect
 - `devices/<vid-pid>/defaults.json`: the settings such a device answered
   with after a power cycle, what `resetDevice` writes back
@@ -151,5 +156,8 @@ All under `~/.config/openxlr/` (or `$XDG_CONFIG_HOME/openxlr/`):
   `submixer` (true/false/absent) turns the submixer on or off; absent
   means the unit's environment decides (`OPENXLR_BUILD_MIXER`). Written
   by the UI's Options window.
+- `bridge/yabridgectl/config.toml`: the managed companion's folder registry,
+  separate from the system yabridgectl configuration. Private wrappers live
+  under `$XDG_DATA_HOME/openxlr/yabridge` (default `~/.local/share/openxlr/yabridge`).
 - `ui.json`: window preferences (tray, start minimized, autostart
   toggles)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,46 +1,40 @@
 # Architecture
 
-```
-  OpenXLR.UI (Avalonia)   ──┐
-  OpenDeck plugin (Node)  ──┼── WebSocket, JSON, 127.0.0.1:37890 ──►  OpenXLR.Daemon (ASP.NET Core)
-  scripts, tools          ──┘                                          hosts OpenXLR.Core
-                                                                          │
-              ┌───────────────────────────────────────────────────────────┼──────────────────┐
-              │                                                           │                  │
-   libusb control transfers (USB helper process)              amixer (ALSA controls)     lilv (in-process)
-   Wave XLR Pro, Wave XLR MK.2,                               XLR Dock: gain, mute,     LV2 plugin catalog
-   XLR Dock MK.2, Wave XLR (MK.1),                            headphone volume
-   XLR Dock: phantom, low impedance
-                                                                          │
-                                       pactl (modules), pw-link, pw-dump, pw-cli, wpctl, parec
-                                                                          ▼
-                                                                   PipeWire graph
-
-  ~/.config/openxlr: mixer.json, profiles/, devices/, gainlock.json (daemon); daemon.json, ui.json (UI)
-  $XDG_RUNTIME_DIR/openxlr/token: the control API token, one per daemon run
-  $XDG_RUNTIME_DIR/openxlr/daemon.lock: held by the running daemon, one instance per user
+```mermaid
+flowchart TD
+    UI["Avalonia UI / OpenDeck"] -->|"authenticated WebSocket"| Daemon["OpenXLR daemon"]
+    Scripts["Scripts / tools"] -->|"authenticated HTTP or WebSocket"| Daemon
+    Daemon --> Core["Core: device control, mixer, profiles"]
+    Core --> USB["USB helper: libusb vendor transfers"]
+    Core --> ALSA["amixer: first XLR Dock controls"]
+    Core --> Graph["PipeWire modules and port links"]
+    Core --> Catalog["lilv: LV2 catalogue"]
+    Core --> Host["Native helper: LV2, CLAP, VST3"]
+    Host <-->|"audio ports"| Graph
+    Host --> Bridge["Optional yabridge / Wine: Windows plugins"]
 ```
 
-- `OpenXLR.Daemon` owns the device and the graph: it opens the
-  interface, polls its state every 100 ms, builds and maintains the
-  PipeWire graph, routes application streams, and serves the WebSocket
-  API. Every state change is broadcast to all clients, whichever client
-  (or the hardware) caused it. Commands are validated before the mixer
-  sees them (known channel and mix ids, catalogued and supported
-  plugins, declared parameter symbols, bounded strings and lists), each
-  client has a command budget, and a WebSocket handshake with a browser
-  Origin from anywhere but localhost is refused. It is a systemd user
-  service, running workstation GC under a 256 MB hard limit.
-- `OpenXLR.UI` is a view over that API with no dependency on
-  `OpenXLR.Core`: it parses the state JSON and sends commands. Outside
-  the API it only runs `systemctl --user` for the daemon's unit and
-  writes `daemon.json` (the submixer on/off preference the daemon reads
-  at start). It can be closed at any time; the daemon keeps mixing.
-- The OpenDeck plugin is an OpenAction plugin running in OpenDeck's
-  Node runtime, another client of the same API.
-- `OpenXLR.Core` holds the device backends, the mixer engine, the
-  PipeWire adapter and the profile store, shared by the daemon and the
-  probe tool.
+- `OpenXLR.Daemon` owns the device and graph. It polls hardware, maintains
+  the mixer, routes application streams and broadcasts state to clients.
+  The WebSocket endpoints and HTTP API share one dispatcher on
+  `127.0.0.1:37890`. Clients authenticate with a private per-run token;
+  browser Origins, command sizes and rates are checked as well.
+- `OpenXLR.UI` is an Avalonia client with no Core assembly dependency. It
+  parses state and sends commands. It also manages local window preferences,
+  autostart and the daemon service, collects diagnostics, and optionally
+  checks GitHub releases. Closing it leaves audio running. Its Flow window
+  builds a four-column view from state; selecting a path changes only
+  the visualization.
+- The OpenDeck plugin is an OpenAction plugin in OpenDeck's Node runtime,
+  using the same authenticated API and live choices as the window.
+- `OpenXLR.Core` contains device backends, the PipeWire adapter, mixer,
+  application matching, plugin catalogues and profile storage. The native
+  host processes plugin audio without passing samples through managed code.
+
+Configuration lives in `$XDG_CONFIG_HOME/openxlr` (default `~/.config/openxlr`).
+The token and instance lock live in `$XDG_RUNTIME_DIR/openxlr`, falling back
+to the configuration directory when unavailable. See [api.md](api.md) for
+file names and [http-api.md](http-api.md) for transport limits.
 
 ## The PipeWire graph
 
@@ -76,15 +70,17 @@ modules or custom drivers:
   restarts it takes every module with it and reuses their ids, so the
   daemon forgets the graph without unloading anything and exits with
   code 75 for systemd to start it afresh.
-- Filter chains (the software low cut and ClipGuard, and the LV2
-  inserts on inputs and mixes) are `filter-chain` nodes, each held by a
+- Filter chains (the software low cut and ClipGuard, and LV2
+  inserts left on the default backend) are `filter-chain` nodes, each held by a
   long-lived `pw-cli -m` process for the life of the chain; their
   controls are set with `pw-cli set-param`.
-- An insert switched to the native host is not a filter-chain node but
-  an `openxlr-lv2-host` process, one per insert, holding that plugin and
-  its editor behind a PipeWire filter node of its own. The rest of the
-  chain stays filter-chain nodes, linked stage to stage, and the daemon
-  speaks to the helper over a pipe that carries control values only.
+- A native insert runs in an `openxlr-lv2-host` process with a PipeWire
+  filter node. LV2 chooses this per insert; CLAP and VST3 always use it.
+  Stages can mix native and filter-chain backends, linked in signal order.
+  The command pipe carries parameter values, status and editor requests,
+  never audio. Exposed parameters are persisted; opaque plugin state and
+  presets are not. See [native/README.md](../native/README.md) for editor
+  recovery, size constraints and LSP renderer defaults.
 - Direct port links (`pw-link`) wire hardware inputs, chains, mixes and
   outputs, so the output device clocks the chain. Hardware inputs are
   wired by capture-channel pair (XLR 1 = pair 0, XLR 2 = pair 1, Line
@@ -102,10 +98,38 @@ modules or custom drivers:
   desktop applets list them; hardware input channels keep the flag and
   stay hidden.
 
+## Plugin discovery and Windows bridging
+
+LV2 metadata is read through lilv. CLAP and VST3 bundles are described in
+isolated helper processes, with bounded output and a cache invalidated by
+bundle changes. An optional managed bridge also keys that cache by its
+package version, source commit and installation directory.
+
+`ManagedYabridge` selects a complete companion installation, or falls back
+to the system/user bridge. It prepends the companion to PATH only for the
+scanner, host and controller it starts. Plugin processes retain HOME,
+WINEPREFIX and their settings environment. The controller alone receives
+a private configuration root and wrapper destination. Private wrappers
+are searched first and deduplicated by plugin id.
+
+The companion supplies 64-bit yabridge; Wine remains external. Its pinned
+source, package formats and separate artifact workflow are documented in
+[packaging/yabridge](../packaging/yabridge/README.md).
+
+## Application identity
+
+Playback-node metadata takes precedence, with missing application and
+process fields filled from the owning PipeWire client. Electron process
+names and Wine/Proton executable names are normalized before looking up
+routing rules and saved overrides. On loading legacy aliases, an existing
+canonical override wins. Assigning or forgetting an app uses the same key.
+Pre-assignments from desktop launchers remain best-effort when the running
+application reports a different identity.
+
 ## The device protocols
 
-The five devices speak three dialects, all reached without detaching
-the kernel's audio driver:
+The five devices use vendor-block and class-request protocols plus ALSA
+controls, all reached without detaching the kernel's audio driver:
 
 - Wave XLR Pro, Wave XLR MK.2 and XLR Dock MK.2: a vendor block bank
   on the unclaimed interface (`bmRequestType 0x41/0xC1`, `bRequest 1`,
@@ -141,12 +165,14 @@ processes.
 
 ```
 src/            .NET solution: Core (device + mixer), Daemon, UI, Probe, Tests
+native/         optional C/C++ plugin host, vendored interface headers, editor tests
 plugin/         the OpenDeck (Stream Deck) plugin
 docs/           this documentation, protocol write-up, capture guides
 tools/          proprobe.py, a standalone Python probe for the vendor protocol,
                 and the CI checks (versions, locked restores, the OpenAPI
                 document's shape, the rpm recipe's %files)
 packaging/      systemd unit, the pipewire-pulse open-file drop-in, udev rule,
-                WirePlumber rules, UCM profile, rpm and nix packaging, OpenDeck patches
+                WirePlumber rules, UCM profile, rpm and nix packaging, OpenDeck patches,
+                optional yabridge companion source and package recipes
 debian/         Debian/Ubuntu packaging
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -22,6 +22,11 @@ volume, low impedance, crossfade.
 
 Wave XLR: gain, mute, headphone volume, low impedance, phantom power.
 
+Hardware EQ is not mapped on the Wave FX devices. The Pro's ducking, mix
+maximizer, channel booster and remaining hardware mix matrix are also
+unmapped. Wave Link configures those onboard effects on supported systems;
+OpenXLR's LV2, CLAP and VST3 inserts process audio on the Linux host.
+
 XLR Dock: gain, mute and headphone volume through the kernel's standard
 ALSA controls, plus phantom power and headphone low impedance over the
 original Wave XLR's protocol dialect, which the dock also answers. The
@@ -35,7 +40,8 @@ provides them (below).
 
 ## Software controls
 
-For devices without the hardware version, the PipeWire layer provides:
+When the backend has no mapped hardware control, OpenXLR provides:
+
 - Low cut: a high-pass at 80 or 120 Hz (the two values Wave Link
   offers), a filter-chain node inserted between the mic and its channel,
   cycled from a button on the XLR 1 strip. Its response was measured
@@ -56,8 +62,10 @@ For devices without the hardware version, the PipeWire layer provides:
   otherwise come up at whatever gain its firmware chooses, which is the
   one thing the lock is there to prevent.
 
-These controls appear only when the active device lacks the hardware
-version, so a signal is never filtered twice.
+The software low cut and limiter appear when the backend does not expose
+the corresponding hardware control. On the original Wave XLR, hardware
+processing configured in Wave Link can still be active; OpenXLR cannot
+read or disable those unmapped settings.
 
 Two behaviours apply on multi-device switching: the mixer's hardware
 input channels follow the active device, and after a switch the
@@ -112,74 +120,56 @@ devices; the hardware input channels are hidden from it.
 
 ## Inserts
 
-LV2 plugins in the signal path. Each XLR input carries a mono chain and
-every mix a stereo one, the ones you add included. An Inserts row
-under the channel or mix lists what is loaded: a green or red LED for
-active or bypassed, a bypass button, and a gear that opens the plugin's
-controls in their own window. The picker shows every installed LV2
-plugin that fits the slot (mono for inputs, stereo for mixes), grouped
-by category. The controls window is generated from the plugin's port
-descriptions, grouped by parameter family, with a Defaults button.
-Chains are saved with the mixer and recalled by profiles.
+LV2, CLAP and VST3 effects can form a mono chain on each XLR input and a
+stereo chain on every mix, including virtual microphones you add. The
+picker filters by format, name, category and compatible channel width.
+Unsupported host requirements are reported instead of loading a plugin
+that the chosen backend cannot run. VST2 is not supported.
 
-Every chain is a PipeWire filter-chain node, the same mechanism as the
-software low cut and ClipGuard, so plugins run inside PipeWire's graph
-with no extra process, and a chain adds latency only while it holds a
-plugin. Plugins are found in the standard LV2 directories
-(`/usr/lib/lv2`, `~/.lv2`, or wherever `LV2_PATH` points); the daemon
-reads them through lilv. `lsp-plugins-lv2` is the set used during
-development. A plugin that requires a host feature the chain does not
-provide is left out of the picker and refused by the daemon rather than
-failing when the chain is built.
+| Format | Processing host | Discovery |
+|---|---|---|
+| LV2 | PipeWire filter-chain by default; optional native host per insert | lilv, standard LV2 directories or `LV2_PATH` |
+| CLAP | native host, one process per insert | standard CLAP directories or `CLAP_PATH` |
+| VST3 | native host, one process per insert | standard VST3 directories or `VST3_PATH` |
+| Windows VST3 / CLAP | yabridge and Wine behind the native host | bridge-generated Linux wrappers |
 
-CLAP and VST3 plugins are offered in the same picker, found in the
-standard directories (`/usr/lib/clap` and `~/.clap`, `/usr/lib/vst3` and
-`~/.vst3`, or wherever `CLAP_PATH` and `VST3_PATH` point). Neither has a
-filter chain to run in, so both always run in the native host described
-below, and their rows carry no host switch. The daemon never loads their
-code itself: the host describes each bundle in a process of its own, so a
-plugin that misbehaves while being asked about its ports costs that
-bundle and nothing else, and what it learns is kept until the bundle
-changes. Windows VST3 plugins come through yabridge, which presents them
-as ordinary bundles under `~/.vst3`; the manual has the Wine and yabridge
-setup for each distribution. VST2 plugins are not supported.
+The Inserts row provides bypass, ordering, removal and generated parameter
+controls. Native plugin editors open on the instance processing the audio.
+For LV2, enabling "Native host" moves only that insert out of filter-chain
+and briefly interrupts its chain. CLAP and VST3 always use that host.
+Packages include the helper; source builds need
+`-p:EnableNativeLv2Host=true`. The helper scans CLAP/VST3 bundles in separate
+processes and caches their descriptions until they change.
 
-Installing a plugin is a pick in the picker or in Options: a file or a
-folder the user downloaded. The daemon works out what it is from its
-name and its first bytes, copies a Linux `.clap`, `.vst3` or `.lv2` into
-the matching directory under the home, hands a folder of Windows plugins
-to yabridge and runs its sync, and answers in a sentence when it cannot
-help: an archive to extract, a Windows installer to run with Wine first,
-a VST2 file. The catalogues are read again afterwards, and every open
-chain fetches the list, so the plugin is in the picker a moment later.
-The Options window says where plugins go, whether yabridge and Wine are
-installed and how many folders they bridge, and it names the pair of
-versions, yabridge up to 5.1.1 with Wine 9.22 or newer, that leaves a
-bridged plugin's own editor deaf to the mouse, since the plugin is still
-worth using through the controls OpenXLR builds for it. It offers the plugin folders
-found in Wine's own drive, which file dialogs hide, so the first Windows
-plugin is one press rather than a hunt; the ones after it, installed into
-a folder already bridged, take the sync beside it.
+Chains and exposed parameter values are saved with the mixer and profiles.
+Opaque plugin state, loaded sample files and plugin preset data are not
+persisted by OpenXLR. A plugin may save its own preferences separately.
 
-The list a window is sent has a size limit. The same plugin often ships
-in more than one format, and while everything fits every copy is offered;
-past the limit, LV2 stays whole and the other formats fill what room is
-left, copies of a plugin already listed going last. A set installed twice,
-as LV2 and as VST3, therefore shows once rather than pushing anything out.
+"Install file…" and "Install folder…" accept extracted Linux plugins or
+Windows plugin folders. Linux bundles are copied into `~/.lv2`, `~/.clap`
+or `~/.vst3`. Windows installers must run in Wine first; OpenXLR bridges
+the installed plugins and rescans automatically. Options offers a rescan,
+a Windows sync, detected Wine folders and the selected bridge's status.
 
-Plugins that ship their own editor still load, and the generated controls
-are shown for them. The editor itself can be opened through a small host
-process, which every package installs. Turning on "Native host" for one
-insert moves that insert out of the shared chain into a process of its
-own, which hosts the plugin and its editor together; the other inserts
-stay in the chain and nothing moves unless you ask. The editor works on the
-audio that is playing and its changes are saved like any other control.
-The plugin keeps processing if the editor stops answering or the X
-display goes away, and a chain whose host keeps crashing is switched off
-once it has failed three times in five minutes, with the reason on the
-insert. Plugins that hand work to a background thread, which is how
-reverbs and convolvers build their impulse responses, are hosted too. The manual covers the
-setup in 3.12.
+The optional `openxlr-yabridge` companion includes the Wine 9.22+ editor
+input fix. It creates wrappers under `~/.local/share/openxlr/yabridge` and
+keeps its controller registry under `~/.config/openxlr/bridge`, honoring
+XDG overrides. Other DAWs' wrappers and controller settings remain separate.
+Private wrappers take priority over duplicate global copies. A system/user
+bridge remains supported; Options warns about known incompatible versions.
+See [Windows plugins](manual.md#windows-plugins) for availability and setup.
+
+The catalogue sent to clients is bounded. While it fits, all formats are
+offered. Beyond the limit, LV2 entries retain priority and other formats
+fill the remaining space, with duplicate names last.
+
+Editor borders follow each plugin's size limits. TDR Nova uses its own UI
+scale menu instead of border resizing. LSP editors default to software
+rendering to avoid freezes during large drags. Display loss and stalled
+editor controls are handled without rebuilding a healthy audio instance;
+a crash of the plugin process interrupts its chain. Repeated chain failures
+stop automatic retries after three failures in five minutes. See
+[plugin editors](manual.md#plugin-editors) for recovery and renderer settings.
 
 The submixer can be switched off in Options. The daemon then controls
 the hardware only, restarts itself, and leaves the sound card in its
@@ -195,7 +185,10 @@ restores the split profile when it stops.
 ## Application routing
 
 - Audio clients are detected from their PipeWire client registration
-  and assigned to a channel by name rules; each assignment is stored in
+  and playback metadata, falling back to the owning client when fields
+  are missing. Windows `.exe` identities normalize to their Wine/Proton
+  key; an existing normalized assignment wins over an old alias. Apps are
+  assigned to a channel by name rules; each assignment is stored in
   the app registry and can be edited while the app is silent
 - Electron apps report "Chromium" as their application name; they are
   identified by their process binary instead, so Discord appears as
@@ -213,8 +206,8 @@ levels, mutes, masters, monitor outputs, aux state, insert chains with
 their parameters). Saved per device and recalled from the header, over
 the API, or from a Stream Deck key. One profile per device can be
 marked to recall on connect: at daemon start, after a replug or power
-cycle, or when switching to that device. Interfaces without settings
-memory (Wave XLR, the first XLR Dock) get their last settings back
+cycle, or when switching to that device. Interfaces using OpenXLR's connect-time
+restoration (Wave XLR, the first XLR Dock) get their last settings back
 on every fresh connect without a profile, and can be reset to the
 firmware defaults recorded after a power cycle. The Wave XLR Pro, which
 keeps its own settings, can be reset to OpenXLR's baseline instead:
@@ -270,15 +263,12 @@ taps on the Stream Deck + XL need OpenDeck newer than 2.14.0
 
 ## Other
 
-- Audio Flow window: a graph of the current routing, sources through
-  outputs, with the filter chains (built-in low cut and ClipGuard, LV2
-  inserts) drawn where they sit in the path and each stage marked active,
-  bypassed or broken
 - Enforced defaults: the daemon re-asserts the chosen system default
   sink and source on its one-second sweep, undoing WirePlumber's
   auto-switch to newly created nodes
 - The control API validates every command before the mixer sees it and
-  answers with an error instead of ignoring it; clients are rate-limited
+  answers with an error instead of ignoring it. A private token is required
+  before any state is sent or command executed; clients are rate-limited
   and browser pages from other origins are refused; see
   [api.md](api.md). The same commands are served over HTTP at `/api/v1`
   with an OpenAPI document ([http-api.md](http-api.md))

--- a/docs/hardware-support.md
+++ b/docs/hardware-support.md
@@ -1,16 +1,17 @@
 # Hardware support
 
-The state of every device OpenXLR supports, control by control. The
-Wave XLR row still needs an owner; the section at the bottom explains
-how to help.
+The controls OpenXLR exposes, with recorded hardware verification kept
+separate from implementation status. An unavailable control may exist in
+the device but have no mapped OpenXLR command. See the final section for
+the checks that still need an owner.
 
 | Device | USB id | Status |
 |---|---|---|
-| Wave XLR Pro | `0fd9:00b4` | every control verified on hardware |
-| XLR Dock | `0fd9:00a6` | every control the hardware has, verified on hardware |
+| Wave XLR Pro | `0fd9:00b4` | exposed controls verified on hardware |
+| XLR Dock | `0fd9:00a6` | exposed controls verified on hardware |
 | Wave XLR | `0fd9:007d` | core controls verified on hardware by community testers on two units (0.1.13) |
-| Wave XLR MK.2 | `0fd9:00b6` | every control verified on hardware by a community tester |
-| XLR Dock MK.2 | `0fd9:00c7` | MK.2 backend at the Pro's block bank; every control verified on hardware |
+| Wave XLR MK.2 | `0fd9:00b6` | exposed controls verified on hardware by a community tester |
+| XLR Dock MK.2 | `0fd9:00c7` | MK.2 backend at the Pro's block bank; exposed controls verified on hardware |
 
 ## Wave XLR Pro (0fd9:00b4)
 
@@ -29,6 +30,13 @@ the commit block every selector write needs.
 | Physical output routing | verified | HP1, HP2, Line Out, USB Aux; verified by listening on both jacks |
 | USB Aux input level + lock, aux return | verified | return routing latches at stream open; the daemon bounces the stream |
 | Reset to OpenXLR's baseline | verified | the device keeps its settings, so the reset writes a known set (gain 30 dB, everything off, levels at half, crossfade on PC) instead of recorded firmware defaults |
+
+The Pro's onboard EQ, ducking, mix maximizer and channel booster have no
+mapped OpenXLR controls. The full hardware mix matrix is also unfinished.
+Elgato's [Pro feature guide](https://www.elgato.com/us/en/explorer/products/wave/wave-xlr-pro-give-your-setup-superpowers/)
+distinguishes those onboard effects from VST processing on the computer.
+OpenXLR exposes Voice Tune and the other DSP controls listed above; its
+plugin inserts run in the Linux audio graph.
 
 ## XLR Dock (0fd9:00a6)
 
@@ -49,7 +57,7 @@ expose, reached over the original Wave XLR's protocol dialect.
 | Phantom power | verified | byte 6 of the dock's config block over the original Wave XLR's protocol dialect. Identified by [openwave PR #8](https://github.com/rikkichy/openwave/pull/8) on the MK.1 against its 48V LED; confirmed here with a condenser microphone on the dock's XLR. Wave Link does not write it for the dock |
 | Low impedance | verified | byte 33 of the same config block, verified by listening on the dock's headphone jack |
 | Device info block (0x000A) | read | 51 bytes; carries the unit's USB serial in ASCII from offset 35, so the diagnostics exporter masks it in the hex dump |
-| Hardware sidetone | not present | no control path found; a byte sweep came back negative |
+| Hardware sidetone | unmapped | no control path found in the byte sweep; this does not establish whether the hardware supports it |
 
 Kernel behaviour: the kernel starves the dock's capture endpoint when
 playback to it starts first, and the mic records silence. OpenXLR
@@ -73,7 +81,14 @@ but the daemon's stream sweep starving its own clients; fixed in
 | Gain, mute | verified | community tester; scale is 256 raw units per dB ([openwave PR #8](https://github.com/rikkichy/openwave/pull/8) measured it on the shared protocol) |
 | Headphone volume, low impedance | verified | community tester |
 | Phantom 48V | coded | config byte 6, found by [openwave PR #8](https://github.com/rikkichy/openwave/pull/8) against the MK.1's own 48V LED; the same byte is verified on the XLR Dock. Added after the tester's run, so an LED check on a MK.1 is still open |
-| Low cut, voice DSP, crossfade | unmapped | the hardware has them; their offsets are unknown. A [USB capture](usb-capture.md) from an owner would map them |
+| Hardware low cut, ClipGuard, mic/PC crossfade | unmapped | Wave Link exposes these controls; their OpenXLR offsets are unknown. Software low cut and limiting are available in the submixer |
+| Save settings to hardware, LED colours | unmapped | OpenXLR restores its last observed settings on connect instead of issuing Wave Link's hardware-save operation |
+
+Elgato's [Wave XLR settings guide](https://help.elgato.com/hc/en-us/articles/4404228579853-Elgato-Wave-XLR-Wave-Link-Settings-Overview)
+documents a separate hardware-save action. OpenXLR's `retainsSettings: false`
+capability describes its restoration policy, not an absence of device memory.
+Hardware low cut or ClipGuard configured in Wave Link may remain active;
+OpenXLR cannot currently read or disable those settings.
 
 ## Wave XLR MK.2 (0fd9:00b6) and XLR Dock MK.2 (0fd9:00c7), verified
 
@@ -111,9 +126,9 @@ every write showed up there and read back from the block. Blocks
 | Headphone volume, low impedance, crossfade | verified | Wave XLR MK.2: community tester. Dock: all three on the author's unit (the mic leaves the direct monitor at the PC end of the crossfade) |
 | Phantom 48V, ClipGuard, compressor | verified | at the Pro's bit positions; community tester, 0.1.12. Dock: phantom confirmed with a condenser mic going silent when switched off, ClipGuard and compressor by ear |
 
-Every control was confirmed on the dock on 2026-09-05, the DSP ones by
-ear through the monitor mix and phantom with a condenser microphone.
-Blocks 0x0002 and 0x0006 exist and are not decoded.
+Every exposed control listed above was confirmed on the dock on
+2026-09-05, the DSP ones by ear through the monitor mix and phantom with a condenser microphone.
+Hardware EQ is not mapped. Blocks 0x0002 and 0x0006 exist and are not decoded.
 
 ## Every device gets
 
@@ -122,9 +137,8 @@ Blocks 0x0002 and 0x0006 exist and are not decoded.
 - Per-device profiles: named scenes of hardware state plus the whole
   submix, recalled from the UI, the API or a Stream Deck key, and one
   of them on connect if chosen
-- Last settings restored on connect for the devices without settings
-  memory (Wave XLR, XLR Dock), plus a reset to the firmware defaults
-  recorded after a power cycle. The Pro and the MK.2 family, the XLR
+- Last settings restored on connect for Wave XLR and the first XLR Dock,
+  plus a reset to the defaults recorded after a power cycle. The Pro and the MK.2 family, the XLR
   Dock MK.2 included, keep their settings on board (verified by
   replugging the dock)
 - Multi-device switching: a header picker chooses which interface
@@ -136,7 +150,7 @@ Blocks 0x0002 and 0x0006 exist and are not decoded.
 
 ## Help confirm a control
 
-Anything marked "coded" above, or the dock's DSP flags, can be
+Anything marked "coded" above can be
 confirmed in a few minutes:
 
 1. Install OpenXLR per the [README](../README.md), including the udev
@@ -147,9 +161,7 @@ confirmed in a few minutes:
 4. Open an [issue](https://github.com/emaspa/openxlr/issues) with the
    archive and what you observed.
 
-MK.1 owners who can record a Wave Link USB capture on Windows can map
-the rest of their device: low cut, the voice DSP, and the crossfade
-exist in the hardware and need their registers found (phantom is
-already coded, from the openwave project). The
-[USB capture guide](usb-capture.md) walks through it in about 15
+MK.1 owners can help map low cut, ClipGuard, mic/PC crossfade and the
+hardware-save action with an ordered Wave Link capture. The
+[USB capture guide](usb-capture.md) explains the process in about 15
 minutes, no programming needed.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -43,6 +43,19 @@ Content-Type; 429 budget exhausted or another HTTP mutation in flight. Chunked b
 five-second deadline. One HTTP command runs at a time, with no waiting queue.
 All authenticated HTTP responses use `Cache-Control: no-store`.
 
+For a read-only check from a shell in the daemon's user session:
+
+```sh
+TOKEN=$(cat "${XDG_RUNTIME_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}}/openxlr/token")
+curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:37890/api/v1/state
+unset TOKEN
+```
+
+`getPluginSetup` is available through `POST /api/v1/commands` and reports
+the effective plugin host, Wine and bridge provider. Its reply fields are
+documented in [api.md](api.md); the transport does not select a bridge itself.
+
 The [OpenAPI document](openapi-v1.json) describes the HTTP endpoints. Restarting
 the daemon rotates its per-session token once the new instance listens;
 clients must reread it.

--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -2,36 +2,46 @@
 
 ## Requirements
 
-- Linux with PipeWire 1.4 or newer (developed on 1.6), `pipewire-pulse`
-  and WirePlumber; `pactl`, `pw-cli`, `pw-link`, `pw-dump`, `parec` on PATH
+- Linux with PipeWire, `pipewire-pulse`
+  and WirePlumber; `pactl`, `pw-cli`, `pw-link`, `pw-dump`, `parec`, `wpctl` and `amixer` on PATH
 - `swh-plugins` (LADSPA) for the software ClipGuard; everything else
   works without it
-- `lilv` and some LV2 plugins for the inserts (`lsp-plugins-lv2` to
-  start); without lilv the plugin picker is simply empty
-- .NET 10 SDK to build (runtime to run)
+- `lilv` for LV2 discovery and compatible LV2, CLAP or VST3 plugins
+- .NET 10 SDK to build; ASP.NET Core 10 runtime for a framework-dependent
+  installation (the base .NET runtime alone does not run the daemon)
+- C/C++ compiler, make, pkg-config, PipeWire/lilv/LV2/X11 headers for the
+  native plugin host; X11 or XWayland for plugin editors
 - libusb 1.0
 - A supported Elgato interface (see the device table in the README); the submixer works
   with any of them, and the aux and output routing features follow the
   device's capabilities
 
-Every step of a from-source deploy, for machines without a package.
+All commands below run from the repository root unless stated otherwise.
+The branch describes current development; check out a release tag before
+building if you want exactly that release.
 
 ## 1. Prerequisites
 
-The .NET 10 SDK, PipeWire with its CLI tools, and libusb. Package names
-by distribution:
+The .NET 10 SDK, ASP.NET Core runtime, audio tools and native build headers.
+Run only the commands for your distribution. Availability depends on its
+release and enabled repositories; the .NET SDK must be version 10.
+The native editor tests additionally use Xvfb and xauth.
 
 ```sh
 # Arch
-sudo pacman -S --needed dotnet-sdk pipewire pipewire-pulse wireplumber libusb
+sudo pacman -S --needed dotnet-sdk aspnet-runtime pipewire pipewire-pulse wireplumber libusb libpulse alsa-utils
 # optional: software ClipGuard for the XLR Dock, and LV2 plugins for inserts
 sudo pacman -S --needed swh-plugins lilv lsp-plugins-lv2
+# native host and editor test dependencies
+sudo pacman -S --needed base-devel lv2 libx11 xorg-server-xvfb xorg-xauth
 
 # Fedora
-sudo dnf install dotnet-sdk-10.0 pipewire pipewire-pulseaudio wireplumber libusb1 ladspa-swh-plugins lilv-libs lsp-plugins-lv2
+sudo dnf install dotnet-sdk-10.0 aspnetcore-runtime-10.0 pipewire pipewire-pulseaudio wireplumber libusb1 pulseaudio-utils alsa-utils ladspa-swh-plugins lilv-libs lsp-plugins-lv2
+sudo dnf install gcc-c++ make pkgconf-pkg-config pipewire-devel lilv-devel lv2-devel libX11-devel xorg-x11-server-Xvfb xorg-x11-xauth
 
 # Debian / Ubuntu (dotnet from Microsoft's feed if the distro lacks 10.0)
-sudo apt install dotnet-sdk-10.0 pipewire pipewire-pulse wireplumber libusb-1.0-0 swh-plugins liblilv-0-0 lsp-plugins-lv2
+sudo apt install dotnet-sdk-10.0 aspnetcore-runtime-10.0 pipewire pipewire-pulse wireplumber libusb-1.0-0 pulseaudio-utils alsa-utils swh-plugins liblilv-0-0 lsp-plugins-lv2
+sudo apt install build-essential pkg-config libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev xvfb xauth
 ```
 
 Verify the audio stack is PipeWire before going further:
@@ -44,47 +54,31 @@ pactl info | grep "Server Name"    # should say PulseAudio (on PipeWire ...)
 
 ```sh
 git clone https://github.com/emaspa/openxlr.git
-cd openxlr/src
-dotnet build -c Release
+cd openxlr
+dotnet restore src/OpenXLR.slnx --locked-mode
+dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror -p:EnableNativeLv2Host=true
 ```
 
 Binaries land in `src/OpenXLR.Daemon/bin/Release/net10.0/` and
-`src/OpenXLR.UI/bin/Release/net10.0/`.
+`src/OpenXLR.UI/bin/Release/net10.0/`. The native flag builds `native/` and
+copies `openxlr-lv2-host` next to the daemon. CLAP/VST3 headers are vendored.
 
-The packages install the small host process that opens a plugin's own
-editor. A source build leaves it out unless you ask:
+You may omit the flag for hardware control and LV2 filter-chain inserts
+without native editors. CLAP and VST3 require the helper. Keep the flag
+on every later build once you rely on it: a build without it removes the
+helper and native inserts report that it is missing. See
+[plugin editors](manual.md#plugin-editors).
 
-```sh
-dotnet build -c Release -p:EnableNativeLv2Host=true
-```
-
-That step compiles the sources under `native/` and copies the helper next to the
-daemon. It needs a C and a C++ compiler, make, pkg-config and the development
-files for PipeWire, lilv, LV2 and X11 (`base-devel`, `pipewire`, `lilv`,
-`lv2` and `libx11` on Arch; `g++` and the `-dev` packages of the same on
-Debian and Ubuntu). The CLAP and VST3 interface headers are part of the
-tree. Without the flag nothing native is built and inserts use
-PipeWire's filter chain, which is also the default when the helper is
-present. The manual describes the feature in 3.12.
-
-Build with the flag every time once you rely on it. A later build without it
-removes the helper again, and inserts set to the native host then report that
-it is not installed.
-
-## 3. Device access (udev rule, then replug the device):
+## 3. Device access
 
 ```sh
-sudo tee /etc/udev/rules.d/70-openxlr.rules << 'EOF'
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="00b4", MODE="0660", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="00a6", MODE="0660", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="007d", MODE="0660", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="00b6", MODE="0660", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="00c7", MODE="0660", TAG+="uaccess"
-EOF
+sudo install -m 0644 packaging/70-openxlr.rules /etc/udev/rules.d/70-openxlr.rules
 sudo udevadm control --reload
 ```
 
-## 4. XLR Dock only: the capture-hold rule
+Replug the interface after reloading the rules.
+
+## 4. WirePlumber rules
 
 XLR Dock owners need one more file. The Linux kernel starves the dock's
 capture endpoint whenever playback to it starts before capture, and the
@@ -96,24 +90,30 @@ capture source always active, so playback can never come first:
 ```sh
 mkdir -p ~/.config/wireplumber/wireplumber.conf.d
 cp packaging/50-xlr-dock-capture-hold.conf ~/.config/wireplumber/wireplumber.conf.d/
+cp packaging/51-openxlr-pro-raw-names.conf ~/.config/wireplumber/wireplumber.conf.d/
 systemctl --user restart wireplumber
 ```
 
+The raw-name rule gives the Pro's multichannel nodes readable descriptions
+in desktop audio settings. It does not change their routing identities. Both files match only their target hardware, so they can be
+installed together on any supported setup. These
+`.conf` rules use WirePlumber 0.5 syntax.
+
 ## 5. First run
 
-Run the daemon in a terminal. The mixer graph is opt-in: without the
-variable the daemon drives the device only and leaves the PipeWire
-graph untouched.
+Run the daemon in a terminal. On a fresh source installation, the mixer graph is opt-in through this
+variable. An existing `daemon.json` submixer preference takes precedence,
+as listed in the environment table below.
 
 ```sh
-OPENXLR_BUILD_MIXER=1 ./OpenXLR.Daemon/bin/Release/net10.0/OpenXLR.Daemon
+OPENXLR_BUILD_MIXER=1 ./src/OpenXLR.Daemon/bin/Release/net10.0/OpenXLR.Daemon
 ```
 
 The log should show your device connecting and `submix graph built`.
-Then, in a second terminal, the UI:
+Then, in a second terminal from the same repository root, run the UI:
 
 ```sh
-./OpenXLR.UI/bin/Release/net10.0/OpenXLR.UI
+./src/OpenXLR.UI/bin/Release/net10.0/OpenXLR.UI
 ```
 
 The header dot turns green when the daemon has the device. If it says
@@ -130,6 +130,7 @@ The manual way, using the reference unit in
 [packaging/openxlr-daemon.service](../packaging/openxlr-daemon.service):
 
 ```sh
+mkdir -p ~/.config/systemd/user
 cp packaging/openxlr-daemon.service ~/.config/systemd/user/
 # edit ExecStart in the copy if you cloned somewhere other than ~/openxlr
 systemctl --user daemon-reload
@@ -173,14 +174,16 @@ the plugin folder (a symlink breaks OpenDeck's asset serving) and
 restart OpenDeck:
 
 ```sh
+mkdir -p ~/.config/opendeck/plugins
 cp -r plugin/com.emaspa.openxlr.sdPlugin ~/.config/opendeck/plugins/
 ```
 
 ## 8. Updating
 
 ```sh
-cd openxlr && git pull
-cd src && dotnet build -c Release
+git pull --ff-only
+dotnet restore src/OpenXLR.slnx --locked-mode
+dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror -p:EnableNativeLv2Host=true
 systemctl --user restart openxlr-daemon.service
 ```
 
@@ -192,16 +195,39 @@ Restart the UI and, if you use it, recopy the OpenDeck plugin folder.
 systemctl --user disable --now openxlr-daemon.service
 rm ~/.config/systemd/user/openxlr-daemon.service
 sudo rm /etc/udev/rules.d/70-openxlr.rules
-rm -rf ~/.config/openxlr ~/.config/opendeck/plugins/com.emaspa.openxlr.sdPlugin
+rm -rf ~/.config/opendeck/plugins/com.emaspa.openxlr.sdPlugin
 rm ~/.config/wireplumber/wireplumber.conf.d/50-xlr-dock-capture-hold.conf
-rm -r ~/.config/systemd/user/pipewire-pulse.service.d   # the open-file drop-in, if you created it
+rm -f ~/.config/wireplumber/wireplumber.conf.d/51-openxlr-pro-raw-names.conf
+rm -f ~/.config/systemd/user/pipewire-pulse.service.d/openxlr.conf
+rm -f ~/.config/autostart/openxlr.desktop
 systemctl --user daemon-reload
 ```
 
+Stop the UI as well. These commands remove the files installed by this
+guide and preserve other service overrides. Saved settings and private
+Windows wrappers remain in `~/.config/openxlr` and
+`~/.local/share/openxlr/yabridge`; back them up before removing them if you
+want a clean slate. Restart WirePlumber at a convenient time to unload the
+removed rules. If you installed the optional UCM profile, use its revert
+script separately.
+
 ## Environment variables
+
+Set these in the daemon environment, for example with `systemctl --user
+edit openxlr-daemon` and a `[Service]` / `Environment=NAME=value` entry.
+Reload the user manager and restart the daemon after changing them. A
+shell export does not update an already running service.
 
 | Variable | Effect |
 |---|---|
 | `OPENXLR_BUILD_MIXER=1` | build the PipeWire submix graph (otherwise device-control only); `daemon.json`'s `submixer` key, written by the Options window, overrides it when present |
 | `OPENXLR_MONITOR_OUTPUT=<sink>` | initial monitor output (overrides saved choice) |
 | `OPENXLR_DEVICE=<pid>` | which interface to drive at start when several are attached (hex product id, e.g. `00a6`) |
+| `LV2_PATH`, `CLAP_PATH`, `VST3_PATH` | colon-separated plugin search directories; CLAP/VST3 private companion directories still take priority |
+| `LADSPA_PATH` | LADSPA directories for the software limiter |
+| `OPENXLR_YABRIDGE` | `system` selects the existing bridge; an absolute path selects a complete companion; unset enables automatic discovery |
+| `WINEPREFIX` | Wine prefix used when locating Windows plugin folders; defaults to `~/.wine` |
+| `LSP_WS_LIB_GLXSURFACE` | native helper defaults to `0` for LSP software rendering; explicit `1` tests OpenGL |
+| `DISPLAY`, `XAUTHORITY` | X11/XWayland session and authentication for native editors; the daemon can obtain these from the systemd user manager |
+| `OPENXLR_HOST_TRACE=1` | VST3 bus and initial processing diagnostics in the daemon log |
+| `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_RUNTIME_DIR` | configuration, private wrapper and runtime roots; see [files and services](manual.md#files) |

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,5 +1,9 @@
 # OpenXLR manual
 
+This manual follows `main`. A released package can lag behind it; read the
+manual at that release's tag for matching behaviour. The app's Manual links
+open this page on GitHub `main`.
+
 How to use OpenXLR day to day: what it changes on your system, the
 concepts behind the mixer window, step-by-step tasks, and what to do
 when something does not work. For installing, see the README; for the
@@ -95,10 +99,12 @@ chains). They are saved per interface. Application routing and the
 system default devices are not part of a profile, so recalling one
 does not rewire the desktop.
 
-**Inserts** are LV2 plugins placed in the signal path: a mono chain on
-each XLR input, a stereo chain on each mix. The XLR Dock and the
-original Wave XLR have no onboard DSP, so on those OpenXLR also offers
-a software low cut and ClipGuard on XLR 1.
+**Inserts** are LV2, CLAP or VST3 effects placed in the signal path: a mono
+chain on each XLR input, a stereo chain on each mix. On the first XLR Dock
+and original Wave XLR, OpenXLR also offers software low cut and limiting
+on XLR 1 because their backends do not expose those hardware controls.
+Unmapped processing previously enabled in Wave Link may still be active
+on the original Wave XLR. See [hardware support](hardware-support.md).
 
 <a name="tasks"></a>
 ## 3. Tasks
@@ -225,17 +231,20 @@ channel, with its level and lock in the INPUTS card.
 ### 3.5 Add a plugin to the signal path
 
 1. Under XLR 1, XLR 2 or a mix, press "Add plugin…". The picker lists
-   the installed LV2 plugins that fit the slot (mono for an input,
-   stereo for a mix), searchable by name or category. `lsp-plugins-lv2`
-   is the set used during development; any LV2 plugin set works.
+   compatible installed LV2, CLAP and VST3 effects (mono for an input,
+   stereo for a mix), searchable by name, category or format. Host
+   feature requirements can exclude a plugin; install a compatible set
+   such as `lsp-plugins-lv2` if the list is empty.
 2. Add. The plugin appears in the Inserts row with a green light while
    active.
 3. Controls opens a window generated from the plugin's parameters,
    grouped, with a Defaults button. Bypass takes it out of the path
    (red light); the arrows reorder the chain; the cross removes it.
-4. Chains are saved with the mixer and with profiles.
+4. Chains and exposed parameter values are saved with the mixer and
+   profiles. OpenXLR does not yet save opaque plugin state, sample-file
+   selections or plugin presets.
 
-The generated controls cover every parameter the plugin exposes. A
+The generated controls cover the parameters in the bounded catalogue. A
 plugin's own editor can be opened as well, with the native host described
 in 3.12. CLAP and VST3 plugins appear in the same picker and always run in
 that host. VST2 plugins cannot be loaded.
@@ -243,10 +252,9 @@ that host. VST2 plugins cannot be loaded.
 <a name="install-plugins"></a>
 **Installing plugins.** The quickest set comes from your distribution:
 on Arch, `lsp-plugins-lv2` and `x42-plugins` cover the microphone path
-well, `lsp-plugins-vst3` is the same set as VST3, and `dragonfly-reverb-clap`,
-`dpf-plugins-clap` and `elephantdsp-roomreverb-clap` are CLAP effects for a
-mix. For a plugin you downloaded, press "Install file…" or "Install
-folder…" in the picker or in Options and pick it; OpenXLR puts it where
+well. Choose LV2, CLAP or VST3 packages available for your distribution;
+the picker offers only plugins compatible with the selected slot.
+For a plugin you downloaded, press "Install file…" or "Install folder…" in the picker or in Options and pick it; OpenXLR puts it where
 it looks and the picker lists it a moment later. A file is a `.clap` or a
 single-file `.vst3`; a folder is a `.vst3` or `.lv2` bundle, or a folder
 holding several of them, such as an extracted download. Linux plugins are
@@ -264,7 +272,13 @@ Linux bundles.
 
 The optional **openxlr-yabridge** package supplies a tested bridge for
 64-bit Windows VST3 and CLAP plugins, including the Wine editor input fix.
-Wine remains a system dependency. Install the companion artifact with
+Wine remains a system dependency. The companion currently comes from the
+separate [Optional Windows bridge workflow](https://github.com/emaspa/openxlr/actions/workflows/yabridge.yml)
+or a source build. That workflow creates binary and source artifacts; it
+does not attach them to OpenXLR releases or publish distribution packages.
+Download and extract the artifact for your distribution, check its
+`SHA256SUMS`, and follow the [package guide](../packaging/yabridge/README.md).
+Install the companion artifact with
 your distribution's package manager, then restart the daemon:
 
 ```sh
@@ -298,74 +312,18 @@ used when the companion is absent, or when the daemon environment sets
 `OPENXLR_YABRIDGE=system`. An absolute path in that variable selects a
 companion installed elsewhere. Restart the daemon after changing it.
 
-**Using a separate yabridge installation.** The instructions below apply
-when choosing the system bridge instead of the companion.
+**Using a separate yabridge installation.** Install Wine through your
+distribution. For yabridge, use its distribution package where available
+or follow the [upstream installation instructions](https://github.com/robbert-vdh/yabridge#installation).
+For example, Arch provides `wine`, `yabridge` and `yabridgectl`.
 
-Wine and yabridge must both be installed for the system bridge.
-The Options window says which of the two it can see.
+For an upstream tarball install, extract it into `~/.local/share` so that
+`~/.local/share/yabridge/yabridgectl` exists. OpenXLR checks this location
+and PATH. Adding it to your interactive shell's PATH alone does not change
+the environment of a running systemd daemon. The
+[editor input note](#windows-editor-input) applies to unpatched bridges.
 
-Arch, and anything built on it such as Manjaro, EndeavourOS and CachyOS,
-has both in its own repositories:
-
-```sh
-sudo pacman -S wine yabridge yabridgectl
-```
-
-NixOS has both as well. Add `wine`, `yabridge` and `yabridgectl` to your
-packages, or try them first with:
-
-```sh
-nix shell nixpkgs#wine nixpkgs#yabridge nixpkgs#yabridgectl
-```
-
-Fedora has Wine but not yabridge; the community repositories that carried
-it have gone stale. Install Wine from Fedora and yabridge from its own
-release:
-
-```sh
-sudo dnf install wine
-```
-
-Debian, Ubuntu, Linux Mint and Pop!_OS also need yabridge from its own
-release. Their own `wine` package works; yabridge's author recommends
-Wine Staging from the [WineHQ repositories](https://wiki.winehq.org/Download)
-if a plugin misbehaves:
-
-```sh
-sudo apt install wine
-```
-
-On those, and on any distribution without a package, take the tarball
-from yabridge's [releases page](https://github.com/robbert-vdh/yabridge/releases)
-and unpack it into `~/.local/share`, which is where its own instructions
-put it. With 5.1.1, the current release:
-
-```sh
-tar -C ~/.local/share -xavf ~/Downloads/yabridge-5.1.1.tar.gz
-```
-
-That leaves `~/.local/share/yabridge/yabridgectl`, which is where OpenXLR
-looks, so nothing else is needed for it: close the Options window and open
-it again, and the card will say that yabridge is installed.
-
-Putting that directory on your PATH is worth it only to run `yabridgectl`
-yourself, and only after the tarball is unpacked: fish refuses a path that
-is not there, and a PATH entry pointing at nothing does no good either
-way. With fish:
-
-```sh
-fish_add_path ~/.local/share/yabridge
-```
-
-With bash, and a new terminal afterwards:
-
-```sh
-echo 'export PATH="$PATH:$HOME/.local/share/yabridge"' >> ~/.bashrc
-```
-
-Run neither on Arch or NixOS: their packages put `yabridgectl` where every
-shell already looks, and `fish_add_path` answers "Skipping non-existent
-path" because nothing was unpacked there.
+**Installing and syncing Windows plugins with either bridge.**
 
 With both in place, run the plugin's Windows installer with Wine and let
 it install where it offers to:
@@ -385,7 +343,9 @@ yabridge has seen that folder before:
 | Rescan | Plugins that arrived by other means, such as a package from your distribution. Nothing to press after a bridge or a sync, since both read the catalogues again |
 
 Bridging and syncing end the same way: yabridge wraps each Windows plugin
-in a bundle under `~/.vst3/yabridge`, OpenXLR reads its catalogues again,
+in the selected bridge's directories: private `vst3`/`clap` directories
+for the companion, normally `~/.vst3/yabridge` or `~/.clap/yabridge` for
+a system bridge. OpenXLR reads its catalogues again,
 and the plugin is in the picker with a VST3 or CLAP badge. Nothing else
 has to be restarted.
 
@@ -439,20 +399,20 @@ shared memory audio buffers into main memory.
 
 It is a warning, not a failure: the plugin runs, but the buffers it shares
 with its Windows half can be paged out under memory pressure, and reading
-them back takes far longer than an audio cycle allows. Every distribution
-ships 8 MiB as the limit, which is what systemd uses when nothing else
-says otherwise.
+them back can exceed an audio cycle. The effective limit depends on the
+distribution and user session; check the running daemon before changing it.
 
-Being in the `audio` group is not enough for this. That group is usually
-granted realtime priority and nothing else; the memory lock comes with the
-`realtime` group. On Arch, and anything built on it:
+Group names alone do not grant a memory-lock limit; the distribution's
+PAM and systemd policy determines it. On Arch, the realtime privileges
+package provides the relevant group policy:
 
 ```sh
 sudo pacman -S realtime-privileges
 sudo usermod -aG realtime $USER
 ```
 
-On any distribution, granting it by hand does the same:
+On systems using PAM limits, an administrator can instead grant the
+`audio` group a memory-lock allowance:
 
 ```sh
 printf '@audio - memlock unlimited\n' | sudo tee /etc/security/limits.d/99-openxlr.conf
@@ -495,10 +455,11 @@ known scene at every login. The reconnect after a passing USB error
 does not count, so the recall never undoes changes you made since.
 Pick "(none)" to stop.
 
-**Interfaces without settings memory.** The Wave XLR and the first XLR
-Dock keep nothing on board; unplugged, they come back with the
-firmware's own values (full gain, headphones at 100%). For them the
-daemon remembers every change and writes it back whenever the
+**Restoring settings on connect.** For the original Wave XLR and first
+XLR Dock, OpenXLR restores the last settings it observed. This policy
+does not describe the device's storage: Wave Link offers a separate
+hardware-save action for the Wave XLR that OpenXLR has not mapped. The
+daemon remembers changes and writes them back whenever the
 interface connects fresh, so a reboot or a replug leaves you where you
 were, with no profile needed. The picker shows "(last settings)" in
 place of "(none)" on these devices; a chosen profile takes precedence.
@@ -552,7 +513,7 @@ Options, STARTUP:
   if it is hidden there) instead of opening a second one.
 
 To land on a known scene at every login, mark a profile to recall on
-connect ([section 3.6](#profiles)). An interface without settings memory comes back
+connect ([section 3.6](#profiles)). An interface using connect-time restoration comes back
 as you left it without one.
 
 The window also remembers which of its sections (INPUTS, HEADPHONES,
@@ -622,16 +583,16 @@ host process that the packages install for you. If you build from source,
 add one flag to get it, as
 [install-from-source.md](install-from-source.md) describes.
 
-To use it:
+For an LV2 insert:
 
 1. Open a plugin's Controls window. A plugin whose editor OpenXLR can
    host shows a "Native host" button.
 2. Turn it on. That one insert moves out of the shared filter chain into
    its own process, which rebuilds the chain and interrupts audio for a
    moment. Every other plugin stays where it is.
-3. Press "Plugin UI". The editor opens on the plugin that is processing
-   your audio. What you change there appears in the controls window and
-   is saved with the mixer and with profiles.
+3. Press "Plugin UI". The editor opens on the plugin processing your audio.
+   Changes to exposed parameters appear in the controls window and are
+   saved with the mixer and profiles. Other internal plugin state is not saved.
 4. Turn "Native host" off to put the insert back in the shared chain.
 
 A CLAP or VST3 plugin has no shared chain to go back to, so it always runs
@@ -672,11 +633,12 @@ systemctl --user restart openxlr-daemon.service
 
 The restart interrupts audio briefly.
 
-Trouble with an editor never costs you the sound. If the X server goes
+Editor display failures are handled separately from audio. If the X server goes
 away while an editor is open, the editor closes and the plugin keeps
 processing; pressing "Plugin UI" again opens a fresh one. If an editor
 stops answering, the insert says its controls are frozen and its audio
-carries on. A plugin that keeps crashing has its chain switched off after
+carries on. A crash of the plugin process interrupts the chain while it
+recovers. A plugin that keeps crashing has its chain switched off after
 it has failed three times in five minutes, with the reason on the insert;
 changing or bypassing that chain starts it over.
 
@@ -724,7 +686,8 @@ Restart OpenDeck after installing or updating the plugin.
 - `lsusb` should list an `0fd9:` device. If it does but the header
   still says no device, look at the daemon's log:
   `journalctl --user -u openxlr-daemon -n 50`. "present but could not
-  be opened" is the udev rule not applied yet.
+  be opened" can mean missing USB permission or a busy interface; check
+  the udev rule and whether another hardware-control program is running.
 - With more than one supported interface attached, the header shows a
   picker; the mixer's input channels follow the chosen one.
 
@@ -740,11 +703,11 @@ restart WirePlumber.
 
 A second cause, when the microphone is silent only after a reboot: the
 dock forgets its gain at every power cycle and comes back at the gain its
-firmware chooses, which is lower than most people set. OpenXLR gives the
-gain back when the dock connects, even when the gain lock is on, from
-0.1.30 onwards. On an older version, take the lock off and set the gain
-again. A gate or an expander in the insert chain, tuned at the gain you
-meant to have, stays shut at a lower one and passes nothing at all, which
+firmware restores, which can differ from the gain used by your insert chain.
+OpenXLR gives the
+gain back when the dock connects, even when the gain lock is on. This
+fix is on `main` after 0.1.29; on a build without it, take the lock off
+and set the gain again. A gate or expander tuned at the gain you meant to have stays shut at a lower one and passes nothing at all, which
 is what makes the microphone sound dead rather than quiet.
 
 <a name="daemon-not-starting"></a>
@@ -770,9 +733,12 @@ is what makes the microphone sound dead rather than quiet.
 - The software ClipGuard needs the SWH LADSPA plugins (`swh-plugins`).
   Without them the control is disabled and its tooltip says so; the
   rest keeps working.
-- The insert picker lists what lilv finds in the standard LV2
-  directories (`/usr/lib/lv2`, `~/.lv2`, or `LV2_PATH`). An empty
-  picker means no LV2 plugins are installed, or lilv is missing.
+- For LV2, check lilv and the installed plugins in `/usr/lib/lv2`, `~/.lv2`
+  or `LV2_PATH`. CLAP and VST3 also require the native helper; Options
+  reports whether it is installed. A source build without the native
+  flag removes it. Check the format filter and press Rescan after an
+  external installation. A Windows bundle also needs Wine and a working
+  bridge; see [Windows plugins](#windows-plugins).
 - Before 0.1.27 an insert whose plugin URI contains a `#` (the x42
   plugins, for one: `darc#mono`) failed with "PipeWire filter chain did
   not create the required ports ... Could not load module", because
@@ -837,8 +803,9 @@ and says so in the editor, which also shows a note once the server is at
 three quarters of its limit. The fix is a systemd drop-in that raises the
 limit to 65536:
 
-1. The deb, rpm and Nix packages install it as
-   `/usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf`. On a
+1. The deb and rpm packages install it as
+   `/usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf`; the NixOS
+   module sets the same service limit declaratively. On a
    source checkout, or any install without it, create the file yourself:
 
    ```sh
@@ -911,14 +878,20 @@ it to a public issue. Nothing is uploaded automatically.
 | `~/.config/openxlr/profiles/<vid-pid>/recall-on-connect` | the profile recalled when that interface connects, when one is chosen |
 | `$XDG_RUNTIME_DIR/openxlr/token` (or `~/.config/openxlr/token` without a runtime directory) | the control API token for this daemon run, readable by your user only; the window and the OpenDeck plugin read it, a daemon older than the window will not have it ([section 3.10](#upgrade)) |
 | `$XDG_RUNTIME_DIR/openxlr/daemon.lock` | held by the running daemon; a second daemon started for the same user stops at once instead of waiting for the port |
-| `~/.config/openxlr/devices/<vid-pid>/last-state.json` | the settings restored on connect to an interface without settings memory |
+| `~/.config/openxlr/devices/<vid-pid>/last-state.json` | the settings restored on connect when `retainsSettings` is false |
 | `~/.config/openxlr/devices/<vid-pid>/defaults.json` | the firmware defaults of such an interface, recorded after a power cycle, written back by "Reset device to defaults" (the Pro has no such file: its reset writes OpenXLR's baseline) |
 | `~/.config/openxlr/daemon.json` | the submixer on/off preference |
 | `~/.config/openxlr/gainlock.json` | which devices have the gain lock set |
+| `~/.config/openxlr/bridge/yabridgectl/config.toml` | companion bridge folder registry, separate from the system bridge |
+| `~/.local/share/openxlr/yabridge/{vst3,clap,vst2}` | companion-generated wrappers; OpenXLR loads VST3 and CLAP only |
 | `~/.config/openxlr/ui.json` | window preferences |
 | `openxlr-daemon.service` (systemd user unit) | the daemon; `journalctl --user -u openxlr-daemon` for its log |
 | `/usr/lib/systemd/user/pipewire-pulse.service.d/openxlr.conf` | installed by the packages: raises pipewire-pulse's open-file limit ([section 5.8](#open-files)) |
 | `ws://127.0.0.1:37890/ws` | the daemon's API, documented in [api.md](api.md); the same commands over HTTP at `/api/v1` ([http-api.md](http-api.md)) |
+
+Configuration paths honor `XDG_CONFIG_HOME`; the private wrapper root honors
+`XDG_DATA_HOME`. Without `XDG_RUNTIME_DIR`, runtime files use the private
+OpenXLR configuration directory.
 
 Uninstalling a package leaves `~/.config/openxlr` in place; remove it
 by hand if you want a clean slate.

--- a/docs/mixer-layout.md
+++ b/docs/mixer-layout.md
@@ -35,7 +35,9 @@ Existing monitor-feed settings and profile semantics are unchanged.
 ## Editing while running
 
 The window's Edit layout button, and the commands below over the API,
-change the layout without stopping audio. Each one is saved before it is
+edit the running graph. Adding or reordering preserves existing routes;
+renaming an application channel can cause a short gap on that channel,
+and deleting a virtual microphone disconnects its recorders. Each one is saved before it is
 acknowledged; a failed save restores the previous layout and reports an
 error. Ordinary fader saves keep their debounced, retried behaviour.
 
@@ -69,7 +71,7 @@ error. Ordinary fader saves keep their debounced, retried behaviour.
 
 Every added channel or mix costs pipewire-pulse a few dozen open files;
 the daemon refuses an addition the server has no room for, and the packages
-raise the server's limit ([manual, section 5.8](manual.md#open-files)).
+raise the server's limit ([manual: open-file limit](manual.md#open-files)).
 
 Ids are generated from names (lowercase letters, digits and hyphens,
 starting with a letter, unique with a numeric suffix) and never change

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,8 +3,8 @@
 What OpenXLR is heading towards, in the order the maintainer intends to
 take it, and the rules a change has to meet to land. Items move here
 from issues and pull requests once they are agreed; a checked item is
-merged on main and verified on hardware, and the release notes say when
-it shipped.
+implemented on `main`. Device-specific verification is recorded in
+[hardware-support.md](hardware-support.md); release notes say when it shipped.
 
 The goal has not changed since the first release: native Linux control
 of the Elgato XLR interfaces, a Wave Link style submixer on plain
@@ -13,7 +13,10 @@ behaviour verified on hardware before it ships. The project is small on
 purpose. It prefers one small, idiomatic change over a framework, and a
 feature that is measured over one that is described.
 
-## Where it stands (0.1.29)
+## Where it stands on main
+
+This includes changes merged after 0.1.29. A checked item does not imply
+that a published package already includes it.
 
 - [x] Wave XLR Pro, XLR Dock (MK.1 and MK.2 modules), Wave XLR, Wave XLR
   MK.2: hardware controls, verified by owners of each device.
@@ -24,15 +27,20 @@ feature that is measured over one that is described.
   or the API, every change saved before it is acknowledged); monitoring
   on several outputs with each output choosing which monitor mix feeds it,
   the USB Aux port as a second computer's feed, live meters, profiles,
-  one profile per device recalled on connect, interfaces without
-  settings memory restored to their last settings on connect with a
+  one profile per device recalled on connect, Wave XLR and the first XLR Dock
+  restored to their last settings on connect with a
   reset to firmware defaults, and an app can be left to the desktop's
   own routing.
-- [x] Software low cut and ClipGuard for devices without the hardware
-  versions.
-- [x] Plugin inserts: LV2 chains on each XLR input and on every mix, hosted
-  by PipeWire's filter-chain, with generated controls; bypass and
-  controls on the Stream Deck.
+- [x] Software low cut and limiting where the backend does not expose
+  the corresponding hardware controls; gain lock respects connect-time
+  restoration while preventing requested gain changes.
+- [x] Plugin inserts: LV2, CLAP and VST3 chains on each XLR input and
+  every mix, generated controls and native editors, bypass and parameter
+  controls on the Stream Deck. See the completed plugin work below.
+- [x] Application identity fallback from streams to clients, normalized
+  Wine/Proton names and migration of stale saved aliases.
+- [x] Flow window: four routing columns, selectable signal paths,
+  processing inside cards and automatic initial sizing.
 - [x] OpenDeck plugin: dials and keys drawn like the hardware, profile
   keys, insert keys and dials, monitor feed keys.
 - [x] Packages: AUR, Debian/Ubuntu, Fedora, NixOS flake and module.
@@ -49,8 +57,8 @@ feature that is measured over one that is described.
 ## Next: mixer layout and customization
 
 The submixer's shape is the user's own since the editable layout landed;
-what remains in this block is how the mixer presents itself. It still
-comes before anything in the plugins section: the routing model, the
+what remains in this block is how the mixer presents itself. The remaining
+layout work comes before further plugin expansion: the routing model, the
 layout editing and the daemon's service behaviour all changed within a
 few releases, and they get to settle in users' hands first.
 
@@ -101,20 +109,21 @@ every view binds to.
 
 ## Later: plugins
 
-Stage 1 (LV2 through filter-chain) is shipped. Stage 2 is the rest of the
-plugin world, and it has to keep the audio path inside PipeWire. It waits
-for the mixer layout block above; the maintainer would rather have one
-host mechanism stable than two half-finished ones.
+LV2 filter-chain, native LV2/CLAP/VST3 hosting and plugin installation are
+implemented. Remaining plugin work follows the mixer priorities above,
+while fixes to existing hosts remain part of normal maintenance.
 
 - [x] Native plugin editors: an LV2 plugin's own window, open on the
   instance that processes its audio. The instance moves out of
-  filter-chain into an optional C helper that carries one plugin and its
+  filter-chain into an optional C/C++ helper that carries one plugin and its
   editor behind a PipeWire filter node. It is a per-insert choice, so an
   existing chain never changes host on upgrade, and every insert without
-  that choice stays in filter-chain. A failing editor costs the editor
-  only: a lost X display, an editor that stops answering and a plugin that
-  crashes on start are each handled with the audio still playing. Every
-  package builds and installs the helper; an ordinary .NET build still
+  that choice stays in filter-chain. Display loss and stalled editor
+  controls leave healthy processing running; plugin-process crashes can
+  interrupt the chain and repeated failures stop automatic retries.
+  Resizing follows plugin constraints, fixed-size VST3 editors retain
+  plugin-driven scaling, and LSP editors default to software rendering.
+  Every package builds and installs the helper; an ordinary .NET build still
   needs no compiler, and a source build opts in with
   `-p:EnableNativeLv2Host=true`.
 - [x] CLAP, in the same host: the helper loads a CLAP plugin, carries
@@ -126,15 +135,18 @@ host mechanism stable than two half-finished ones.
   headers (vendored, MIT), one plugin per process, with the component and
   controller wired, parameters as controls, and the editor on a run loop of
   ours. Windows VST3 plugins arrive through yabridge as ordinary bundles.
-  Scans are cached per bundle, since a module of two hundred plugins takes
-  a quarter of a minute to describe. Carla was considered and dropped: no
-  commit in six months, no CLAP, and a second audio engine.
+  Scans are cached per bundle to avoid repeating expensive discovery.
+  Audio remains on PipeWire ports in the same per-insert process model.
 - [x] Installing plugins from the window: pick a file or a folder and the
   daemon puts it where it looks, copies Linux bundles into the home
   directories, hands Windows plugins to yabridge and syncs, and reads the
   catalogues again. A card in Options says where plugins go and whether
   yabridge and Wine are there, with a rescan, a sync and the steps behind a
   Manual link.
+- [x] Optional OpenXLR yabridge companion: pinned 64-bit bridge with the
+  Wine editor input fix, private wrappers and controller settings, system
+  bridge fallback, and binary/source package artifacts. The separate CI
+  workflow does not publish them to release or distribution repositories.
 - [ ] Presets: per-plugin and whole-chain, with export and import; copy a
   chain between channels; A/B comparison.
 - [ ] Plugin latency reported per insert and compensated across mixes.
@@ -218,8 +230,9 @@ host mechanism stable than two half-finished ones.
 - Contributors are credited in the README once their work is merged, in
   a Credits section the maintainer writes, and in the release notes. A
   pull request does not add its own credit paragraph.
-- The .NET build stays a .NET build. Native helpers, when they come, are
-  optional at build time and packaged separately.
+- The .NET build stays usable without a native compiler. The plugin host
+  is optional at source-build time and included in distribution packages.
+  The Windows bridge is a separate optional companion.
 - The audio graph is not rebuilt for a change that does not need it;
   every node the daemon creates has a name that survives restarts, and
   existing users' assignments and profiles keep working across upgrades.

--- a/docs/usb-capture.md
+++ b/docs/usb-capture.md
@@ -4,8 +4,11 @@ This guide is for owners of the original Wave XLR (`0fd9:007d`) who want
 to help map the rest of its protocol. No programming needed, just
 Wireshark and about 15 minutes.
 
-The goal is the mic DSP: low cut, ClipGuard, and the mic/PC crossfade
-exist in the hardware but their registers have not been captured.
+The remaining targets are low cut, ClipGuard, mic/PC crossfade and the
+hardware-save action exposed by Wave Link. Their OpenXLR commands are not
+yet mapped; the [support table](hardware-support.md#wave-xlr-0fd9007d)
+tracks current status. Capture these device controls separately from
+software plugin effects.
 Phantom power is already coded (the
 [openwave](https://github.com/rikkichy/openwave) project found its
 byte); the phantom toggles in your capture serve as confirmation, and
@@ -66,6 +69,8 @@ time with 5 second pauses between them, in this order:
 4. ClipGuard on, pause, off.
 5. Headphone volume: minimum, pause, maximum, pause, middle.
 6. Mic/PC balance: sweep it fully one way, pause, fully back.
+7. Save settings to hardware, if your Wave Link version offers it. Note
+   the gain before saving, then replug and record what was retained.
 
 Jot down the order you actually did things in and roughly when. The
 notes matter as much as the capture.
@@ -86,7 +91,9 @@ XLR MK.1 USB capture" and attach:
 In Wireshark, type
 `usb.idProduct == 0x007d` into the filter bar and press enter. You
 should see a packet from the replug; its "Device address" field, say 5,
-identifies your Wave XLR. Now filter `usb.device_address == 5` and you
-are looking at only the Wave XLR's traffic. Toggling phantom in Wave
-Link should have produced a small burst of packets at each moment you
-clicked.
+identifies your Wave XLR on that USB bus. Filter by both `usb.bus_id`
+and `usb.device_address` if the file contains several buses. Recheck the
+address after a replug; it may change. Use File, Export Specified Packets
+and select displayed packets to create a device-only file to share. A
+display filter alone does not remove other devices from the saved capture.
+Toggling phantom should produce a small burst at each recorded action.

--- a/docs/wave-xlr-linux-audio-stack-research.md
+++ b/docs/wave-xlr-linux-audio-stack-research.md
@@ -2,7 +2,9 @@
 
 The survey and decisions that preceded OpenXLR, condensed from the
 research log. Repository statistics are from the dates given and have
-drifted since. The protocol findings that came out of this work are in
+drifted since. For installation and current behaviour, use the
+[manual](manual.md), [architecture](architecture.md) and
+[hardware support](hardware-support.md). The protocol findings that came out of this work are in
 [wave-xlr-pro-protocol.md](wave-xlr-pro-protocol.md).
 
 ## 1. The replacement target
@@ -45,8 +47,9 @@ driver work.
 - Stream Deck hosts: [OpenDeck](https://github.com/nekename/OpenDeck)
   (Tauri, runs Elgato SDK plugins, OpenAction plugin API) was chosen.
   Its 2.14.0 release (2026-07-29) supports the Stream Deck + XL
-  natively, including encoder events, touch taps and per-encoder LCD
-  rendering. StreamController's + XL support was in beta with open
+  natively, including encoder events and per-encoder LCD rendering. Touch-tap
+  support for the + XL needed a later upstream fix; see the
+  [current plugin instructions](features.md#opendeck-plugin). StreamController's + XL support was in beta with open
   dial and touchscreen issues. Neither host imports Elgato profiles;
   profiles are rebuilt by hand.
 - Adjacent projects used as references: goxlr-utility (headless daemon

--- a/docs/wave-xlr-pro-capture-plan.md
+++ b/docs/wave-xlr-pro-capture-plan.md
@@ -1,10 +1,12 @@
 # Wave XLR Pro USB protocol capture plan
 
 Status: completed historical procedure. The ordered follow-up capture
-resolved the control map; use
+resolved the input and output-selector controls described here; use
 [wave-xlr-pro-protocol.md, section 6](wave-xlr-pro-protocol.md#6-capture-2-xlrpro2pcapng-2026-08-25-with-ordered-action-log-outputs-mic-dsp-usb-aux)
 for current offsets. The steps below are retained as the methodology for
 capturing another device, not as the current protocol specification.
+Hardware EQ and the remaining mix matrix still need separate captures;
+see [hardware support](hardware-support.md) and the [roadmap](roadmap.md#devices).
 
 Goal: capture every USB control transfer Wave Link sends to the Wave XLR Pro so its vendor
 protocol can be reimplemented in a Linux backend. The device has
@@ -68,7 +70,8 @@ USBPcap captures the whole root hub, so filter in Wireshark. Two ways:
 - Useful display filters while reviewing:
   - Control transfers only: `usb.transfer_type == 0x02`
   - Vendor/class SETUP packets (the interesting writes): `usb.bmRequestType.type == 2` (vendor)
-    or `== 1` (class). The MK.2 used **standard class requests**, so also watch class ones.
+    or `== 1` (class). The MK.1 uses class requests; the MK.2/Pro family uses vendor requests.
+    Watch both when identifying an unknown device.
   - Interrupt IN traffic (the 6-byte endpoint): `usb.transfer_type == 0x01`
   - Just the setup stage with data: `usb.setup.wLength > 0`
 

--- a/docs/wave-xlr-pro-protocol.md
+++ b/docs/wave-xlr-pro-protocol.md
@@ -1,7 +1,9 @@
 # Wave XLR Pro vendor control protocol
 
 How the Wave XLR Pro's vendor protocol was captured and decoded, in the order it happened;
-later sections correct earlier ones where noted.
+later sections correct earlier ones where noted. This is a chronological
+notebook: provisional labels are retained as evidence, not API promises.
+For supported controls, start with [hardware-support.md](hardware-support.md).
 
 Source: `wavexlrpro.pcapng` (7.4 GB, 4.6M packets, 649 s, Wave Link on Windows, 2026-08-25).
 Decoded on Linux with tshark. No companion action-log was captured, so **block/offset → named
@@ -10,7 +12,7 @@ below are directly observed and solid.
 
 ## Implementation
 
-The shipping implementation of this protocol is
+The current implementation of this protocol is
 `src/OpenXLR.Core/Devices/WaveXlrProDevice.cs` (libusb control transfers,
 read-modify-write of the blocks below, commit block after selector
 writes): both XLR structures, both headphone volumes, the USB Aux input
@@ -60,7 +62,8 @@ interface, class 0xFF, that has no kernel driver, so no audio-driver detach need
 | wLength        | fixed per block  | fixed per block  |
 
 So it is NOT the MK.1 `wIndex=0x3303` trick and NOT the MK.2 `wIndex=0x0203` standard-class
-scheme. It is a **paged property bank**: `wValue` selects a fixed-size block; the whole block is
+address. The MK.2 also uses vendor requests; "standard-class" above was
+an early classification error. It is a **paged property bank**: `wValue` selects a fixed-size block; the whole block is
 read or written as one unit; individual controls are byte fields at fixed offsets inside a block.
 
 ## 2. The blocks (wValue) observed

--- a/native/README.md
+++ b/native/README.md
@@ -1,4 +1,4 @@
-# Optional LV2 editor host
+# Native plugin host
 
 This directory builds `openxlr-lv2-host`, a small process that loads one
 plugin, LV2, CLAP or VST3, gives it PipeWire ports and, on request, opens
@@ -9,8 +9,8 @@ DSP instance directly (LV2 instance access), which a PipeWire filter chain
 cannot offer.
 
 The distribution packages build and install it, and its presence changes
-nothing on its own: inserts use the filter chain until one is explicitly
-switched to the native host in its controls window.
+existing LV2 inserts: they use filter-chain until explicitly switched in
+the controls window. CLAP and VST3 always use this helper.
 
 ## Build
 
@@ -22,7 +22,7 @@ dotnet build src/OpenXLR.slnx -c Release -p:EnableNativeLv2Host=true
 
 The flag compiles this directory and copies the helper next to the daemon,
 which is what the packaging recipes do. `make -C native` builds it alone.
-It needs a C11 compiler, make, pkg-config and the development files for
+It needs a C11 and a C++ compiler, make, pkg-config and the development files for
 PipeWire, lilv, LV2 and X11; the libraries it links are already runtime
 dependencies of every package.
 
@@ -48,15 +48,18 @@ tests the explicit OpenGL override. It creates no audio links.
 - One process per insert, holding one plugin instance and its editor.
 - Audio stays in PipeWire: the process is a `pw_filter` with the plugin's
   ports. Samples never cross the command pipe or managed code.
-- The pipe carries control values only, in both directions. What the editor
-  changes comes back and is saved with the mixer, like any other control.
+- The pipe carries parameter values, status and editor requests in both
+  directions, never audio. Exposed parameter changes are saved with the mixer;
+  opaque plugin state and plugin presets are not persisted.
 - The daemon owns the process. Closing its stdin ends the helper, which is
   why it watches that pipe rather than using PDEATHSIG, whose Linux semantics
   follow the thread that spawned it.
 
-## What it will not do to your audio
+## Editor failures and audio recovery
 
-The whole point is that an editor cannot cost you the microphone.
+Display loss or stalled editor controls do not rebuild a healthy audio
+instance. Plugin code and its editor share a process, so a process crash
+can still interrupt that insert's chain.
 
 - A protocol error from the editor is logged and the plugin keeps running.
   Xlib's default handler would have exited the process.
@@ -143,7 +146,10 @@ since that is most of the cost of describing a large module; every VST3
 plugin is assumed to have one and the host finds out when asked. The
 interface headers are vendored under `vst3/` (MIT, VST 3.8.1); only their
 inline parts are used, so nothing of the SDK is compiled. Windows VST3
-plugins arrive through yabridge as ordinary bundles.
+plugins arrive through yabridge as ordinary bundles. The optional
+[OpenXLR companion](../packaging/yabridge/README.md) supplies matching
+64-bit libraries and host with the Wine input fix, selected through the
+helper's PATH. Wine and plugin settings remain in the user's environment.
 
 Editor X events wake the main loop directly; the 30 Hz tick remains for
 idle work and the Wine coordinate workaround. During a frame resize, the

--- a/packaging/opendeck-patches/README.md
+++ b/packaging/opendeck-patches/README.md
@@ -1,8 +1,9 @@
 # OpenDeck patches
 
 Patches against OpenDeck 2.14.0 (`src-tauri`, apply with `patch -Np1`)
-that this project's Stream Deck experience currently depends on, kept
-here until they land upstream. (A swipe-to-dial-ticks patch used to
+retained for the image-quality change described below. A stock OpenDeck
+works with the plugin; this patch is optional. Check the linked upstream
+changes before applying it to a newer OpenDeck release. (A swipe-to-dial-ticks patch used to
 live here too; upstream declined it as inconsistent with Elgato's
 behaviour, so it was dropped.)
 
@@ -11,7 +12,7 @@ behaviour, so it was dropped.)
   resizes with nearest-neighbour, which visibly aliases every plugin's
   keys. Upstream:
   [nekename/OpenDeck#439](https://github.com/nekename/OpenDeck/pull/439)
-  (draft; the maintainer prefers the fix in the crate, see
+  (the original proposal; the corresponding crate change is
   [OpenActionAPI/rust-elgato-streamdeck#62](https://github.com/OpenActionAPI/rust-elgato-streamdeck/pull/62)).
 The Arch build that applies it lives outside this repo (an AUR
 `opendeck` checkout with the patch added to `prepare()`); a stock

--- a/packaging/ucm/README.md
+++ b/packaging/ucm/README.md
@@ -1,16 +1,17 @@
 # UCM profile for the Wave XLR Pro (experimental)
 
 An ALSA UCM2 profile that splits the Pro's 17-in/18-out multichannel
-card into named, useful devices for people running WITHOUT the OpenXLR
-daemon: a "Monitor (headphones / line out)" sink on playback pair 2/3,
+card into named devices when the OpenXLR submixer is off, or when
+OpenXLR is not running: a "Monitor (headphones / line out)" sink on playback pair 2/3,
 the three other hardware-monitor-bus feeds as Line1..3 (pairs 10/11,
 12/13, 14/15), and mono "XLR 1" / "XLR 2" sources (capture pairs 0 and
 1). Suggested by the goxlr-utility / PipeWeaver author; the GoXLR's own
 in-tree UCM profile is the precedent.
 
-Install: `install.sh` as root (purely additive under
+From this directory, install: `./install.sh` as root (purely additive under
 `/usr/share/alsa/ucm2/USB-Audio/`, edits nothing shipped), then restart
-pipewire + wireplumber. Revert: `revert.sh` + the same restart.
+pipewire + wireplumber. Revert: `./revert.sh` as root, then the same restart. Restarting the audio
+services interrupts playback and recording.
 
 ## Verified 2026-08-30 on real hardware
 
@@ -28,9 +29,9 @@ pipewire + wireplumber. Revert: `revert.sh` + the same restart.
 
 Under the HiFi split the raw multichannel nodes the daemon links
 against do not exist. The daemon therefore switches the card to the
-pro-audio profile while it drives the device and restores the previous
-profile on graceful shutdown, so the split serves exactly when OpenXLR
-is not running.
+pro-audio profile while its submixer runs and restores the previous
+profile on graceful shutdown. In hardware-control-only mode the split
+can remain active; see [the manual](../../docs/manual.md#hardware-only).
 
 ## Status
 

--- a/packaging/yabridge/README.md
+++ b/packaging/yabridge/README.md
@@ -15,8 +15,15 @@ folder sync from writing into another DAW's bridge tree.
 
 ## Install
 
-Choose the companion artifact for the distribution, then use its package
-manager:
+The [Optional Windows bridge workflow](https://github.com/emaspa/openxlr/actions/workflows/yabridge.yml)
+produces binary and corresponding source artifacts for review. It does
+not publish to GitHub Releases, AUR, COPR or the PPA. Download an artifact
+from a successful run or build it below; extract it and verify the included
+`SHA256SUMS` with `sha256sum -c SHA256SUMS` in its directory.
+
+Choose the package for your distribution and architecture, then run only
+the matching command. The companion supports x86-64 Linux and 64-bit
+Windows plugins; it does not bundle Wine or 32-bit plugin support:
 
 ```sh
 sudo apt install ./openxlr-yabridge_*_amd64.deb wine
@@ -30,16 +37,25 @@ OpenXLR selects the companion's matching libraries and host through its
 isolated helper's PATH. It can still read existing system wrappers; new
 wrappers are private. Other DAWs keep their existing environment and files.
 
-For NixOS, set `services.openxlr.yabridgePackage` to this flake's
-`packages.x86_64-linux.openxlr-yabridge`. The module passes the store path
-to the daemon. Build it separately with `nix build .#openxlr-yabridge`.
+For NixOS, import the OpenXLR module as shown in the [README](../../README.md#install),
+then add this to the service configuration (`openxlr` is the flake input):
+
+```nix
+services.openxlr.yabridgePackage = openxlr.packages.x86_64-linux.openxlr-yabridge;
+```
+
+The module passes the store path to the daemon. Build it separately with
+`nix build .#openxlr-yabridge` from the repository root.
 
 `OPENXLR_YABRIDGE=system` opts out and uses the system/user bridge. An
 absolute path selects a companion installed elsewhere. Restart the daemon
-after changing this setting. The system bridge needs its own synced
+after changing this setting. The selected directory must contain the complete
+payload and its `openxlr-yabridge.json` receipt; an incomplete directory is
+not selected. Options shows the effective provider, version and path.
+The system bridge needs its own synced
 wrappers when opting out; OpenXLR's private files remain for switching back.
 
-## Build and publish
+## Build and prepare publication
 
 Tools: Python 3, Git, Meson, Ninja, CMake, pkg-config, a C++ compiler,
 winegcc/wineg++, Wine development files, XCB and D-Bus headers, Cargo and

--- a/src/README.md
+++ b/src/README.md
@@ -13,7 +13,7 @@ into a second, contradictory product manual.
 - `OpenXLR.Core`: device backends, capability model, PipeWire graph, profiles,
   application matching, meters, and plugin chains.
 - `OpenXLR.Daemon`: owns hardware and mixer state and exposes the localhost
-  WebSocket API.
+  WebSocket and HTTP APIs.
 - `OpenXLR.UI`: Avalonia client; it never owns hardware or audio state.
 - `OpenXLR.Probe`: diagnostics and protocol-development console tool.
 - `OpenXLR.Tests`: regression tests for routing, device capabilities, profiles,
@@ -30,8 +30,9 @@ into a second, contradictory product manual.
   the graph.
 - Hardware input channels follow the actively selected interface. There is no
   `setMicInput` command or `OPENXLR_MIC_INPUT` override.
-- Low cut, software ClipGuard, and LV2 inserts are optional filter chains in
-  front of the affected channel. A replacement chain must be complete before
+- Low cut and software ClipGuard use PipeWire filter-chain. LV2 inserts
+  default to filter-chain and can opt into the native helper; CLAP and VST3
+  always use it. Chains can precede XLR channels or process mix outputs. A replacement chain must be complete before
   it replaces the audible route.
 - Device controls are capability-gated. A backend must not advertise a control
   until its implementation and hardware mapping are usable.
@@ -41,17 +42,21 @@ into a second, contradictory product manual.
 From the repository root:
 
 ```sh
-dotnet restore src/OpenXLR.slnx
-dotnet build src/OpenXLR.slnx -c Release --no-restore
+dotnet restore src/OpenXLR.slnx --locked-mode
+dotnet build src/OpenXLR.slnx -c Release --no-restore -warnaserror -p:EnableNativeLv2Host=true
 dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build
 ```
 
 Run the daemon with the mixer enabled:
 
 ```sh
-OPENXLR_BUILD_MIXER=1 dotnet run --project src/OpenXLR.Daemon
-dotnet run --project src/OpenXLR.UI
+OPENXLR_BUILD_MIXER=1 ./src/OpenXLR.Daemon/bin/Release/net10.0/OpenXLR.Daemon
+# in another terminal, from the repository root:
+./src/OpenXLR.UI/bin/Release/net10.0/OpenXLR.UI
 ```
 
 The WebSocket command table and configuration paths are maintained only in the
-root [README](../README.md#websocket-api).
+[API reference](../docs/api.md). The complete check list is in
+[CONTRIBUTING.md](../CONTRIBUTING.md); native editor and bridge details
+are in [native/README.md](../native/README.md) and the
+[companion guide](../packaging/yabridge/README.md).


### PR DESCRIPTION
The guides still described LV2-only inserts, source builds omitted the native helper, and hardware support claims exceeded the mapped controls. This revision aligns the README and all authored guides with current mixer, plugin and packaging behavior.

- Document LV2/CLAP/VST3 hosting, editor constraints and LSP rendering, managed Windows bridging, private paths and system fallback.
- Update routing identity, Flow, settings restoration, API fields, source commands, service setup and uninstall instructions. Add a documentation index and preserve dated protocol evidence.
- Distinguish current main from released packages and companion CI artifacts from published distribution packages. Clarify hardware DSP, software effects and unmapped controls.

Validation: native-enabled Release build with zero warnings/errors; 327 .NET tests; 5 OpenDeck tests; native editor regressions on the desktop display; all 153 relative/app-manual links and 41 dispatched commands checked; shell example syntax, manifest, OpenAPI, version, locked-restore, shell lint, RPM and whitespace checks passed. The documented authenticated HTTP state read also succeeded against the local daemon.

Documentation only. No hardware writes or live plugin changes were needed. Distribution installation recipes were checked against packaging sources, not installed afresh on every distribution. Native Xvfb coverage runs in CI; Xvfb is not installed on the local workstation. No release version, tag or release workflow output changes.
