### PR TITLE
UI: the microphone inserts open the same window as a mix's

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -230,16 +230,18 @@ channel, with its level and lock in the INPUTS card.
 <a name="plugins"></a>
 ### 3.5 Add a plugin to the signal path
 
-1. Under XLR 1, XLR 2 or a mix, press "Add plugin…". The picker lists
+1. Under XLR 1, XLR 2 or a mix, press "Inserts…". The chain window opens
+   with that chain's plugins and an "Add plugin…" button. The picker lists
    compatible installed LV2, CLAP and VST3 effects (mono for an input,
    stereo for a mix), searchable by name, category or format. Host
    feature requirements can exclude a plugin; install a compatible set
    such as `lsp-plugins-lv2` if the list is empty.
-2. Add. The plugin appears in the Inserts row with a green light while
-   active.
+2. Add. The plugin appears in the chain window and in the Inserts row on
+   the strip, with a green light while active.
 3. Controls opens a window generated from the plugin's parameters,
    grouped, with a Defaults button. Bypass takes it out of the path
-   (red light); the arrows reorder the chain; the cross removes it.
+   (red light); the arrows reorder the chain; the cross removes it. The
+   strip keeps the short form: bypass and the cog that opens the controls.
 4. Chains and exposed parameter values are saved with the mixer and
    profiles. OpenXLR does not yet save opaque plugin state, sample-file
    selections or plugin presets.

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -47,6 +47,11 @@ public sealed class InsertsViewModel : ViewModelBase
     public Task ShowNativeEditorAsync(InsertViewModel insert)
         => _client.ShowInsertUiAsync(_channel, insert.Id);
 
+    /// <summary>Chain window subtitle: where these plugins sit in the path.</summary>
+    public string ChainHint => _channels == 1
+        ? "Plugins, in order, before this input reaches the mixes"
+        : "Stereo plugins, in order, before this mix reaches its outputs";
+
     /// <summary>Picker header: which plugins fit this chain.</summary>
     public string PickerHint => _channels == 1
         ? "Plugins that fit the mono mic path (one input, one output)"

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -283,36 +283,39 @@
         </Grid>
 
         <!-- XLR 1 plugin inserts: plugins in the mic path, after the
-             software low cut and ClipGuard, heard by every mix. The picker
-             and each plugin's controls open in their own windows. -->
+             software low cut and ClipGuard, heard by every mix. The chain
+             window adds, reorders and removes; each plugin's controls open
+             in their own window. -->
         <StackPanel Spacing="4" Margin="0,4,0,0" IsVisible="{Binding HasMixer}">
           <Grid ColumnDefinitions="90,*,Auto">
             <TextBlock Text="Inserts" Classes="h" VerticalAlignment="Center"
                        ToolTip.Tip="Plugins processing XLR 1 before it reaches the mixes"/>
-            <TextBlock Grid.Column="1" Text="{Binding Inserts.Summary}" Classes="h" FontSize="11" VerticalAlignment="Center"/>
-            <Button Grid.Column="2" Content="Add plugin…" Padding="12,3" FontSize="12" MinHeight="0" Click="OnAddInsert"/>
+            <Button Grid.Column="2" Content="{Binding Inserts.ButtonText}" Padding="12,3" FontSize="12" MinHeight="0"
+                    Click="OnXlrInserts" ToolTip.Tip="Plugins processing XLR 1 before it reaches the mixes"/>
           </Grid>
+          <!-- the chain at a glance: LED, name, bypass, controls; adding,
+               ordering and removing live in the chain window -->
           <ItemsControl ItemsSource="{Binding Inserts.Items}" IsVisible="{Binding Inserts.HasItems}">
             <ItemsControl.ItemTemplate>
               <DataTemplate x:DataType="vm:InsertViewModel">
-                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,3">
-                  <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <Ellipse Width="9" Height="9" VerticalAlignment="Center"
-                             Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
+                <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,0,0,3">
+                  <Ellipse Width="9" Height="9" VerticalAlignment="Center" Margin="0,0,8,0"
+                           Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
+                  <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                     <TextBlock Text="{Binding Label}" Foreground="#e6e9f0" FontSize="12"/>
                     <TextBlock Text="{Binding StateText}" Classes="h" FontSize="11"/>
                     <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
                   </StackPanel>
