### PR TITLE
Options: keep the update check label on two rows

### DIFF
--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -136,7 +136,9 @@
     <Border Classes="card">
       <StackPanel Spacing="6">
         <TextBlock Text="UPDATES" Classes="h"/>
-        <CheckBox Content="Check GitHub for stable releases at startup (at most once per day)"
+        <!-- Two rows on purpose: left to wrap on its own the label breaks after
+             "per" and leaves "day)" alone on the second line. -->
+        <CheckBox Content="Check GitHub for stable releases at startup&#x0a;(at most once per day)"
                   IsChecked="{Binding CheckForUpdates, Mode=TwoWay}"/>
         <TextBlock Text="Off by default. Check now makes one explicit request. Nothing is downloaded or installed."
                    FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>


### PR DESCRIPTION
## Summary

Put `(at most once per day)` on its own line in the Options update-check checkbox. This prevents `day)` wrapping alone onto a second row. Keep the checkbox behaviour unchanged.

The empty startup-note row reported in the same screenshot exists only on the local Flatpak development branch, so its fix is separate from this main-branch change.

## Verification

- Release build with warnings treated as errors: 0 warnings, 0 errors.
- .NET regression tests: 333 passed, 0 failed.
- Avalonia layout probe using the actual Options markup confirms the label occupies two balanced rows.
- Both Options fixes were loaded into a native-host-enabled build from the Flatpak development tree, with the larger insert buttons preserved. The user confirmed the fixes are visible in the running app.

No version bump. No manual change because the setting and its behaviour are unchanged.
