### PR TITLE
Roadmap: the onboard effects no control reaches yet

### DIFF
--- a/docs/hardware-support.md
+++ b/docs/hardware-support.md
@@ -32,7 +32,12 @@ the commit block every selector write needs.
 | Reset to OpenXLR's baseline | verified | the device keeps its settings, so the reset writes a known set (gain 30 dB, everything off, levels at half, crossfade on PC) instead of recorded firmware defaults |
 
 The Pro's onboard EQ, ducking, mix maximizer and channel booster have no
-mapped OpenXLR controls. The full hardware mix matrix is also unfinished.
+mapped OpenXLR controls. Elgato describes all four as running on the
+device: a four-band equalizer, ducking that lowers the other mixes while
+you speak and is applied per mix, a maximizer per mix, and a booster
+worth up to 12 dB above the normal ceiling on any input. The same
+four-band equalizer runs on the Wave XLR MK.2 and the XLR Dock MK.2,
+which have no ducking. The full hardware mix matrix is also unfinished.
 Elgato's [Pro feature guide](https://www.elgato.com/us/en/explorer/products/wave/wave-xlr-pro-give-your-setup-superpowers/)
 distinguishes those onboard effects from VST processing on the computer.
 OpenXLR exposes Voice Tune and the other DSP controls listed above; its

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -211,6 +211,19 @@ while fixes to existing hosts remain part of normal maintenance.
   (see the protocol notes, block 0x0001 bytes 12 and 13). Direct control
   of that matrix from the window is the long-term answer to the
   crossfade and mic-monitoring questions.
+- [ ] The four-band equalizer the Wave FX processor runs on the Pro, the
+  Wave XLR MK.2 and the XLR Dock MK.2. It is onboard DSP on all three,
+  and OpenXLR maps none of it, so a user who shapes their voice in Wave
+  Link on Windows loses that shape on Linux. Four bands means the
+  registers are wider than anything mapped so far, and the capture has to
+  separate the per-band frequency, gain and width bytes.
+- [ ] Ducking on the Pro, which lowers the other mixes while you speak
+  and is applied per mix. It is the one onboard effect that touches the
+  mix matrix rather than the microphone path, so it is worth capturing
+  together with the matrix above.
+- [ ] The Pro's mix maximizer and channel booster, the other two onboard
+  effects with no mapped control. The booster adds up to 12 dB above the
+  normal ceiling on any input; the maximizer is per mix.
 - [ ] LED controls where captures show the registers; nothing is guessed.
 - [ ] UCM profile for the Pro upstreamed to alsa-ucm-conf once a second
   owner confirms the split.


### PR DESCRIPTION
Checked against Elgato's own material, and you were right on both counts.

**The Pro.** Its feature guide assigns these to the device rather than to VST processing on the computer: "Ducking automatically lowers background audio when you speak, applied per mix", "Equalizer sculpts your voice across four bands", plus the mix maximizer and the channel booster, which pushes any input up to 12 dB beyond the standard ceiling.

**The MK.2 family.** The Wave XLR MK.2 and the XLR Dock MK.2 run five effects on the Wave FX processor: low cut, expander, voice tune, compressor and the same four-band equalizer. No ducking on either; that one is the Pro's.

Our hardware notes already said the Pro's EQ, ducking, maximizer and booster were unmapped, but nothing recorded that the equalizer is on the MK.2 devices too, and none of it was on the roadmap.

Three items added under Devices, each with what makes it awkward: four bands mean wider registers than anything captured so far and the capture has to separate frequency, gain and width per band; ducking touches the mix matrix rather than the microphone path, so it belongs with the matrix capture already listed above it.

Documentation only.