### PR TITLE
Diagnostics: include plugin discovery and bridge evidence

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,7 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `meters` | 15 Hz while the mixer is built | live stereo levels per channel and mix |
 | `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, `windowsDirectories` (the folders yabridge bridges) and `wineFolders` (Wine's own plugin folders that hold a plugin and are not bridged yet, offered as one press since a file dialog hides them) |
+| `pluginDiagnostics` | in answer to `getPluginDiagnostics` | `discovery`: daemon host/controller paths, Wine prefix, architecture, effective search paths, bounded `yabridgectl status` output and latest completed CLAP/VST3 scan reports |
 | `pluginInstall` | in answer to `installPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
 | `error` | when a command without a `requestId` is rejected | `message` |
 | `commandResult` | in answer to a command that carried a `requestId` | `requestId`, `error` (null on success); preceded by the state the result refers to |
@@ -85,6 +86,7 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setAuxPortEnabled` | `value` | send the Aux mix to the USB Aux port |
 | `setOutputVolume` | `value` | volume of the selected monitor devices |
 | `listPlugins` | none | the installed LV2, CLAP and VST3 plugins, answered with a `plugins` message |
+| `getPluginDiagnostics` | none | read bridge status and existing native scan evidence without syncing, rescanning or changing inserts; answered with `pluginDiagnostics` |
 | `getPluginSetup` | none | where plugins are installed and what bridges Windows ones, answered with a `pluginSetup` message |
 | `installPlugin` | `path` | install what is at an absolute path the user picked: a `.clap` or single-file `.vst3` is copied into `~/.clap` or `~/.vst3`, a `.vst3` or `.lv2` directory into `~/.vst3` or `~/.lv2`, a plain directory installs every plugin inside it, and a Windows VST3 or CLAP plugin has its directory added to yabridge and synced. Archives, installers and VST2 files are refused with a message that says what to do. The catalogues are read again before the `pluginInstall` answer |
 | `syncWindowsPlugins` | none | run yabridge's sync over the folders it knows, then read the catalogues again; answered with `pluginInstall` |
@@ -161,3 +163,34 @@ All under `~/.config/openxlr/` (or `$XDG_CONFIG_HOME/openxlr/`):
   under `$XDG_DATA_HOME/openxlr/yabridge` (default `~/.local/share/openxlr/yabridge`).
 - `ui.json`: window preferences (tray, start minimized, autostart
   toggles)
+
+## Plugin discovery diagnostics
+
+`getPluginDiagnostics` reads the daemon's environment, not the UI's shell.
+`discovery` includes `controller`, `wineExecutable`, `winePrefix`,
+`sourceCommit` for a managed bridge, `hostExecutable`, `hostInstalled`,
+`processArchitecture`, `searchPaths` and `scans`. `searchPaths.lv2Override`
+is the explicit `LV2_PATH` or null for lilv defaults; `clap` and `vst3`
+contain up to 64 effective search directories, including private wrappers.
+
+`status` is null without a controller. Otherwise it contains `exitCode`,
+`timedOut`, `truncated`, `output` and `error`, or just `error` when the
+controller cannot start. The status command has a five-second deadline,
+64 KiB stdout and 16 KiB stderr limits. It does not run a sync.
+
+`scans` contains the last completed report for each native format since
+startup, with `kind`, `completedAt`, `entries` and `omitted`. An empty list
+means no native scan has completed yet. Entries carry `path`, `outcome`,
+`cached`, `plugins`, `duplicates`, `exitCode` and `detail`. Outcomes include
+`host-missing`, `directory`, `directory-missing`, `directory-error`,
+`start-error`, `scan-failed`, `timeout`, `output-limit`, `invalid-description`,
+`no-plugins`, `ok` and `scan-error`. Reports retain at most 128 entries per
+format, preferring failures over successful entries when full. Paths are
+limited to 4096 characters and details to 2048, with truncation marked.
+
+These reports describe scanner output before the combined catalogue's size
+budget and the picker's channel-width/format filters. Compare them with
+`listPlugins` to distinguish scanning from filtering. Reading diagnostics
+does not invalidate scan caches or retry plugins. The API returns paths and
+scanner messages to authenticated clients; the UI redacts personal paths
+when writing the diagnostics archive.

--- a/docs/features.md
+++ b/docs/features.md
@@ -284,4 +284,6 @@ taps on the Stream Deck + XL need OpenDeck newer than 2.14.0
   Options
 - Diagnostics archive: one action collects app and device state, a
   vendor block dump, the PipeWire graph, daemon logs and configs into a
-  tarball for bug reports
+  tarball for bug reports. It also includes plugin catalogue and bridge
+  setup, effective search paths and bounded native scan outcomes, with
+  personal paths redacted and no forced sync or insert changes

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -53,7 +53,8 @@ unset TOKEN
 ```
 
 `getPluginSetup` is available through `POST /api/v1/commands` and reports