-                  <Button Grid.Column="1" Content="Controls" Padding="8,1" MinHeight="0" FontSize="11" Margin="0,0,4,0"
-                          Click="OnInsertControls" ToolTip.Tip="Open this plugin's controls in a window"/>
-                  <ToggleButton Grid.Column="2" Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}"
-                                Padding="8,1" MinHeight="0" FontSize="11" Margin="0,0,4,0"/>
-                  <Button Grid.Column="3" Content="▲" Padding="6,1" MinHeight="0" FontSize="10" Margin="0,0,2,0"
-                          Click="OnInsertUp" ToolTip.Tip="Move earlier in the chain"/>
-                  <Button Grid.Column="4" Content="▼" Padding="6,1" MinHeight="0" FontSize="10" Margin="0,0,4,0"
-                          Click="OnInsertDown" ToolTip.Tip="Move later in the chain"/>
-                  <Button Grid.Column="5" Content="✕" Padding="6,1" MinHeight="0" FontSize="10"
-                          Click="OnInsertRemove" ToolTip.Tip="Remove this insert"/>
+                  <ToggleButton Grid.Column="2" Content="N" IsChecked="{Binding NativeHost, Mode=TwoWay}"
+                                IsVisible="{Binding CanChooseNativeHost}"
+                                IsEnabled="{Binding CanTurnNativeHostOn}"
+                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,0,0"
+                                ToolTip.Tip="Run this plugin in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
+                  <ToggleButton Grid.Column="3" Content="B" IsChecked="{Binding Bypass, Mode=TwoWay}"
+                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,2,0"
+                                ToolTip.Tip="Bypass"/>
+                  <Button Grid.Column="4" Content="⚙" Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10"
+                          Click="OnInsertControls" ToolTip.Tip="{Binding ControlsHint}"/>
                 </Grid>
               </DataTemplate>
             </ItemsControl.ItemTemplate>
@@ -344,30 +347,32 @@
           <Grid ColumnDefinitions="90,*,Auto">
             <TextBlock Text="Inserts" Classes="h" VerticalAlignment="Center"
                        ToolTip.Tip="Plugins processing XLR 2 before it reaches the mixes"/>
-            <TextBlock Grid.Column="1" Text="{Binding Inserts2.Summary}" Classes="h" FontSize="11" VerticalAlignment="Center"/>
-            <Button Grid.Column="2" Content="Add plugin…" Padding="12,3" FontSize="12" MinHeight="0" Tag="xlr2" Click="OnAddInsert"/>
+            <Button Grid.Column="2" Content="{Binding Inserts2.ButtonText}" Padding="12,3" FontSize="12" MinHeight="0"
+                    Tag="xlr2" Click="OnXlrInserts" ToolTip.Tip="Plugins processing XLR 2 before it reaches the mixes"/>
           </Grid>
+          <!-- the chain at a glance: LED, name, bypass, controls; adding,
+               ordering and removing live in the chain window -->
           <ItemsControl ItemsSource="{Binding Inserts2.Items}" IsVisible="{Binding Inserts2.HasItems}">
             <ItemsControl.ItemTemplate>
               <DataTemplate x:DataType="vm:InsertViewModel">
-                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,3">
-                  <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <Ellipse Width="9" Height="9" VerticalAlignment="Center"
-                             Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
+                <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,0,0,3">
+                  <Ellipse Width="9" Height="9" VerticalAlignment="Center" Margin="0,0,8,0"
+                           Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
+                  <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                     <TextBlock Text="{Binding Label}" Foreground="#e6e9f0" FontSize="12"/>
                     <TextBlock Text="{Binding StateText}" Classes="h" FontSize="11"/>
                     <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
                   </StackPanel>
