### PR TITLE
Mixer: enlarge the inline insert buttons

### DIFF
--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -101,6 +101,27 @@
       <Setter Property="HorizontalContentAlignment" Value="Center"/>
       <Setter Property="Padding" Value="8,5"/>
     </Style>
+    <!-- the small controls on an insert row: N (own process), B (bypass) and
+         the cog that opens the plugin's controls. They stay narrow enough for
+         the row but keep a 24 by 24 target so they are easy to hit and their
+         letter is readable. -->
+    <Style Selector="ToggleButton.insertmini">
+      <Setter Property="Padding" Value="6,2"/>
+      <Setter Property="MinWidth" Value="24"/>
+      <Setter Property="MinHeight" Value="24"/>
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+      <Setter Property="VerticalContentAlignment" Value="Center"/>
+    </Style>
+    <Style Selector="Button.insertmini">
+      <Setter Property="Padding" Value="6,2"/>
+      <Setter Property="MinWidth" Value="24"/>
+      <Setter Property="MinHeight" Value="24"/>
+      <Setter Property="FontSize" Value="12"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+      <Setter Property="VerticalContentAlignment" Value="Center"/>
+      <Setter Property="HorizontalContentAlignment" Value="Center"/>
+    </Style>
     <!-- mute buttons: green while audio passes, red when muted. The compact
          strip buttons also swap their letter: O = open, M = muted. -->
     <Style Selector="ToggleButton.mutemini">
@@ -306,15 +327,20 @@
                     <TextBlock Text="{Binding StateText}" Classes="h" FontSize="11"/>
                     <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
                   </StackPanel>
-                  <ToggleButton Grid.Column="2" Content="N" IsChecked="{Binding NativeHost, Mode=TwoWay}"
+                  <ToggleButton Grid.Column="2" Content="N" Classes="insertmini"
+                                IsChecked="{Binding NativeHost, Mode=TwoWay}"
                                 IsVisible="{Binding CanChooseNativeHost}"
                                 IsEnabled="{Binding CanTurnNativeHostOn}"
-                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,0,0"
+                                Margin="4,0,0,0"
+                                AutomationProperties.Name="Run this plugin in its own process"
                                 ToolTip.Tip="Run this plugin in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
-                  <ToggleButton Grid.Column="3" Content="B" IsChecked="{Binding Bypass, Mode=TwoWay}"
-                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,2,0"
+                  <ToggleButton Grid.Column="3" Content="B" Classes="insertmini"
+                                IsChecked="{Binding Bypass, Mode=TwoWay}"
+                                Margin="4,0,2,0"
+                                AutomationProperties.Name="Bypass this plugin"
                                 ToolTip.Tip="Bypass"/>
-                  <Button Grid.Column="4" Content="⚙" Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10"
+                  <Button Grid.Column="4" Content="⚙" Classes="insertmini"
+                          AutomationProperties.Name="Open this plugin's controls"
                           Click="OnInsertControls" ToolTip.Tip="{Binding ControlsHint}"/>
                 </Grid>
               </DataTemplate>
@@ -363,15 +389,20 @@
                     <TextBlock Text="{Binding StateText}" Classes="h" FontSize="11"/>
                     <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
                   </StackPanel>
-                  <ToggleButton Grid.Column="2" Content="N" IsChecked="{Binding NativeHost, Mode=TwoWay}"
+                  <ToggleButton Grid.Column="2" Content="N" Classes="insertmini"
+                                IsChecked="{Binding NativeHost, Mode=TwoWay}"
                                 IsVisible="{Binding CanChooseNativeHost}"
                                 IsEnabled="{Binding CanTurnNativeHostOn}"
-                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,0,0"
+                                Margin="4,0,0,0"
+                                AutomationProperties.Name="Run this plugin in its own process"
                                 ToolTip.Tip="Run this plugin in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
-                  <ToggleButton Grid.Column="3" Content="B" IsChecked="{Binding Bypass, Mode=TwoWay}"
-                                Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,2,0"
+                  <ToggleButton Grid.Column="3" Content="B" Classes="insertmini"
+                                IsChecked="{Binding Bypass, Mode=TwoWay}"
+                                Margin="4,0,2,0"
+                                AutomationProperties.Name="Bypass this plugin"
                                 ToolTip.Tip="Bypass"/>
-                  <Button Grid.Column="4" Content="⚙" Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10"
+                  <Button Grid.Column="4" Content="⚙" Classes="insertmini"
+                          AutomationProperties.Name="Open this plugin's controls"
                           Click="OnInsertControls" ToolTip.Tip="{Binding ControlsHint}"/>
                 </Grid>
               </DataTemplate>
@@ -579,16 +610,20 @@
                                    Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
                           <TextBlock Grid.Column="1" Text="{Binding Label}" Foreground="#e6e9f0" FontSize="11"
                                      VerticalAlignment="Center" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
-                          <ToggleButton Grid.Column="2" Content="N" IsChecked="{Binding NativeHost, Mode=TwoWay}"
+                          <ToggleButton Grid.Column="2" Content="N" Classes="insertmini"
+                                        IsChecked="{Binding NativeHost, Mode=TwoWay}"
                                         IsVisible="{Binding CanChooseNativeHost}"
                                         IsEnabled="{Binding CanTurnNativeHostOn}"
-                                        Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,0,0"
-                                        HorizontalAlignment="Right"
+                                        Margin="4,0,0,0" HorizontalAlignment="Right"
+                                        AutomationProperties.Name="Run this plugin in its own process"
                                         ToolTip.Tip="Run this plugin in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
-                          <ToggleButton Grid.Column="3" Content="B" IsChecked="{Binding Bypass, Mode=TwoWay}"
-                                        Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10" Margin="4,0,2,0"
-                                        HorizontalAlignment="Right" ToolTip.Tip="Bypass"/>
-                          <Button Grid.Column="4" Content="⚙" Padding="6,0" MinHeight="0" MinWidth="0" FontSize="10"
+                          <ToggleButton Grid.Column="3" Content="B" Classes="insertmini"
+                                        IsChecked="{Binding Bypass, Mode=TwoWay}"
+                                        Margin="4,0,2,0" HorizontalAlignment="Right"
+                                        AutomationProperties.Name="Bypass this plugin"
+                                        ToolTip.Tip="Bypass"/>
+                          <Button Grid.Column="4" Content="⚙" Classes="insertmini"
+                                  AutomationProperties.Name="Open this plugin's controls"
                                   Click="OnInsertControls" ToolTip.Tip="{Binding ControlsHint}"/>
                         </Grid>
                       </DataTemplate>


### PR DESCRIPTION
## Summary

The inline N, B and cog controls were using 10px text with no minimum size or vertical padding. Give all nine controls across the two microphone strips and mix cards shared styles with 12px text, vertical padding and minimum 24 by 24 logical-pixel targets.

Add descriptive accessibility names. Labels, tooltips, colours, bindings and click behaviour stay unchanged. No version bump or packaging changes.

Fixes #74.

## Verification

- Locked restore and Release build with warnings treated as errors and the native plugin host enabled: 0 warnings, 0 errors.
- .NET test suite on the branch based on main: 333 passed, 0 failed, 0 skipped.
- Desktop acceptance of the same UI change before isolating it from the Flatpak development branch: buttons measured 42 physical pixels tall at 1.75 display scale, equivalent to 24 logical pixels. Five mix cards fit in a roughly 1300px-wide window without clipping or horizontal overflow.
- Extreme layouts with more mix cards were not tested. Existing ellipsis handling remains in place for plugin names.

No manual change is needed because the documented controls and their behaviour are unchanged.