-the effective plugin host, Wine and bridge provider. Its reply fields are
+the effective plugin host, Wine and bridge provider. `getPluginDiagnostics` reads bridge status and the latest completed native
+scan evidence without syncing or changing inserts. Both reply shapes are
 documented in [api.md](api.md); the transport does not select a bridge itself.
 
 The [OpenAPI document](openapi-v1.json) describes the HTTP endpoints. Restarting

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -873,11 +873,32 @@ Options, SUPPORT, Collect diagnostics. It writes
 `~/openxlr-diagnostics-<timestamp>.tar.gz` with the daemon's state and
 capabilities, a dump of the interface's vendor blocks, the PipeWire
 graph and device listings, the recent daemon journal, the
-configuration files and version information. The home path, host name
+configuration files and version information. Plugin evidence includes the
+catalogue, effective bridge setup and latest native scan results. The home path, host name
 and the serial numbers of attached USB devices are redacted, in the
 text files and inside the hex dump of the vendor blocks (the XLR Dock
 stores its serial in one); review the archive anyway before attaching
 it to a public issue. Nothing is uploaded automatically.
+
+For a Windows plugin missing from the picker, collect diagnostics after the
+scan finishes and name the plugin and intended insert slot in the report.
+The archive adds:
+
+- `plugins.json`: the catalogue, including format, identifier, channel width,
+  parameters, host support and bundle paths.
+- `plugin-setup.json`: Wine/yabridge versions, selected bridge provider,
+  registered Windows folders and install destinations.
+- `plugin-discovery.json`: the daemon's search paths and Wine prefix,
+  `yabridgectl status`, and the latest completed VST3/CLAP scan results,
+  including cache hits, duplicate ids, missing loaders, failures and timeouts.
+
+Collection does not sync folders, force a rescan or change live inserts.
+Scan evidence is bounded and marks omitted entries. It is collected from
+scans performed by the updated daemon; restart an older daemon after updating
+when convenient, then let discovery finish. An older, disconnected or busy
+daemon produces an explicit unavailable entry instead of stopping the archive.
+Plugin binaries, presets, Wine registry files and the API token are not copied.
+Review plugin names, paths and scanner output before sharing the archive.
 
 <a name="files"></a>
 ## 6. Files and services

