### PR TITLE
UI: the Options window fits a 1080p screen

### DIFF
--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -3,7 +3,7 @@
         xmlns:vm="using:OpenXLR.UI"
         x:Class="OpenXLR.UI.OptionsWindow"
         x:DataType="vm:OptionsViewModel"
-        Title="OpenXLR Options" Width="560" SizeToContent="Height"
+        Title="OpenXLR Options" Width="980" SizeToContent="Height"
         WindowStartupLocation="CenterOwner"
         Background="#16181d" CanResize="False">
 
@@ -23,7 +23,16 @@
     </Style>
   </Window.Styles>
 
-  <StackPanel Margin="14" Spacing="8">
+  <!-- Two columns of cards. One column of them is taller than a 1080p screen,
+       and a window that cannot be resized has no way to show what falls off
+       the bottom. The scroll view is the floor under that, and the code
+       behind caps the height to the screen the window opens on. -->
+  <DockPanel Margin="14">
+    <Button DockPanel.Dock="Bottom" Content="Close" HorizontalAlignment="Right"
+            Padding="18,6" Margin="0,10,0,0" Click="OnClose"/>
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+      <Grid ColumnDefinitions="*,10,*">
+        <StackPanel Spacing="8">
 
     <Border Classes="card">
       <StackPanel Spacing="6">
@@ -41,21 +50,6 @@
                   ToolTip.Tip="Off: OpenXLR controls the hardware only and leaves the sound card in its stock PipeWire layout (the UCM profile where one exists). Plugin inserts go with the submixer. Toggling restarts the daemon."/>
         <TextBlock Text="{Binding SubmixerNote}" Foreground="#8b93a7" FontSize="11" TextWrapping="Wrap"
                    Margin="26,0,0,0" IsVisible="{Binding SubmixerNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-      </StackPanel>
-    </Border>
-
-    <Border Classes="card">
-      <StackPanel Spacing="6">
-        <TextBlock Text="UPDATES" Classes="h"/>
-        <CheckBox Content="Check GitHub for stable releases at startup (at most once per day)"
-                  IsChecked="{Binding CheckForUpdates, Mode=TwoWay}"/>
-        <TextBlock Text="Off by default. Check now makes one explicit request. Nothing is downloaded or installed."
-                   FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
-        <TextBlock Text="{Binding Updates.Title}" Foreground="#5ba8f5" TextWrapping="Wrap"/>
-        <StackPanel Orientation="Horizontal" Spacing="8">
-          <Button Content="Check now" Click="OnCheckUpdates" IsEnabled="{Binding !Updates.Busy}"/>
-          <Button Content="View result" Click="OnUpdates"/>
-        </StackPanel>
       </StackPanel>
     </Border>
 
@@ -94,6 +88,18 @@
       </StackPanel>
     </Border>
 
+    <Border Classes="card" IsVisible="{Binding Main.ShowResetDefaults}">
+      <StackPanel Spacing="6">
+        <TextBlock Text="INTERFACE" Classes="h"/>
+        <TextBlock Text="{Binding Main.ResetDescription}"
+                   FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
+        <Button Content="Reset device to defaults" Padding="14,5" HorizontalAlignment="Left" Click="OnResetDevice"/>
+      </StackPanel>
+    </Border>
+
+        </StackPanel>
+        <StackPanel Grid.Column="2" Spacing="8">
+
     <Border Classes="card">
       <StackPanel Spacing="6">
         <TextBlock Text="PLUGINS" Classes="h"/>
@@ -127,12 +133,18 @@
       </StackPanel>
     </Border>
 
-    <Border Classes="card" IsVisible="{Binding Main.ShowResetDefaults}">
+    <Border Classes="card">
       <StackPanel Spacing="6">
-        <TextBlock Text="INTERFACE" Classes="h"/>
-        <TextBlock Text="{Binding Main.ResetDescription}"
+        <TextBlock Text="UPDATES" Classes="h"/>
+        <CheckBox Content="Check GitHub for stable releases at startup (at most once per day)"
+                  IsChecked="{Binding CheckForUpdates, Mode=TwoWay}"/>
+        <TextBlock Text="Off by default. Check now makes one explicit request. Nothing is downloaded or installed."
                    FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
-        <Button Content="Reset device to defaults" Padding="14,5" HorizontalAlignment="Left" Click="OnResetDevice"/>
+        <TextBlock Text="{Binding Updates.Title}" Foreground="#5ba8f5" TextWrapping="Wrap"/>
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <Button Content="Check now" Click="OnCheckUpdates" IsEnabled="{Binding !Updates.Busy}"/>
+          <Button Content="View result" Click="OnUpdates"/>
+        </StackPanel>
       </StackPanel>
     </Border>
 
@@ -149,6 +161,8 @@
       </StackPanel>
     </Border>
 
-    <Button Content="Close" HorizontalAlignment="Right" Padding="18,6" Margin="0,2,0,6" Click="OnClose"/>
-  </StackPanel>
+        </StackPanel>
+      </Grid>
+    </ScrollViewer>
+  </DockPanel>
 </Window>

--- a/src/OpenXLR.UI/OptionsWindow.axaml.cs
+++ b/src/OpenXLR.UI/OptionsWindow.axaml.cs
@@ -9,6 +9,16 @@ public partial class OptionsWindow : Window
     public OptionsWindow()
     {
         InitializeComponent();
+        // The window sizes itself to its cards, so on a short screen it can be
+        // taller than the desktop, with its bottom off the edge and no way to
+        // resize it. Cap it to the screen it opens on; the cards scroll.
+        Opened += (_, _) =>
+        {
+            var screen = Screens.ScreenFromWindow(this);
+            if (screen is null) return;
+            double usable = screen.WorkingArea.Height / screen.Scaling;
+            if (usable > 200) MaxHeight = usable - 60;
+        };
     }
 
     public OptionsWindow(OptionsViewModel vm) : this()


### PR DESCRIPTION
The cards ran down a single 560 wide column, about 1130 tall once the plugins card grew, so on a 1080p screen the bottom of the window sat off the edge. The window cannot be resized, so there was no way to reach what was down there.

Two columns now, 980 by 642 measured on the running window: startup, the system defaults and the interface reset on the left, plugins, updates and support on the right, which balances the two sides to within about 50 pixels.

Under that, two things so it cannot happen again on a screen shorter than this one. The cards sit in a scroll view, and the window caps its height to the working area of the screen it opens on, minus room for decoration. A short or heavily scaled display scrolls the cards instead of hiding them.

Verified by opening the window from this build: 980 by 642, nothing clipped, both columns complete.