-                  <Button Grid.Column="1" Content="Controls" Padding="8,1" MinHeight="0" FontSize="11" Margin="0,0,4,0"
-                          Click="OnInsertControls" ToolTip.Tip="Open this plugin's controls in a window"/>
-                  <ToggleButton Grid.Column="2" Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}"
-                                Padding="8,1" MinHeight="0" FontSize="11" Margin="0,0,4,0"/>
-                  <Button Grid.Column="3" Content="▲" Padding="6,1" MinHeight="0" FontSize="10" Margin="0,0,2,0"
-                          Click="OnInsertUp" ToolTip.Tip="Move earlier in the chain"/>
-                  <Button Grid.Column="4" Content="▼" Padding="6,1" MinHeight="0" FontSize="10" Margin="0,0,4,0"
-                          Click="OnInsertDown" ToolTip.Tip="Move later in the chain"/>
-                  <Button Grid.Column="5" Content="✕" Padding="6,1" MinHeight="0" FontSize="10"
-                          Click="OnInsertRemove" ToolTip.Tip="Remove this insert"/>
+                  <ToggleButton Grid.Column="2" Content="N" IsChecked="{Binding NativeHost, Mode=TwoWay}"
+                                IsVisible="{Binding CanChooseNativeHost}"
+                                IsEnabled="{Binding CanTurnNativeHostOn}"
+                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,0,0"
+                                ToolTip.Tip="Run this plugin in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
+                  <ToggleButton Grid.Column="3" Content="B" IsChecked="{Binding Bypass, Mode=TwoWay}"
+                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,2,0"
+                                ToolTip.Tip="Bypass"/>
+                  <Button Grid.Column="4" Content="⚙" Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10"
+                          Click="OnInsertControls" ToolTip.Tip="{Binding ControlsHint}"/>
                 </Grid>
               </DataTemplate>
             </ItemsControl.ItemTemplate>

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -152,15 +152,13 @@ public partial class MainWindow : Window
 
     private void OnCycleSoftLowCut(object? sender, RoutedEventArgs e) => _vm.CycleSoftLowCut();
 
-    // Plugin inserts: the picker is a modal dialog; each insert's controls
-    // and each mix's chain live in their own windows (see InsertWindows).
-    private async void OnAddInsert(object? sender, RoutedEventArgs e)
+    // Plugin inserts: every chain, input or mix, opens the same window,
+    // and each insert's controls open in their own (see InsertWindows).
+    private void OnXlrInserts(object? sender, RoutedEventArgs e)
     {
         // The button's Tag names the channel: "xlr2" for the second input.
-        InsertsViewModel chain = (sender as Control)?.Tag as string == "xlr2" ? _vm.Inserts2 : _vm.Inserts;
-        var picker = new PluginPickerWindow { DataContext = chain };
-        PluginChoice? choice = await picker.ShowDialog<PluginChoice?>(this);
-        if (choice is not null) chain.Add(choice);
+        bool second = (sender as Control)?.Tag as string == "xlr2";
+        InsertWindows.OpenChain(this, second ? _vm.Inserts2 : _vm.Inserts, second ? "xlr2" : "xlr1");
     }
 
     private async void OnInsertControls(object? sender, RoutedEventArgs e)

--- a/src/OpenXLR.UI/MixInsertsWindow.axaml
+++ b/src/OpenXLR.UI/MixInsertsWindow.axaml
@@ -19,7 +19,7 @@
     <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,10">
       <StackPanel>
         <TextBlock Text="{Binding Title}" FontSize="16" FontWeight="Bold" Foreground="#e6e9f0"/>
-        <TextBlock Text="Stereo plugins, in order, before this mix reaches its outputs" Classes="h" FontSize="11"/>
+        <TextBlock Text="{Binding ChainHint}" Classes="h" FontSize="11"/>
       </StackPanel>
       <Button Grid.Column="1" Content="Add plugin…" Padding="12,4" VerticalAlignment="Top" Click="OnAddInsert"/>
     </Grid>


### PR DESCRIPTION
XLR 1 and XLR 2 used to add plugins straight from the strip and keep the full editor row inline. They now match the mixes: an "Inserts…" button opens the chain window for that input, and the strip keeps the short row with the light, the name, the native host toggle, bypass and the cog.

The chain window's subtitle follows the chain, so a mic path reads "Plugins, in order, before this input reaches the mixes" and a mix keeps its stereo wording.

Manual section 3.5 updated. Checked on the Pro with a plugin in XLR 1: the button counts, the window opens once per input, and the row behaves as it does on a mix.

Fixes https://github.com/emaspa/openxlr/issues/69