--- a/src/OpenXLR.Core/Mixing/ClapCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/ClapCatalog.cs
@@ -96,47 +96,86 @@ public static class Vst3Catalog
 internal static class HostScan
 {
     internal static IReadOnlyList<PluginInfo> Run(string kind, string command, IEnumerable<string> directories,
-        Func<string, IEnumerable<string>> bundlesIn)
+        Func<string, IEnumerable<string>> bundlesIn,
+        Func<string, ProcessResult>? describe = null, ScanCache? scanCache = null)
     {
         // Nothing here may throw: the catalogue is read once and kept, so an
         // exception would be kept with it, and every lookup after would fail.
         var result = new List<PluginInfo>();
+        var evidence = new PluginScanDiagnostics.Capture(kind);
         try
         {
-            if (!NativePluginHost.HostInstalled) return result;
+            if (describe is null && !NativePluginHost.HostInstalled)
+            {
+                evidence.Add(NativePluginHost.Executable, "host-missing");
+                return result;
+            }
             ManagedYabridge? bridge = ManagedYabridge.Discover();
-            var cache = new ScanCache(bridge is null ? ScanCache.DefaultDirectory
+            var cache = scanCache ?? new ScanCache(bridge is null ? ScanCache.DefaultDirectory
                 : Path.Combine(ScanCache.DefaultDirectory, "bridge-" + bridge.CacheKey));
             var known = new HashSet<string>(StringComparer.Ordinal);
             foreach (string directory in directories)
             {
-                if (!Directory.Exists(directory)) continue;
+                if (!Directory.Exists(directory))
+                {
+                    evidence.Add(directory, "directory-missing");
+                    continue;
+                }
                 IEnumerable<string> bundles;
                 try { bundles = bundlesIn(directory).OrderBy(f => f, StringComparer.Ordinal).ToList(); }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { continue; }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    evidence.Add(directory, "directory-error", detail: ex.Message);
+                    continue;
+                }
+                evidence.Add(directory, "directory", detail: $"{bundles.Count()} candidate bundles");
                 foreach (string bundle in bundles)
                 {
                     byte[]? description = cache.Lookup(bundle);
+                    bool cached = description is not null;
+                    string? stderr = null;
                     if (description is null)
                     {
                         // A module that carries hundreds of plugins is created and
                         // released plugin by plugin; a minute is generous for that,
                         // and it is spent once per bundle until the bundle changes.
                         ProcessResult scan;
-                        try { scan = ProcessRunner.Run(NativePluginHost.Executable, [command, bundle], TimeSpan.FromSeconds(60),
-                            environment: bridge?.HostEnvironment()); }
-                        catch (Exception) { continue; }
-                        if (scan.ExitCode != 0 || scan.TimedOut || scan.Truncated) continue;
+                        try { scan = describe is not null ? describe(bundle)
+                            : ProcessRunner.Run(NativePluginHost.Executable, [command, bundle], TimeSpan.FromSeconds(60),
+                                environment: bridge?.HostEnvironment()); }
+                        catch (Exception ex)
+                        {
+                            evidence.Add(bundle, "start-error", detail: ex.Message);
+                            continue;
+                        }
+                        stderr = scan.Stderr;
+                        if (scan.ExitCode != 0 || scan.TimedOut || scan.Truncated)
+                        {
+                            evidence.Add(bundle, scan.TimedOut ? "timeout" : scan.Truncated ? "output-limit" : "scan-failed",
+                                exitCode: scan.ExitCode, detail: stderr);
+                            continue;
+                        }
                         description = scan.Stdout;
                         cache.Store(bundle, description);
                     }
-                    try { result.AddRange(Parse(description, kind).Where(plugin => known.Add(plugin.Plugin))); }
-                    catch (Exception ex) when (ex is JsonException or InvalidOperationException or FormatException) { /* one bad bundle */ }
+                    try
+                    {
+                        IReadOnlyList<PluginInfo> parsed = Parse(description, kind);
+                        int before = result.Count;
+                        result.AddRange(parsed.Where(plugin => known.Add(plugin.Plugin)));
+                        evidence.Add(bundle, parsed.Count == 0 ? "no-plugins" : "ok", cached,
+                            parsed.Count, parsed.Count - (result.Count - before), detail: stderr);
+                    }
+                    catch (Exception ex) when (ex is JsonException or InvalidOperationException or FormatException)
+                    {
+                        evidence.Add(bundle, "invalid-description", cached, detail: ex.Message);
+                    }
                 }
             }
             cache.Save();
         }
-        catch (Exception) { /* whatever was read stands */ }
+        catch (Exception ex) { evidence.Add("", "scan-error", detail: ex.Message); }
+        finally { evidence.Complete(); }
         return result;
     }
 

--- a/src/OpenXLR.Core/Mixing/PluginInstaller.cs
+++ b/src/OpenXLR.Core/Mixing/PluginInstaller.cs
@@ -465,6 +465,31 @@ public sealed class PluginInstaller
         return digits.Count > 1 && digits[1] >= minor;
     }
 
