### PR TITLE
Options: hide empty startup notes and balance the update label

### DIFF
--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -39,7 +39,8 @@
         <TextBlock Text="STARTUP" Classes="h"/>
         <CheckBox Content="{Binding StartupLabel}" IsEnabled="{Binding StartupAvailable}"
                   IsChecked="{Binding StartDaemonAtLogin, Mode=TwoWay}"/>
-        <TextBlock Text="{Binding StartupNote}" TextWrapping="Wrap" Foreground="#8b93a7" FontSize="11"/>
+        <TextBlock Text="{Binding StartupNote}" TextWrapping="Wrap" Foreground="#8b93a7" FontSize="11"
+                   Margin="26,0,0,0" IsVisible="{Binding StartupNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
         <CheckBox Content="Start the mixer UI at login" IsVisible="{Binding IsNative}"
                   IsChecked="{Binding OpenWindowAtLogin, Mode=TwoWay}"/>
         <CheckBox Content="Close button minimizes to tray instead of quitting"
@@ -138,7 +139,9 @@
     <Border Classes="card">
       <StackPanel Spacing="6">
         <TextBlock Text="UPDATES" Classes="h"/>
-        <CheckBox Content="Check GitHub for stable releases at startup (at most once per day)"
+        <!-- Two rows on purpose: left to wrap on its own the label breaks after
+             "per" and leaves "day)" alone on the second line. -->
+        <CheckBox Content="Check GitHub for stable releases at startup&#x0a;(at most once per day)"
                   IsChecked="{Binding CheckForUpdates, Mode=TwoWay}"/>
         <TextBlock Text="Off by default. Check now makes one explicit request. Nothing is downloaded or installed."
                    FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>


### PR DESCRIPTION
## Summary

Hide the startup note when it is empty, using the same visibility guard as the submixer note. When present, indent it under the checkbox label. This removes the blank row below Start the daemon in the Options window.

Also put `(at most once per day)` on its own line in the update-check checkbox, matching #76 for main.

This PR targets `packaging/flatpak`, not main. No other Flatpak work or insert-button changes are part of this diff.

## Verification

- Options UI Release build with warnings treated as errors: 0 warnings, 0 errors.
- Native-host-enabled solution build with both Options changes and the already-merged insert-button fix: 0 warnings, 0 errors.
- Layout probe against the applied markup shows uniform 38px checkbox spacing instead of the extra 20px blank row, and the update text fits on two balanced rows.
- The user confirmed the fixes in the running app after UI-only deployment. The daemon and audio were not restarted.

No version bump or setting behaviour changes.
