### PR TITLE
Packaging: vendor the runtime packs each Ubuntu series asks for

### DIFF
--- a/packaging/ppa/make-source.sh
+++ b/packaging/ppa/make-source.sh
@@ -12,6 +12,12 @@
 #         packaging/ppa/make-source.sh v0.1.22 noble resolute
 #         dput ppa:sparvoli/openxlr dist/ppa/openxlr_*_source.changes
 #
+# The first argument is a git ref, so v0.1.22 and not 0.1.22.
+#
+# Launchpad refuses a version it has already seen, so a rebuild of the
+# same upstream version needs a higher series suffix: PPA_SUFFIX=2 makes
+# the packages X.Y.Z~noble2.
+#
 # Needs git, dotnet-sdk-10.0, devscripts, debhelper and the maintainer's
 # GPG key (DEBSIGN_KEYID overrides the key picked from the changelog).
 set -eu
@@ -19,6 +25,16 @@ set -eu
 ref=${1:?usage: $0 <git-ref> <series>...}
 shift
 [ $# -gt 0 ] || { echo "usage: $0 <git-ref> <series>..." >&2; exit 1; }
+
+suffix=${PPA_SUFFIX:-1}
+
+# Each series builds with its own dotnet SDK, and an SDK asks for the
+# runtime packs of exactly the runtime it bundles. The SDK here is
+# usually ahead of the one in an older series, so a feed vendored from
+# this machine alone leaves that builder asking for packs it cannot
+# reach (NU1102, no network on the builders). Vendor those versions too;
+# add one whenever a series ships a runtime this list does not cover.
+pack_versions=${PPA_RUNTIME_PACKS:-10.0.11 10.0.12}
 
 repo=$(cd "$(dirname "$0")/../.." && pwd)
 out=${OUT:-$repo/dist/ppa}
@@ -43,6 +59,27 @@ for proj in OpenXLR.Daemon OpenXLR.UI; do
     dotnet restore "$tree/src/$proj" -r linux-x64 -p:SelfContained=false \
         --locked-mode --packages "$work/packages"
 done
+
+# The runtime packs for the other series, fetched without referencing
+# them: PackageDownload puts them in the same folder the feed is laid
+# out from.
+mkdir -p "$work/packs"
+{
+    echo '<Project Sdk="Microsoft.NET.Sdk">'
+    echo '  <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>'
+    echo '  <ItemGroup>'
+    for v in $pack_versions; do
+        for pack in Microsoft.NETCore.App.Runtime.linux-x64 \
+                    Microsoft.NETCore.App.Host.linux-x64 \
+                    Microsoft.AspNetCore.App.Runtime.linux-x64; do
+            echo "    <PackageDownload Include=\"$pack\" Version=\"[$v]\" />"
+        done
+    done
+    echo '  </ItemGroup>'
+    echo '</Project>'
+} > "$work/packs/packs.csproj"
+dotnet restore "$work/packs/packs.csproj" --packages "$work/packages"
+
 rm -rf "$tree"/src/*/obj
 for dir in "$work"/packages/*/*/; do
     dest=$tree/vendor/nuget/${dir#"$work/packages/"}
@@ -56,7 +93,7 @@ for series in "$@"; do
     cp -a "$tree" "$build"
     (
         cd "$build"
-        DEBEMAIL=$maint dch --newversion "$version~${series}1" \
+        DEBEMAIL=$maint dch --newversion "$version~${series}$suffix" \
             --distribution "$series" --force-distribution \
             --force-bad-version \
             "Source package for the PPA, built for $series."
@@ -64,7 +101,7 @@ for series in "$@"; do
         # tarball is mostly .nupkg archives, which do not compress.
         dpkg-buildpackage -S -d -z1 ${DEBSIGN_KEYID:+--sign-key="$DEBSIGN_KEYID"}
     )
-    mv "$work"/openxlr_"$version~${series}1"* "$out/"
+    mv "$work"/openxlr_"$version~${series}$suffix"* "$out/"
 done
 
 ls -l "$out"


### PR DESCRIPTION
The 0.1.31 noble build failed with NU1102: the vendored feed had the 10.0.12 runtime packs from this desk's SDK, while noble's SDK pins 10.0.11 and the builders have no network. Resolute, whose SDK matches, built fine.

`make-source.sh` now also downloads the runtime, host and ASP.NET packs for every version in `PPA_RUNTIME_PACKS` (10.0.11 and 10.0.12 today) into the same folder the feed is laid out from, so each series finds what its SDK asks for. `PPA_SUFFIX` sets the series suffix, which a rebuild of an already uploaded version needs, and the usage note says the first argument is a git ref.

Verified the download layout locally: the packs land with their .nupkg, .nupkg.sha512 and .nuspec, which is what the feed loop copies.