+    /// <summary>Read bridge status without syncing or executing a plugin.</summary>
+    public object Diagnostics()
+    {
+        object? status = null;
+        if (_yabridgectl is not null)
+        {
+            try
+            {
+                ProcessResult result = ProcessRunner.Run(_yabridgectl, ["status"], TimeSpan.FromSeconds(5),
+                    stdoutCap: 64 * 1024, stderrCap: 16 * 1024, environment: _managed?.ControllerEnvironment());
+                status = new { result.ExitCode, result.TimedOut, result.Truncated, output = result.StdoutText, error = result.Stderr };
+            }
+            catch (Exception ex) { status = new { error = PluginScanDiagnostics.Clip(ex.Message, 2048) }; }
+        }
+        return new
+        {
+            controller = _yabridgectl, wineExecutable = _wine, winePrefix = _winePrefix,
+            sourceCommit = _managed?.SourceCommit, status,
+            hostExecutable = NativePluginHost.Executable, hostInstalled = _hostInstalled,
+            processArchitecture = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString(),
+            searchPaths = new { lv2Override = Environment.GetEnvironmentVariable("LV2_PATH"), clap = ClapCatalog.SearchPath().Take(64), vst3 = Vst3Catalog.SearchPath().Take(64) },
+            scans = PluginScanDiagnostics.Snapshot()
+        };
+    }
+
     /// <summary>What is there: the directories, the host, yabridge and Wine.</summary>
     public PluginSetup Setup()
     {

--- a/src/OpenXLR.Core/Mixing/PluginScanDiagnostics.cs
+++ b/src/OpenXLR.Core/Mixing/PluginScanDiagnostics.cs
@@ -1,0 +1,50 @@
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>Bounded evidence from the last completed scan of each native format.</summary>
+public sealed record PluginScanEntry(string Path, string Outcome, bool Cached = false,
+    int Plugins = 0, int Duplicates = 0, int? ExitCode = null, string? Detail = null);
+
+public sealed record PluginScanReport(string Kind, DateTimeOffset CompletedAt,
+    IReadOnlyList<PluginScanEntry> Entries, int Omitted);
+
+public static class PluginScanDiagnostics
+{
+    private static readonly object Gate = new();
+    private static readonly Dictionary<string, PluginScanReport> Reports = new();
+
+    public static IReadOnlyList<PluginScanReport> Snapshot()
+    {
+        lock (Gate) return Reports.Values.OrderBy(r => r.Kind, StringComparer.Ordinal).ToArray();
+    }
+
+    internal sealed class Capture(string kind)
+    {
+        internal const int Limit = 128;
+        private readonly List<PluginScanEntry> _entries = [];
+        private int _omitted;
+
+        public void Add(string path, string outcome, bool cached = false, int plugins = 0,
+            int duplicates = 0, int? exitCode = null, string? detail = null)
+        {
+            if (_entries.Count >= Limit)
+            {
+                _omitted++;
+                if (outcome is "ok" or "directory") return;
+                int replace = _entries.FindLastIndex(e => e.Outcome is "ok" or "directory");
+                if (replace < 0) return;
+                _entries.RemoveAt(replace);
+            }
+            _entries.Add(new(Clip(path, 4096)!, outcome, cached, plugins, duplicates, exitCode, Clip(detail, 2048)));
+        }
+
+        public PluginScanReport Complete()
+        {
+            var report = new PluginScanReport(kind, DateTimeOffset.UtcNow, _entries.ToArray(), _omitted);
+            lock (Gate) Reports[kind] = report;
+            return report;
+        }
+    }
+
+    internal static string? Clip(string? text, int limit)
+        => text is { Length: > 0 } && text.Length > limit ? text[..limit] + " [truncated]" : text;
+}

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -249,3 +249,10 @@ public static class DaemonVersion
             .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?
             .InformationalVersion.Split('+')[0] ?? "0.0.0";
 }
+
+/// <summary>Read-only plugin discovery evidence, separate from the bounded plugin catalogue.</summary>
+public sealed record PluginDiagnosticsMessage(object Discovery)
+{
+    [JsonPropertyName("type")] public string Type => "pluginDiagnostics";
+    [JsonPropertyName("discovery")] public object Discovery { get; } = Discovery;
+}

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -197,6 +197,9 @@ public sealed class WebSocketHub
                 IReadOnlyList<OpenXLR.Core.Mixing.PluginInfo> plugins = await Task.Run(() => OpenXLR.Core.Mixing.PluginCatalog.Plugins);
                 await reply(new PluginsMessage(plugins));
                 break;
+            case "getPluginDiagnostics":
+                await reply(new PluginDiagnosticsMessage(await Task.Run(() => new OpenXLR.Core.Mixing.PluginInstaller().Diagnostics())));
+                break;
             case "getPluginSetup":
                 await reply(new PluginSetupMessage(await Task.Run(() => new OpenXLR.Core.Mixing.PluginInstaller().Setup())));
                 break;

