### PR TITLE
Docs: say where the Windows bridge comes from

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ Collect diagnostics).
   monitor mixes on several outputs at once.
 - **Inserts**: LV2, CLAP and VST3 plugin chains on each XLR input and each mix, with a
   plugin picker, generated controls, bypass and native plugin editors.
-  Windows VST3 and CLAP plugins use Wine and yabridge; an optional
-  OpenXLR companion supplies the Wine editor input fix and private wrappers.
+  Windows VST3 and CLAP plugins use Wine and yabridge; the
+  `openxlr-yabridge` package supplies a tested bridge with the Wine editor
+  input fix and private wrappers.
 - **Application routing**: audio clients are detected from their
   PipeWire registration and routed to a channel by name rules, with the
   assignment remembered per app; an app can also be left to the
@@ -220,10 +221,13 @@ also covers WirePlumber rules, the open-file limit, the user service,
 updating and uninstalling. Keep the native build flag on subsequent builds
 to retain CLAP, VST3 and plugin editors.
 
-For Windows plugins, see [the manual](docs/manual.md#windows-plugins) and
-[the companion package guide](packaging/yabridge/README.md). The companion
-has a separate build workflow; its CI artifacts are not automatically
-published to the OpenXLR release or distribution repositories.
+For Windows plugins, install `openxlr-yabridge` from the same place you
+installed OpenXLR: the AUR, the PPA, the COPR repository, or the packages
+on the release page. It carries a tested bridge with the Wine editor input
+fix, without which a plugin editor ignores the mouse on Wine 9.22 and
+newer. [The manual](docs/manual.md#windows-plugins) walks through it and
+[the package guide](packaging/yabridge/README.md) covers building it
+yourself.
 
 ## Documentation
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -151,10 +151,10 @@ or `~/.vst3`. Windows installers must run in Wine first; OpenXLR bridges
 the installed plugins and rescans automatically. Options offers a rescan,
 a Windows sync, detected Wine folders and the selected bridge's status.
 
-The optional `openxlr-yabridge` companion includes the Wine 9.22+ editor
-input fix. It creates wrappers under `~/.local/share/openxlr/yabridge` and
-keeps its controller registry under `~/.config/openxlr/bridge`, honoring
-XDG overrides. Other DAWs' wrappers and controller settings remain separate.
+The `openxlr-yabridge` companion is packaged on every channel OpenXLR is,
+and includes the Wine 9.22+ editor input fix. It creates wrappers under
+`~/.local/share/openxlr/yabridge` and keeps its controller registry under
+`~/.config/openxlr/bridge`, honoring XDG overrides. Other DAWs' wrappers and controller settings remain separate.
 Private wrappers take priority over duplicate global copies. A system/user
 bridge remains supported; Options warns about known incompatible versions.
 See [Windows plugins](manual.md#windows-plugins) for availability and setup.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -270,30 +270,40 @@ searched).
 [yabridge](https://github.com/robbert-vdh/yabridge), which wraps them as
 Linux bundles.
 
-The optional **openxlr-yabridge** package supplies a tested bridge for
-64-bit Windows VST3 and CLAP plugins, including the Wine editor input fix.
-Wine remains a system dependency. The companion currently comes from the
-separate [Optional Windows bridge workflow](https://github.com/emaspa/openxlr/actions/workflows/yabridge.yml)
-or a source build. That workflow creates binary and source artifacts; it
-does not attach them to OpenXLR releases or publish distribution packages.
-Download and extract the artifact for your distribution, check its
-`SHA256SUMS`, and follow the [package guide](../packaging/yabridge/README.md).
-Install the companion artifact with
-your distribution's package manager, then restart the daemon:
+The **openxlr-yabridge** package supplies a tested bridge for 64-bit
+Windows VST3 and CLAP plugins, built from a pinned source with the Wine
+editor input fix. Install it from the same place you installed OpenXLR.
+Wine comes with it as a dependency.
 
 ```sh
-# Debian or Ubuntu
-sudo apt install ./openxlr-yabridge_*_amd64.deb wine
-# Fedora
-sudo dnf install ./openxlr-yabridge-*.x86_64.rpm wine
-# Arch
-sudo pacman -U ./openxlr-yabridge-*-x86_64.pkg.tar.zst
+# Arch, from the AUR
+yay -S openxlr-yabridge
+
+# Ubuntu, from the PPA you already added for OpenXLR
+sudo apt install openxlr-yabridge
+
+# Fedora 44, from the COPR repository you already enabled
+sudo dnf install openxlr-yabridge
 ```
 
-Use the command for your distribution. Run
-`systemctl --user restart openxlr-daemon` to load the companion; this briefly interrupts audio. Options
-then identifies the selected bridge as "OpenXLR bridge". Use "Bridge
-Wine's plugins" or pick a Windows plugin folder to create private wrappers.
+On NixOS, set `services.openxlr.yabridgePackage` to the flake's
+`openxlr-yabridge` package. On any other distribution, take the `.deb`,
+the `.rpm` or the `.pkg.tar.zst` from the
+[latest release](https://github.com/emaspa/openxlr/releases/latest), check
+it against `SHA256SUMS-yabridge.txt`, and install it by hand. The
+[package guide](../packaging/yabridge/README.md) covers building it
+yourself.
+
+Restart the daemon with `systemctl --user restart openxlr-daemon` so it
+finds the companion; this briefly interrupts audio. Options then
+identifies the selected bridge as "OpenXLR bridge". Use "Bridge Wine's
+plugins" or pick a Windows plugin folder to create private wrappers.
+
+Without the companion, a distribution yabridge works only with Wine older
+than 9.22. From 9.22 an embedded plugin window never learns where it is,
+so every click lands as far from the pointer as the window is from the
+corner of the screen, and the plugin ignores the mouse entirely. Options
+says so when it sees that pair of versions.
 
 The companion keeps those wrappers in
 `~/.local/share/openxlr/yabridge/{vst3,clap}` and its directory registry in

--- a/packaging/yabridge/README.md
+++ b/packaging/yabridge/README.md
@@ -15,14 +15,24 @@ folder sync from writing into another DAW's bridge tree.
 
 ## Install
 
-The [Optional Windows bridge workflow](https://github.com/emaspa/openxlr/actions/workflows/yabridge.yml)
-produces binary and corresponding source artifacts for review. It does
-not publish to GitHub Releases, AUR, COPR or the PPA. Download an artifact
-from a successful run or build it below; extract it and verify the included
-`SHA256SUMS` with `sha256sum -c SHA256SUMS` in its directory.
+Most people install it from the same place they installed OpenXLR:
 
-Choose the package for your distribution and architecture, then run only
-the matching command. The companion supports x86-64 Linux and 64-bit
+```sh
+yay -S openxlr-yabridge          # Arch, from the AUR
+sudo apt install openxlr-yabridge   # Ubuntu, from the PPA
+sudo dnf install openxlr-yabridge   # Fedora 44, from the COPR repository
+```
+
+On NixOS, set `services.openxlr.yabridgePackage` to the flake's
+`openxlr-yabridge` package.
+
+Every release also carries the packages themselves, next to a
+`SHA256SUMS-yabridge.txt` to check them against. The
+[Optional Windows bridge workflow](https://github.com/emaspa/openxlr/actions/workflows/yabridge.yml)
+builds the same set from any branch, for review.
+
+To install a package by hand, choose the one for your distribution and run
+only the matching command. The companion supports x86-64 Linux and 64-bit
 Windows plugins; it does not bundle Wine or 32-bit plugin support:
 
 ```sh


### PR DESCRIPTION
The companion is now packaged on every channel OpenXLR is, so the documentation should stop sending people to a CI artifact.

- **The manual** leads with the one-line install for each channel: `yay -S openxlr-yabridge`, `sudo apt install openxlr-yabridge` from the PPA already added for OpenXLR, `sudo dnf install openxlr-yabridge` from the COPR repository already enabled, and `services.openxlr.yabridgePackage` on NixOS. The release packages and a source build follow as the fallbacks.
- It also says what happens without the companion: a distribution yabridge works only with Wine older than 9.22, and from 9.22 an embedded plugin editor ignores the mouse entirely, which is the fault Options warns about.
- **The README** and the feature notes drop "optional" and "not published" for the same reason.
- **The package guide** opens with the channel installs, keeps the by-hand instructions below them, and points at `SHA256SUMS-yabridge.txt` on the release.

Documentation only.