--- a/src/OpenXLR.Tests/DiagnosticsTests.cs
+++ b/src/OpenXLR.Tests/DiagnosticsTests.cs
@@ -5,6 +5,79 @@ namespace OpenXLR.Tests;
 public sealed class DiagnosticsTests
 {
     [Fact]
+    public async Task UnavailableDaemonStillProducesValidPluginReports()
+    {
+        string dir = Directory.CreateTempSubdirectory("plugin-diag-offline-").FullName;
+        await using var client = new DaemonClient();
+        try
+        {
+            await Diagnostics.WritePluginDataAsync(client, dir, TimeSpan.FromMilliseconds(100));
+            foreach (string file in Directory.GetFiles(dir))
+            {
+                using var data = System.Text.Json.JsonDocument.Parse(File.ReadAllText(file));
+                Assert.Contains("No reply", data.RootElement.GetProperty("unavailable").GetString());
+            }
+            Assert.Equal(3, Directory.GetFiles(dir).Length);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ArchiveIncludesPluginEvidenceFromDaemonAndRedactsPaths()
+    {
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                var command = await SocketTestServer.Receive(socket, stop);
+                string cmd = command["cmd"]!.GetValue<string>();
+                if (cmd == "auth") continue;
+                Assert.DoesNotContain(cmd, new[] { "rescanPlugins", "syncWindowsPlugins", "setInserts" });
+                object reply = cmd switch
+                {
+                    "listPlugins" => new { type = "plugins", plugins = new[] { new { name = "Windows EQ", path = home + "/.vst3/EQ.vst3", audioIns = 2 } } },
+                    "getPluginSetup" => new { type = "pluginSetup", bridgeProvider = "openxlr", wineVersion = "wine-11.0", windowsDirectories = new[] { home + "/.wine/VST3" } },
+                    "getPluginDiagnostics" => new { type = "pluginDiagnostics", scans = new[] { new { path = home + "/.vst3/Missing.vst3", error = "module not found" } } },
+                    _ => new { type = "diagnostics", blocks = new { } }
+                };
+                await SocketTestServer.Send(socket, reply, stop);
+                await SocketTestServer.Send(socket, new { type = "commandResult", requestId = command["requestId"]!.GetValue<string>() }, stop);
+            }
+        });
+        await using var client = new DaemonClient(server.Url);
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        string archive = await Diagnostics.CollectAsync(client);
+        try
+        {
+            using var file = File.OpenRead(archive);
+            using var gzip = new System.IO.Compression.GZipStream(file, System.IO.Compression.CompressionMode.Decompress);
+            using var tar = new System.Formats.Tar.TarReader(gzip);
+            var entries = new Dictionary<string, string>();
+            while (tar.GetNextEntry() is { } entry)
+                if (entry.DataStream is { } data)
+                    entries[entry.Name.TrimStart('.', '/')] = new StreamReader(data).ReadToEnd();
+            Assert.Contains("plugins.json", entries.Keys);
+            Assert.Contains("plugin-setup.json", entries.Keys);
+            Assert.Contains("plugin-discovery.json", entries.Keys);
+            Assert.Contains("Windows EQ", entries["plugins.json"]);
+            Assert.Contains("openxlr", entries["plugin-setup.json"]);
+            Assert.Contains("module not found", entries["plugin-discovery.json"]);
+            foreach (string name in new[] { "plugins.json", "plugin-setup.json", "plugin-discovery.json" })
+            {
+                Assert.DoesNotContain(home, entries[name]);
+                Assert.Contains("<redacted>", entries[name]);
+                using var json = System.Text.Json.JsonDocument.Parse(entries[name]);
+            }
+            Assert.Contains("plugin", entries["PRIVACY.txt"], StringComparison.OrdinalIgnoreCase);
+        }
+        finally { File.Delete(archive); }
+    }
+
+    [Fact]
     public void Redact_RemovesCommonIdentityAndSerialFields()
     {
         string input = $$"""

--- a/src/OpenXLR.Tests/HttpApiTests.cs
+++ b/src/OpenXLR.Tests/HttpApiTests.cs
@@ -97,6 +97,14 @@ public sealed class HttpApiTests
                 new StringContent("{\"cmd\":\"getDiagnostics\"}", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.OK, valid.StatusCode);
             Assert.Contains("\"ok\":true", await valid.Content.ReadAsStringAsync());
+            using var pluginDiagnostics = await http.PostAsync("/api/v1/commands",
+                new StringContent("{\"cmd\":\"getPluginDiagnostics\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, pluginDiagnostics.StatusCode);
+            using var evidence = System.Text.Json.JsonDocument.Parse(await pluginDiagnostics.Content.ReadAsStringAsync());
+            var discovery = evidence.RootElement.GetProperty("messages")[0];
+            Assert.Equal("pluginDiagnostics", discovery.GetProperty("type").GetString());
+            Assert.True(discovery.GetProperty("discovery").TryGetProperty("searchPaths", out _));
+            Assert.True(discovery.GetProperty("discovery").TryGetProperty("scans", out _));
         }
         finally { await app.StopAsync(); }
     }

--- a/src/OpenXLR.Tests/PluginScanDiagnosticsTests.cs
+++ b/src/OpenXLR.Tests/PluginScanDiagnosticsTests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using OpenXLR.Core;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class PluginScanDiagnosticsTests
+{
+    [Fact]
+    public void BridgeDiagnosticsRunsStatusOnlyAndPreservesItsFailure()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+        string dir = Directory.CreateTempSubdirectory("bridge-diagnostics-").FullName;
+        try
+        {
+            string controller = Path.Combine(dir, "yabridgectl");
+            File.WriteAllText(controller, "#!/bin/sh\n[ \"$1\" = status ] || exit 99\necho 'Example.vst3 -> missing wrapper'\necho 'bridge libraries missing' >&2\nexit 17\n");
+            File.SetUnixFileMode(controller, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            var installer = new PluginInstaller(dir, dir, dir, controller, null, winePrefix: Path.Combine(dir, "prefix"));
+            var data = System.Text.Json.JsonSerializer.SerializeToElement(installer.Diagnostics(), new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+            Assert.Equal(controller, data.GetProperty("controller").GetString());
+            Assert.Equal(17, data.GetProperty("status").GetProperty("exitCode").GetInt32());
+            Assert.Contains("missing wrapper", data.GetProperty("status").GetProperty("output").GetString());
+            Assert.Contains("libraries missing", data.GetProperty("status").GetProperty("error").GetString());
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void FailedAndCachedBundlesRemainVisibleWithoutChangingDiscovery()
+    {
+        string dir = Directory.CreateTempSubdirectory("plugin-scan-evidence-").FullName;
+        string kind = Guid.NewGuid().ToString("N");
+        try
+        {
+            string[] names = ["good", "duplicate", "failed", "timeout", "large", "invalid", "empty"];
+            string[] bundles = names.Select(n => Path.Combine(dir, n + ".vst3")).ToArray();
+            foreach (string path in bundles) File.WriteAllText(path, "fixture");
+            int goodCalls = 0;
+            ProcessResult Describe(string path)
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                if (name == "failed") return new(9, [], "Wine: required module is missing", false, false);
+                if (name == "timeout") return new(-1, [], "hung while loading", true, false);
+                if (name == "large") return new(0, [], "too much output", false, true);
+                if (name == "invalid") return new(0, Encoding.UTF8.GetBytes("{bad json"), "", false, false);
+                if (name == "empty") return new(0, Encoding.UTF8.GetBytes("{\"plugins\":[]}"), "no factory", false, false);
+                goodCalls++;
+                return new(0, Encoding.UTF8.GetBytes("{\"plugins\":[{\"id\":\"same-id\",\"name\":\"EQ\",\"audioIns\":2,\"audioOuts\":2}]}"), "", false, false);
+            }
+            var cache = new ScanCache(Path.Combine(dir, "cache"));
+            var result = HostScan.Run(kind, "unused", [dir, Path.Combine(dir, "missing")], _ => bundles, Describe, cache);
+            Assert.Single(result);
+            var report = PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind);
+            Assert.Contains(report.Entries, e => e.Outcome == "scan-failed" && e.ExitCode == 9 && e.Detail!.Contains("required module"));
+            Assert.Contains(report.Entries, e => e.Outcome == "timeout");
+            Assert.Contains(report.Entries, e => e.Outcome == "output-limit");
+            Assert.Contains(report.Entries, e => e.Outcome == "invalid-description");
+            Assert.Contains(report.Entries, e => e.Outcome == "no-plugins");
+            Assert.Contains(report.Entries, e => e.Outcome == "directory-missing");
+            Assert.Contains(report.Entries, e => e.Duplicates == 1);
+            Assert.Equal(2, goodCalls);
+
+            result = HostScan.Run(kind, "unused", [dir], _ => bundles, Describe, cache);
+            Assert.Single(result);
+            Assert.Equal(2, goodCalls); // reading evidence does not invalidate the cache
+            report = PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind);
+            Assert.Equal(2, report.Entries.Count(e => e.Outcome == "ok" && e.Cached));
+            Assert.Contains(report.Entries, e => e.Outcome == "invalid-description" && e.Cached);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void EvidenceHasEntryAndTextBoundsAndKeepsLateFailures()
+    {
+        var capture = new PluginScanDiagnostics.Capture("bounded-test");
+        for (int i = 0; i < 200; i++) capture.Add("/plugin/" + i, "ok");
+        capture.Add(new string('p', 9000), "scan-failed", detail: new string('e', 9000));
+        var report = capture.Complete();
+        Assert.Equal(128, report.Entries.Count);
+        Assert.Equal(73, report.Omitted);
+        var failure = Assert.Single(report.Entries, e => e.Outcome == "scan-failed");
+        Assert.True(failure.Path.Length < 4200);
+        Assert.True(failure.Detail!.Length < 2100);
+        Assert.EndsWith("[truncated]", failure.Detail);
+    }
+
+    [Fact]
+    public void DirectoryAndLaunchErrorsDoNotHideOtherBundles()
+    {
+        string dir = Directory.CreateTempSubdirectory("plugin-scan-error-").FullName;
+        string kind = Guid.NewGuid().ToString("N");
+        try
+        {
+            var cache = new ScanCache(Path.Combine(dir, "cache"));
+            HostScan.Run(kind, "unused", [dir], _ => throw new UnauthorizedAccessException("cannot read folder"), _ => throw new Exception(), cache);
+            Assert.Contains(PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind).Entries, e => e.Outcome == "directory-error");
+            HostScan.Run(kind, "unused", [dir], _ => [Path.Combine(dir, "plugin.vst3")], _ => throw new IOException("loader missing"), cache);
+            Assert.Contains(PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind).Entries, e => e.Outcome == "start-error" && e.Detail == "loader missing");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -60,6 +60,10 @@ public sealed class DaemonClient : IAsyncDisposable
     public Task<JsonNode?> RequestPluginsAsync(TimeSpan timeout)
         => QueryAsync("plugins", "listPlugins", timeout);
 
+    /// <summary>Latest scan evidence and effective bridge status; null on timeout or an older daemon.</summary>
+    public Task<JsonNode?> RequestPluginDiagnosticsAsync(TimeSpan timeout)
+        => QueryAsync("pluginDiagnostics", "getPluginDiagnostics", timeout);
+
     /// <summary>Where plugins go and what bridges Windows ones (a "pluginSetup" message); null on timeout.</summary>
     public Task<JsonNode?> RequestPluginSetupAsync(TimeSpan timeout)
         => QueryAsync("pluginSetup", "getPluginSetup", timeout);
@@ -233,7 +237,7 @@ public sealed class DaemonClient : IAsyncDisposable
             else if (type == "state") { LastStateJson = text; StateReceived?.Invoke(node); }
             else if (type == "diagnostics") StoreReply(type, node);
             else if (type == "plugins") StoreReply(type, node["plugins"]);
-            else if (type is "pluginSetup" or "pluginInstall") StoreReply(type, node);
+            else if (type is "pluginSetup" or "pluginInstall" or "pluginDiagnostics") StoreReply(type, node);
             else if (type == "commandResult" && node["requestId"]?.GetValue<string>() is string requestId)
             {
                 CompleteQuery(requestId);

--- a/src/OpenXLR.UI/Diagnostics.cs
+++ b/src/OpenXLR.UI/Diagnostics.cs
@@ -6,6 +6,9 @@ using System.IO.Compression;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -39,7 +42,10 @@ public static class Diagnostics
                 This archive is created locally and is never uploaded automatically.
                 It contains OpenXLR state, USB control blocks, PipeWire topology,
                 recent openxlr-daemon journal entries, application audio metadata,
-                configuration files, and system version information. The home
+                configuration files, plugin names and paths, the plugin catalogue,
+                Wine/yabridge versions and status, latest scan results, and system
+                version information. No plugin binaries, presets, Wine registry
+                files or API token are collected. The home
                 path, the host name, the serial numbers of attached USB devices
                 (including inside PipeWire node names) and process-id fields are
                 redacted, but review the archive before attaching it to a public
@@ -52,6 +58,8 @@ public static class Diagnostics
             var blocks = await client.RequestDiagnosticsAsync(TimeSpan.FromSeconds(5));
             await File.WriteAllTextAsync(Path.Combine(work, "device-blocks.json"),
                 RedactHex(blocks?.ToJsonString() ?? "unavailable (daemon not running or no device)", DefaultSecrets()));
+
+            await WritePluginDataAsync(client, work, TimeSpan.FromSeconds(15));
 
             // Audio stack.
             await WriteCmd(work, "pw-dump.json", "pw-dump");
@@ -81,6 +89,43 @@ public static class Diagnostics
         {
             try { Directory.Delete(work, recursive: true); } catch (IOException) { }
         }
+    }
+
+    internal static async Task WritePluginDataAsync(DaemonClient client, string directory, TimeSpan timeout)
+    {
+        // Independent reply types; all requests use the daemon's environment.
+        var requests = new[]
+        {
+            ("plugins.json", client.RequestPluginsAsync(timeout)),
+            ("plugin-setup.json", client.RequestPluginSetupAsync(timeout)),
+            ("plugin-discovery.json", client.RequestPluginDiagnosticsAsync(timeout))
+        };
+        string[] secrets = DefaultSecrets().ToArray();
+        foreach (var (file, request) in requests)
+        {
+            JsonNode? reply = await request;
+            var data = reply?.DeepClone() ?? new JsonObject
+            {
+                ["unavailable"] = "No reply: daemon disconnected, query timed out, or command unsupported."
+            };
+            RedactJson(data, secrets);
+            await File.WriteAllTextAsync(Path.Combine(directory, file), data.ToJsonString(
+                new JsonSerializerOptions { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }));
+        }
+    }
+
+    private static void RedactJson(JsonNode node, string[] secrets)
+    {
+        if (node is JsonObject obj)
+        {
+            foreach (string key in obj.Select(p => p.Key).ToArray())
+                if (obj[key] is JsonValue value && value.TryGetValue<string>(out string? text)) obj[key] = Redact(text, secrets);
+                else if (obj[key] is { } child) RedactJson(child, secrets);
+        }
+        else if (node is JsonArray array)
+            for (int i = 0; i < array.Count; i++)
+                if (array[i] is JsonValue value && value.TryGetValue<string>(out string? text)) array[i] = Redact(text, secrets);
+                else if (array[i] is { } child) RedactJson(child, secrets);
     }
 
     private static async Task WriteCmd(string dir, string file, string exe, params string[] args)


### PR DESCRIPTION
A Windows VST3 can be in a bridged folder yet absent from the picker, and existing support archives contain neither the effective bridge setup nor the scanner's discarded errors. Diagnostics now includes the daemon's catalogue, bridge setup, and discovery evidence in three redacted JSON files.

The read-only `getPluginDiagnostics` command reports effective paths and Wine prefix, bounded yabridgectl status, and the last completed CLAP/VST3 scans. Scan reports retain failures, timeouts, invalid responses, duplicate ids and cache hits, with explicit truncation. Collection does not sync, force a rescan or modify live inserts. Older or unavailable daemons produce an unavailable record.

Validation:

- Archive regression failed before the change because plugins.json was missing, then passed with all three reports present and redacted.
- Native-enabled Release build: zero warnings/errors. All 333 .NET tests passed, including real HTTP dispatch and scanner failure/cache/budget tests. Five OpenDeck tests, native desktop editor regressions, shell lint, OpenAPI, version, locked-restore and RPM checks passed.
- An isolated API instance with no hosted device/mixer services exported an actual archive using 346 installed plugins, including Nova and Supermassive. All new JSON files parsed, home paths were redacted, and bridge status completed without a timeout or truncation.

The running mixer and plugin instances were not restarted. This instruments discovery; it does not claim to fix the reported third-party plugin failures. Native Xvfb coverage runs in CI because Xvfb is not installed locally. No version or release changes.
