### PR TITLE
Mixer: preserve routing and settings through failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
             g++ libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev xvfb xauth
           make -C native
           test -x native/openxlr-lv2-host
+          make -C native test-audio test-clap
           xvfb-run -a make -C native test-editor
 
       - name: Tray window lifecycle

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ native/openxlr-lv2-host
 native/*.o
 native/tests/*.o
 native/tests/editor
+native/tests/audio
+native/tests/clap
 # nix build output symlink
 result
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,10 @@ tools/check-locked-restore.sh
 tools/check-openapi.py docs/openapi-v1.json
 tools/check-spec.py packaging/rpm/openxlr.spec
 make -C native  # C/C++, PipeWire, lilv, LV2 and X11 development headers
+make -C native test-audio test-clap  # audio bounds, stall detection and CLAP bus layouts
 xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
+OPENXLR_TEST_DESKTOP=1 xvfb-run -a dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~TrayWindowTests
+OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~WindowLayoutTests
 ```
 
 These cover the main CI build and tests; the workflow also checks packaged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,9 @@ tools/check-locked-restore.sh                   # every packaging path restores 
 tools/check-openapi.py docs/openapi-v1.json     # the HTTP API document keeps its shape
 tools/check-spec.py packaging/rpm/openxlr.spec  # every installed file is in %files
 make -C native  # C/C++, PipeWire, lilv, LV2 and X11 development headers
+make -C native test-audio test-clap  # audio bounds, stall detection and CLAP bus layouts
 xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
+OPENXLR_TEST_DESKTOP=1 xvfb-run -a dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~TrayWindowTests
 OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~WindowLayoutTests
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -189,9 +189,12 @@ means no native scan has completed yet. Entries carry `path`, `outcome`,
 `cached`, `plugins`, `duplicates`, `exitCode` and `detail`. Outcomes include
 `host-missing`, `directory`, `directory-missing`, `directory-error`,
 `start-error`, `scan-failed`, `timeout`, `output-limit`, `invalid-description`,
-`no-plugins`, `ok` and `scan-error`. Reports retain at most 128 entries per
-format, preferring failures over successful entries when full. Paths are
-limited to 4096 characters and details to 2048, with truncation marked.
+`no-plugins`, `ok` and `scan-error`. A cached description is reused only
+while the native helper that wrote it is the one asking, so `cached` is
+false everywhere in the first scan after the helper changes. Reports retain
+at most 128 entries per format, preferring failures over successful entries
+when full. Paths are limited to 4096 characters and details to 2048, with
+truncation marked.
 
 These reports describe scanner output before the `plugins` message's size
 budget and the picker's channel-width/format filters. Compare them with

--- a/docs/features.md
+++ b/docs/features.md
@@ -139,7 +139,8 @@ For LV2, enabling "Native host" moves only that insert out of filter-chain
 and briefly interrupts its chain. CLAP and VST3 always use that host.
 Packages include the helper; source builds need
 `-p:EnableNativeLv2Host=true`. The helper scans CLAP/VST3 bundles in separate
-processes and caches their descriptions until they change.
+processes and caches their descriptions until the bundle or the helper itself
+changes, so an updated helper reads every installed bundle once.
 
 Chains and exposed parameter values are saved with the mixer and profiles.
 Opaque plugin state, loaded sample files and plugin preset data are not

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -271,7 +271,11 @@ it looks and the picker lists it a moment later. A file is a `.clap` or a
 single-file `.vst3`; a folder is a `.vst3` or `.lv2` bundle, or a folder
 holding several of them, such as an extracted download. Linux plugins are
 copied into `~/.clap`, `~/.vst3` or `~/.lv2`, so the download can go
-afterwards. An archive has to be extracted first. Plugins installed by
+afterwards. Installing over a plugin that is already there builds the new
+copy beside it and swaps the two only once the copy is complete, so a
+download that turns out to be unreadable, or a disk that fills up, costs
+the update and not the plugin you had. An archive has to be extracted
+first. Plugins installed by
 other means, or copied into `/usr/lib/clap`, `/usr/lib/vst3` or
 `/usr/lib/lv2` by a package, appear after "Rescan" in Options or a daemon
 restart (`LV2_PATH`, `CLAP_PATH` and `VST3_PATH` override the places
@@ -479,6 +483,13 @@ and when you switch to it in the device picker. Use it to land on a
 known scene at every login. The reconnect after a passing USB error
 does not count, so the recall never undoes changes you made since.
 Pick "(none)" to stop.
+
+A profile only sets the sends and mixes it names. Add a channel or a
+virtual microphone after saving a profile, and recalling that profile
+leaves the new one as it is: its sends stay closed, the way a new
+channel or mix starts, instead of opening at full level because an
+older profile had nothing to say about them. Save the profile again to
+take the new sends into it.
 
 **Restoring settings on connect.** For the original Wave XLR and first
 XLR Dock, OpenXLR restores the last settings it observed. This policy
@@ -691,8 +702,12 @@ away while an editor is open, the editor closes and the plugin keeps
 processing; pressing "Plugin UI" again opens a fresh one. If an editor
 stops answering, the insert says its controls are frozen and its audio
 carries on. A crash of the plugin process interrupts the chain while it
-recovers. A plugin that keeps crashing has its chain switched off after
-it has failed three times in five minutes, with the reason on the insert;
+recovers, and so does a plugin that stops passing audio: one that blocks
+inside its own processing is noticed after a few seconds and replaced the
+same way a crashed one is, since an instance that is neither dead nor
+processing would otherwise sit there silent. A plugin that keeps crashing
+has its chain switched off after it has failed three times in five
+minutes, with the reason on the insert;
 changing or bypassing that chain starts it over.
 
 <a name="stream-deck"></a>

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -279,7 +279,11 @@ first. Plugins installed by
 other means, or copied into `/usr/lib/clap`, `/usr/lib/vst3` or
 `/usr/lib/lv2` by a package, appear after "Rescan" in Options or a daemon
 restart (`LV2_PATH`, `CLAP_PATH` and `VST3_PATH` override the places
-searched).
+searched). What a CLAP or VST3 bundle said about itself is remembered
+until the bundle changes, so a rescan costs nothing for plugins already
+known. Updating OpenXLR reads every one of them again once, because the
+new version may see them differently, which makes the first scan after
+an update as slow as the first ever.
 
 <a name="windows-plugins"></a>
 **Windows VST3 and CLAP plugins.** They run through

--- a/native/Makefile
+++ b/native/Makefile
@@ -28,9 +28,32 @@ tests/editor.o: tests/editor.c host.c $(HEADERS)
 tests/editor: tests/editor.o lv2.o clap.o vst3.o
 	$(CXX) $^ -o $@ $(LDFLAGS) $(LDLIBS)
 
-.PHONY: test-editor clean
+tests/audio.o: tests/audio.c host.c $(HEADERS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+tests/audio: tests/audio.o lv2.o clap.o vst3.o
+	$(CXX) $^ -o $@ $(LDFLAGS) $(LDLIBS)
+
+# This one compiles clap.c into itself to reach the layout reading, so it
+# links without clap.o.
+tests/clap.o: tests/clap.c host.c clap.c $(HEADERS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+tests/clap: tests/clap.o lv2.o vst3.o
+	$(CXX) $^ -o $@ $(LDFLAGS) $(LDLIBS)
+
+.PHONY: test test-editor test-audio test-clap clean
+# The editor tests need a display; the others need nothing.
+test: test-audio test-clap test-editor
+
 test-editor: tests/editor
 	./tests/editor
 
+test-audio: tests/audio
+	./tests/audio
+
+test-clap: tests/clap
+	./tests/clap
+
 clean:
-	rm -f openxlr-lv2-host $(OBJECTS) tests/editor tests/editor.o
+	rm -f openxlr-lv2-host $(OBJECTS) tests/editor tests/editor.o tests/audio tests/audio.o tests/clap tests/clap.o

--- a/native/clap.c
+++ b/native/clap.c
@@ -12,7 +12,16 @@
 #include <stdlib.h>
 #include <string.h>
 
-enum { MAX_TIMERS = 32, MAX_FDS = 32, MAX_EVENTS = 1024 };
+enum {
+  MAX_TIMERS = 32,
+  MAX_FDS = 32,
+  MAX_EVENTS = 1024,
+  // A plugin may declare more audio ports than the one pair a chain insert
+  // uses: a sidechain input, a second output. Every declared port still has
+  // to be handed a buffer, so these bound what can be carried.
+  MAX_PORTS = 8,
+  MAX_PORT_CHANNELS = 8
+};
 
 typedef struct Clap Clap;
 
@@ -54,6 +63,17 @@ struct Clap {
   Timer timers[MAX_TIMERS];
   Fd fds[MAX_FDS];
   int64_t steady;
+  // Every audio port the plugin declares, not only the pair the chain uses.
+  // CLAP says the buffer arrays a process call carries have to be as long as
+  // the counts the plugin declared, so a plugin with a sidechain input may
+  // read the second entry; passing one entry with a count of one would send
+  // it past the end. The main ports carry the chain's own buffers, the rest
+  // read silence and write into a buffer nothing listens to.
+  clap_audio_buffer_t in_buses[MAX_PORTS], out_buses[MAX_PORTS];
+  float *in_channels[MAX_PORTS][MAX_PORT_CHANNELS];
+  float *out_channels[MAX_PORTS][MAX_PORT_CHANNELS];
+  uint32_t in_bus_count, out_bus_count, main_in, main_out;
+  float *quiet, *discard;  // silence for the spare inputs, a sink for the spare outputs
   // The events of one process call. The plugin reads the inputs through
   // in_list and answers through out_list; neither allocates.
   clap_event_param_value_t in_events[MAX_EVENTS];
@@ -363,23 +383,100 @@ static const clap_plugin_factory_t *factory_of(Clap *c) {
   return c->entry->get_factory(CLAP_PLUGIN_FACTORY_ID);
 }
 
-// The main audio port in one direction, or the first one: its channel count.
-static uint32_t main_port_channels(const clap_plugin_t *plugin,
-                                   const clap_plugin_audio_ports_t *ports,
-                                   bool input) {
-  if (!ports)
-    return 0;
-  uint32_t count = ports->count(plugin, input), fallback = 0;
+// What one direction's audio ports amount to, as far as this host cares.
+// The scanner and the loader both read a layout through clap_layout, so the
+// catalogue can never offer a plugin the loader would then refuse.
+typedef struct {
+  uint32_t count;          // ports the plugin declares in this direction
+  uint32_t main;           // index of the main one
+  uint32_t main_channels;  // its channel count, which is what the catalogue shows
+} PortLayout;
+
+// Read one direction's layout and say whether this host can carry it. The
+// main port is the first one flagged as such, or port 0 when none is.
+// `chain_channels` is the width of the insert the plugin would run in, or 0
+// when the caller is only describing the plugin: a scan does not know what
+// it would be inserted into, and the catalogue matches widths itself.
+// On refusal `why` is filled with the reason, in the same words whichever
+// caller reports it.
+static bool clap_layout(const clap_plugin_t *plugin,
+                        const clap_plugin_audio_ports_t *ports, bool input,
+                        unsigned chain_channels, PortLayout *out, char *why,
+                        size_t why_size) {
+  const char *side = input ? "input" : "output";
+  *out = (PortLayout){0};
+  uint32_t count = ports ? ports->count(plugin, input) : 0;
+  if (count == 0 || count > MAX_PORTS) {
+    snprintf(why, why_size,
+             "the plugin declares %u audio %s ports; this host carries 1 to %d",
+             count, side, MAX_PORTS);
+    return false;
+  }
+  out->count = count;
+  bool flagged = false;
   for (uint32_t i = 0; i < count; ++i) {
     clap_audio_port_info_t info;
-    if (!ports->get(plugin, i, input, &info))
-      continue;
-    if (info.flags & CLAP_AUDIO_PORT_IS_MAIN)
-      return info.channel_count;
-    if (i == 0)
-      fallback = info.channel_count;
+    if (!ports->get(plugin, i, input, &info)) {
+      snprintf(why, why_size, "the plugin would not describe its audio %s port %u",
+               side, i);
+      return false;
+    }
+    if (info.channel_count > MAX_PORT_CHANNELS) {
+      snprintf(why, why_size,
+               "the plugin's audio %s port %u has %u channels; this host carries %d",
+               side, i, info.channel_count, MAX_PORT_CHANNELS);
+      return false;
+    }
+    if (!flagged && ((info.flags & CLAP_AUDIO_PORT_IS_MAIN) || i == 0)) {
+      flagged = (info.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0;
+      out->main = i;
+      out->main_channels = info.channel_count;
+    }
   }
-  return fallback;
+  if (chain_channels && out->main_channels != chain_channels) {
+    snprintf(why, why_size,
+             "the plugin's main audio %s port has %u channels, not the chain's %u",
+             side, out->main_channels, chain_channels);
+    return false;
+  }
+  return true;
+}
+
+// Lay out the buffer arrays one direction's process call needs. CLAP asks
+// for as many buffers as the plugin declared ports, so a plugin with a
+// sidechain input reads the second entry of an array a one-port host would
+// have made one entry long. The main port carries the chain's own buffers;
+// every other port is given one of the two spare buffers, silence in and a
+// sink out, so it is real memory of the right length whatever the plugin
+// does with it.
+static bool clap_map_ports(Clap *c, Host *h,
+                           const clap_plugin_audio_ports_t *ports, bool input) {
+  PortLayout layout;
+  char why[256];
+  if (!clap_layout(c->plugin, ports, input, h->channels, &layout, why, sizeof(why))) {
+    fprintf(stderr, "%s\n", why);
+    return false;
+  }
+  clap_audio_buffer_t *buses = input ? c->in_buses : c->out_buses;
+  float *(*channels)[MAX_PORT_CHANNELS] = input ? c->in_channels : c->out_channels;
+  float *spare = input ? c->quiet : c->discard;
+  for (uint32_t i = 0; i < layout.count; ++i) {
+    clap_audio_port_info_t info;
+    if (!ports->get(c->plugin, i, input, &info))
+      return false;   // clap_layout already read every port; a change now is a refusal
+    for (uint32_t k = 0; k < info.channel_count; ++k)
+      channels[i][k] = spare;
+    buses[i].data32 = channels[i];
+    buses[i].channel_count = info.channel_count;
+  }
+  if (input) {
+    c->in_bus_count = layout.count;
+    c->main_in = layout.main;
+  } else {
+    c->out_bus_count = layout.count;
+    c->main_out = layout.main;
+  }
+  return true;
 }
 
 static bool clap_load(Host *h, char **arguments) {
@@ -418,14 +515,14 @@ static bool clap_load(Host *h, char **arguments) {
     fputs("the plugin refused to initialise\n", stderr);
     return false;
   }
+  c->quiet = calloc(MAX_FRAMES, sizeof(float));
+  c->discard = calloc(MAX_FRAMES, sizeof(float));
+  if (!c->quiet || !c->discard)
+    return false;
   const clap_plugin_audio_ports_t *ports =
       c->plugin->get_extension(c->plugin, CLAP_EXT_AUDIO_PORTS);
-  if (main_port_channels(c->plugin, ports, true) != h->channels ||
-      main_port_channels(c->plugin, ports, false) != h->channels) {
-    fputs("the plugin's main ports do not match the chain's channels\n",
-          stderr);
+  if (!clap_map_ports(c, h, ports, true) || !clap_map_ports(c, h, ports, false))
     return false;
-  }
   c->params = c->plugin->get_extension(c->plugin, CLAP_EXT_PARAMS);
   c->gui = c->plugin->get_extension(c->plugin, CLAP_EXT_GUI);
   c->timer_support =
@@ -500,6 +597,8 @@ static void clap_unload(Host *h) {
   if (c->library)
     dlclose(c->library);
   free(c->records);
+  free(c->quiet);
+  free(c->discard);
   free(c);
   h->impl = NULL;
 }
@@ -509,15 +608,16 @@ static void clap_unload(Host *h) {
 static void clap_process_audio(Host *h, uint32_t frames, float *const *in,
                                float *const *out) {
   Clap *c = h->impl;
-  float *inputs[MAX_CHANNELS], *outputs[MAX_CHANNELS];
+  // Only the main ports change from cycle to cycle; the spare ones were
+  // pointed at their buffers when the layout was mapped at load.
   for (unsigned i = 0; i < h->channels; ++i) {
-    inputs[i] = in[i];
-    outputs[i] = out[i];
+    c->in_channels[c->main_in][i] = in[i];
+    c->out_channels[c->main_out][i] = out[i];
   }
   if (!atomic_load(&c->processing)) {
     if (!c->plugin->start_processing(c->plugin)) {
       for (unsigned i = 0; i < h->channels; ++i)
-        memset(outputs[i], 0, frames * sizeof(float));
+        memset(out[i], 0, frames * sizeof(float));
       return;
     }
     atomic_store(&c->processing, true);
@@ -544,16 +644,14 @@ static void clap_process_audio(Host *h, uint32_t frames, float *const *in,
     };
     p->last_sent = desired;
   }
-  clap_audio_buffer_t input = {.data32 = inputs, .channel_count = h->channels};
-  clap_audio_buffer_t output = {.data32 = outputs, .channel_count = h->channels};
   clap_process_t process = {
       .steady_time = c->steady,
       .frames_count = frames,
       .transport = NULL,
-      .audio_inputs = &input,
-      .audio_outputs = &output,
-      .audio_inputs_count = 1,
-      .audio_outputs_count = 1,
+      .audio_inputs = c->in_buses,
+      .audio_outputs = c->out_buses,
+      .audio_inputs_count = c->in_bus_count,
+      .audio_outputs_count = c->out_bus_count,
       .in_events = &c->in_list,
       .out_events = &c->out_list,
   };
@@ -561,7 +659,7 @@ static void clap_process_audio(Host *h, uint32_t frames, float *const *in,
   c->steady += frames;
   if (status == CLAP_PROCESS_ERROR)
     for (unsigned i = 0; i < h->channels; ++i)
-      memset(outputs[i], 0, frames * sizeof(float));
+      memset(out[i], 0, frames * sizeof(float));
   for (uint32_t i = 0; i < c->record_count; ++i)
     if (c->records[i].ctl->output) {
       double value;
@@ -737,9 +835,20 @@ int clap_scan(const char *file) {
     }
     const clap_plugin_audio_ports_t *ports =
         plugin->get_extension(plugin, CLAP_EXT_AUDIO_PORTS);
-    printf("],\"audioIns\":%u,\"audioOuts\":%u",
-           main_port_channels(plugin, ports, true),
-           main_port_channels(plugin, ports, false));
+    // The catalogue shows the main ports' widths, and says so when the whole
+    // layout is one this host would refuse to load. Both come from the same
+    // reading the loader does, so the picker never offers a plugin that
+    // would then be turned away, and the reason is worded the same either way.
+    PortLayout in_layout, out_layout;
+    char refusal[256] = "";
+    bool carried = clap_layout(plugin, ports, true, 0, &in_layout, refusal, sizeof(refusal)) &&
+                   clap_layout(plugin, ports, false, 0, &out_layout, refusal, sizeof(refusal));
+    printf("],\"audioIns\":%u,\"audioOuts\":%u", in_layout.main_channels,
+           out_layout.main_channels);
+    if (!carried) {
+      printf(",\"layoutRefused\":");
+      json_string(refusal);
+    }
     const clap_plugin_gui_t *gui = plugin->get_extension(plugin, CLAP_EXT_GUI);
     printf(",\"gui\":%s",
            gui && gui->is_api_supported(plugin, CLAP_WINDOW_API_X11, false)

--- a/native/clap.c
+++ b/native/clap.c
@@ -839,15 +839,20 @@ int clap_scan(const char *file) {
     // layout is one this host would refuse to load. Both come from the same
     // reading the loader does, so the picker never offers a plugin that
     // would then be turned away, and the reason is worded the same either way.
+    // Both directions are read, and neither reading is skipped: the widths
+    // of both are printed, so a short circuit on the first refusal would
+    // leave the second layout unwritten and print whatever the stack held.
+    // A refused reading zeroes its own layout, so a plugin refused in one
+    // direction is still described in the other.
     PortLayout in_layout, out_layout;
-    char refusal[256] = "";
-    bool carried = clap_layout(plugin, ports, true, 0, &in_layout, refusal, sizeof(refusal)) &&
-                   clap_layout(plugin, ports, false, 0, &out_layout, refusal, sizeof(refusal));
+    char in_why[256] = "", out_why[256] = "";
+    bool ins = clap_layout(plugin, ports, true, 0, &in_layout, in_why, sizeof(in_why));
+    bool outs = clap_layout(plugin, ports, false, 0, &out_layout, out_why, sizeof(out_why));
     printf("],\"audioIns\":%u,\"audioOuts\":%u", in_layout.main_channels,
            out_layout.main_channels);
-    if (!carried) {
+    if (!ins || !outs) {
       printf(",\"layoutRefused\":");
-      json_string(refusal);
+      json_string(!ins ? in_why : out_why);   // the input's reason first, as the loader reports it
     }
     const clap_plugin_gui_t *gui = plugin->get_extension(plugin, CLAP_EXT_GUI);
     printf(",\"gui\":%s",

--- a/native/host.c
+++ b/native/host.c
@@ -222,6 +222,34 @@ bool host_on_audio_thread(Host *h) {
 
 // --- audio ------------------------------------------------------------------
 
+bool host_quantum_supported(const Host *h, uint32_t frames, uint32_t rate_denom) {
+  return frames <= MAX_FRAMES && rate_denom == h->rate;
+}
+
+float *host_fallback(float *buffer, uint32_t frames, bool clear) {
+  if (clear)
+    memset(buffer, 0,
+           sizeof(float) * (frames > MAX_FRAMES ? MAX_FRAMES : frames));
+  return buffer;
+}
+
+bool host_audio_stuck(uint64_t entered, uint64_t left, uint64_t *last,
+                      unsigned *outstanding, unsigned window) {
+  if (entered == left) {  // nothing in the plugin right now
+    *last = entered;
+    *outstanding = 0;
+    return false;
+  }
+  if (entered != *last) {  // a different call, so the previous one returned
+    *last = entered;
+    *outstanding = 1;
+    return false;
+  }
+  if (*outstanding < window)
+    ++*outstanding;
+  return *outstanding >= window;
+}
+
 static void process_audio(void *data, struct spa_io_position *position) {
   Host *h = data;
   if (!atomic_load(&h->audio_thread_known)) {
@@ -229,26 +257,37 @@ static void process_audio(void *data, struct spa_io_position *position) {
     atomic_store(&h->audio_thread_known, true);
   }
   uint32_t frames = position->clock.duration;
-  bool broken = frames > MAX_FRAMES || position->clock.rate.denom != h->rate;
+  // Refuse the cycle before anything is written. The fallback buffers hold
+  // MAX_FRAMES frames, so a larger quantum has to be turned away here: the
+  // silence and scratch writes below would run past their end, and the
+  // check that used to sit after them came too late to prevent that.
+  // The output ports' own buffers are sized for this quantum, so those are
+  // the only ones it is safe to clear on the way out.
+  if (!host_quantum_supported(h, frames, position->clock.rate.denom)) {
+    atomic_store(&h->audio_error, true);
+    for (unsigned i = 0; i < h->channels; ++i) {
+      float *buffer = pw_filter_get_dsp_buffer(h->out_ports[i], frames);
+      if (buffer)
+        memset(buffer, 0, sizeof(float) * frames);
+    }
+    return;
+  }
   float *in[MAX_CHANNELS], *out[MAX_CHANNELS];
   for (unsigned i = 0; i < h->channels; ++i) {
     float *buffer = pw_filter_get_dsp_buffer(h->in_ports[i], frames);
-    if (!buffer) {
-      memset(h->silence, 0, sizeof(float) * frames);
-      buffer = h->silence;
-    }
+    if (!buffer)
+      buffer = host_fallback(h->silence, frames, true);
     in[i] = buffer;
     out[i] = pw_filter_get_dsp_buffer(h->out_ports[i], frames);
     if (!out[i])
-      out[i] = h->scratch;
+      out[i] = host_fallback(h->scratch, frames, false);
   }
-  if (broken) {
-    atomic_store(&h->audio_error, true);
-    for (unsigned i = 0; i < h->channels; ++i)
-      memset(out[i], 0, sizeof(float) * frames);
-    return;
-  }
+  // Bracket the plugin's callback so the process monitor can tell a stuck
+  // one from an idle node: entered and left differ only while a call is
+  // outstanding, and a stuck call keeps the same entered value.
+  atomic_fetch_add(&h->audio_entered, 1);
   h->backend->process(h, frames, in, out);
+  atomic_fetch_add(&h->audio_left, 1);
 }
 
 static void state_changed(void *data, enum pw_filter_state old,
@@ -700,8 +739,17 @@ static void stop(void *data, int signal) {
   pw_main_loop_quit(((Host *)data)->loop);
 }
 
+// How many consecutive polls one plugin callback may span before it counts
+// as stuck. At a poll a second that is several seconds inside the plugin,
+// on top of which the daemon waits out its own patience before it replaces
+// the process: long enough that no working plugin is ever mistaken for one.
+enum { AUDIO_STALL_POLLS = 6 };
+
 static void *monitor_audio(void *data) {
   Host *h = data;
+  uint64_t last_entered = 0;
+  unsigned outstanding = 0;
+  bool said = false;
   while (!atomic_load(&h->monitor_stop)) {
     // The redirected input pipe belongs to the daemon process, unlike
     // PDEATHSIG, which follows the short-lived .NET thread that spawned us.
@@ -709,6 +757,25 @@ static void *monitor_audio(void *data) {
     struct pollfd input = {STDIN_FILENO, POLLHUP | POLLERR, 0};
     if (poll(&input, 1, 1000) > 0 && (input.revents & (POLLHUP | POLLERR)))
       _exit(0);
+    // The beat says the audio is moving, not merely that the process is
+    // alive. A plugin that blocks inside its own process callback leaves
+    // this thread and the editor loop untouched, so beating regardless
+    // would leave the daemon carrying an instance that passes no audio and
+    // never gets replaced. A node with no call outstanding is idle or
+    // suspended on purpose and keeps beating.
+    if (host_audio_stuck(atomic_load(&h->audio_entered),
+                         atomic_load(&h->audio_left), &last_entered,
+                         &outstanding, AUDIO_STALL_POLLS)) {
+      if (!said) {
+        fprintf(stderr,
+                "the plugin has been inside one audio callback for %d s; "
+                "restart the chain\n",
+                AUDIO_STALL_POLLS);
+        said = true;
+      }
+      continue;
+    }
+    said = false;
     puts("heartbeat");
   }
   return NULL;

--- a/native/host.h
+++ b/native/host.h
@@ -96,6 +96,12 @@ struct Host {
   _Atomic bool audio_error;
   _Atomic bool monitor_stop;
   unsigned heartbeat_ticks;
+  // Audio-callback progress. The audio thread bumps entered before the
+  // plugin's process call and left after it returns, so the two differ
+  // exactly while a call is outstanding and entered stops moving when one
+  // never returns. An idle or suspended node makes no calls at all, which
+  // reads as no call outstanding rather than as a stall.
+  _Atomic uint64_t audio_entered, audio_left;
   pthread_t main_thread, audio_thread;
   _Atomic bool audio_thread_known;
   // The editor's window
@@ -156,6 +162,22 @@ void host_editor_lost(Host *h);
 void host_run_guarded(Host *h, void (*call)(void *), void *argument);
 // Ask the supervisor for a fresh process; audio ends with this one.
 void host_fail(Host *h, const char *why);
+// Whether one cycle can be carried at all: the fixed fallback buffers hold
+// MAX_FRAMES frames, and the plugin was activated for one sample rate. A
+// cycle that fails this is refused before anything is written.
+bool host_quantum_supported(const Host *h, uint32_t frames, uint32_t rate_denom);
+// A channel PipeWire gave no buffer for this cycle borrows one of the two
+// fixed fallback buffers. The clear is bounded by their length, so it can
+// never run past the allocation.
+float *host_fallback(float *buffer, uint32_t frames, bool clear);
+// Whether the plugin's audio callback is stuck: the same call has been
+// outstanding across every poll of a window. `entered` and `left` come from
+// the host, `last` and `outstanding` are the caller's running state, and
+// `window` is how many consecutive polls a single call may span before it
+// counts as stuck. A node with no call outstanding, idle or suspended, is
+// never stuck.
+bool host_audio_stuck(uint64_t entered, uint64_t left, uint64_t *last,
+                      unsigned *outstanding, unsigned window);
 struct pw_loop *host_loop(Host *h);
 bool host_on_main_thread(Host *h);
 bool host_on_audio_thread(Host *h);

--- a/native/tests/audio.c
+++ b/native/tests/audio.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// The audio thread's two safety rules, without a graph to run them in: a
+// cycle the fixed buffers cannot carry is refused before anything is
+// written, and a plugin stuck inside one process call is told apart from a
+// node that simply has no work.
+#define main host_program_main
+#include "../host.c"
+#undef main
+#include <assert.h>
+
+// A canary past the end of a fallback buffer. Nothing may reach it.
+enum { CANARY = 64 };
+
+static float *guarded(void) {
+  float *buffer = malloc(sizeof(float) * (MAX_FRAMES + CANARY));
+  assert(buffer);
+  for (unsigned i = 0; i < MAX_FRAMES + CANARY; ++i)
+    buffer[i] = -1.0f;
+  return buffer;
+}
+
+static void assert_canary(const float *buffer) {
+  for (unsigned i = MAX_FRAMES; i < MAX_FRAMES + CANARY; ++i)
+    assert(buffer[i] == -1.0f);
+}
+
+int main(void) {
+  Host h = {.rate = 48000, .channels = 2};
+
+  // The quantum the graph runs at decides whether the cycle can happen at
+  // all. Anything longer than the fallback buffers, or a sample rate the
+  // plugin was not activated for, has to be turned away.
+  assert(host_quantum_supported(&h, 1024, 48000));
+  assert(host_quantum_supported(&h, MAX_FRAMES, 48000));
+  assert(!host_quantum_supported(&h, MAX_FRAMES + 1, 48000));
+  assert(!host_quantum_supported(&h, 65536, 48000));
+  assert(!host_quantum_supported(&h, 1024, 44100));
+  puts("PASS: an oversized quantum or a changed rate refuses the cycle");
+
+  // And the write itself is bounded, so the refusal above is not the only
+  // thing standing between a large quantum and the end of the buffer.
+  float *silence = guarded();
+  assert(host_fallback(silence, 512, true) == silence);
+  for (unsigned i = 0; i < 512; ++i)
+    assert(silence[i] == 0.0f);
+  assert(silence[512] == -1.0f);
+  assert_canary(silence);
+  assert(host_fallback(silence, MAX_FRAMES * 8, true) == silence);
+  assert_canary(silence);
+  free(silence);
+  puts("PASS: the fallback buffers are never written past their end");
+
+  // A plugin that blocks inside its own process call leaves the monitor
+  // thread and the editor loop untouched, so the beat has to come from the
+  // audio callback's own progress. Entered and left differ only while a
+  // call is outstanding.
+  uint64_t entered = 0, left = 0, last = 0;
+  unsigned outstanding = 0;
+  const unsigned window = 6;
+
+  // A node with no work: nothing outstanding, never stuck, however long.
+  for (unsigned poll = 0; poll < 100; ++poll)
+    assert(!host_audio_stuck(entered, left, &last, &outstanding, window));
+  puts("PASS: an idle or suspended node is never taken for a stuck one");
+
+  // A node processing normally: every poll sees a different call, or none.
+  for (unsigned poll = 0; poll < 100; ++poll) {
+    ++entered;
+    assert(!host_audio_stuck(entered, left, &last, &outstanding, window));
+    ++left;
+    assert(!host_audio_stuck(entered, left, &last, &outstanding, window));
+  }
+  puts("PASS: a callback that returns keeps the process healthy");
+
+  // A slow but progressing callback: outstanding at every poll, but a
+  // different one each time.
+  for (unsigned poll = 0; poll < 100; ++poll) {
+    ++entered;
+    assert(!host_audio_stuck(entered, left, &last, &outstanding, window));
+    ++left;
+  }
+  puts("PASS: a slow callback that keeps arriving is not a stall");
+
+  // The stall: one call, outstanding across poll after poll.
+  ++entered;
+  for (unsigned poll = 1; poll < window; ++poll)
+    assert(!host_audio_stuck(entered, left, &last, &outstanding, window));
+  assert(host_audio_stuck(entered, left, &last, &outstanding, window));
+  assert(host_audio_stuck(entered, left, &last, &outstanding, window));
+  puts("PASS: one callback outstanding across the whole window reads as stuck");
+
+  // And it recovers: the plugin returns, and the next call is a fresh one.
+  ++left;
+  assert(!host_audio_stuck(entered, left, &last, &outstanding, window));
+  ++entered;
+  assert(!host_audio_stuck(entered, left, &last, &outstanding, window));
+  puts("PASS: a callback that comes back is healthy again");
+  return 0;
+}

--- a/native/tests/clap.c
+++ b/native/tests/clap.c
@@ -269,5 +269,25 @@ int main(void) {
   assert(clap_layout(&fake, &ap_ext, true, 0, &scanned, scan_why, sizeof(scan_why)));
   assert(!clap_layout(&fake, &ap_ext, true, 1, &loaded, load_why, sizeof(load_why)));
   puts("PASS: the scanner and the loader refuse the same layouts, in the same words");
+
+  // 8. A refusal in one direction leaves the other one described. The scan
+  // prints both widths, so a reading it skips is a reading of whatever the
+  // stack held: skipping the output reading once a refused input had
+  // short-circuited it put 0xFEFEFEFE into the catalogue's JSON as an
+  // audioOuts of 4278124286, for four real LSP mixers. Both layouts are
+  // poisoned first, so anything left unwritten is caught here.
+  in_side = (Side){.count = MAX_PORTS + 1, .channels = {2, 2, 2, 2, 2, 2, 2, 2}};
+  out_side = (Side){.count = 1, .channels = {2}, .main = 0, .flag_main = true};
+  PortLayout poisoned_in, poisoned_out;
+  memset(&poisoned_in, 0xFE, sizeof(poisoned_in));
+  memset(&poisoned_out, 0xFE, sizeof(poisoned_out));
+  char why_in[256] = "", why_out[256] = "";
+  bool read_in = clap_layout(&fake, &ap_ext, true, 0, &poisoned_in, why_in, sizeof(why_in));
+  bool read_out = clap_layout(&fake, &ap_ext, false, 0, &poisoned_out, why_out, sizeof(why_out));
+  assert(!read_in && read_out);
+  assert(poisoned_in.count == 0 && poisoned_in.main == 0 && poisoned_in.main_channels == 0);
+  assert(poisoned_out.count == 1 && poisoned_out.main_channels == 2);
+  assert(why_in[0] && !why_out[0]);
+  puts("PASS: a refused direction writes its own layout and leaves the other described");
   return 0;
 }

--- a/native/tests/clap.c
+++ b/native/tests/clap.c
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// The CLAP audio port layout, against fake plugins that declare more buses
+// than the chain uses. A plugin's declared bus count is what its process
+// call is allowed to index, so a host that hands it fewer sends it past the
+// end of the array; and the scanner and the loader have to agree about which
+// layouts can be carried, or the catalogue offers a plugin that is then
+// refused. No PipeWire and no audio device: the buffers are plain malloc.
+//
+// host.c is included under a renamed main, as tests/editor.c does, and clap.c
+// after the macro is undone, since clap_map_ports has a local called main.
+#define main host_program_main
+#include "../host.c"
+#undef main
+#include "../clap.c"
+#include <assert.h>
+
+// --- a fake plugin ----------------------------------------------------------
+
+typedef struct {
+  uint32_t count;
+  uint32_t channels[MAX_PORTS];
+  uint32_t main;      // which index carries CLAP_AUDIO_PORT_IS_MAIN
+  bool flag_main;     // whether any port is flagged at all
+} Side;
+
+static Side in_side, out_side;
+static bool touched_every_bus;
+static uint32_t seen_in_count, seen_out_count;
+
+static uint32_t ap_count(const clap_plugin_t *p, bool input) {
+  return input ? in_side.count : out_side.count;
+}
+
+static bool ap_get(const clap_plugin_t *p, uint32_t index, bool input,
+                   clap_audio_port_info_t *info) {
+  Side *s = input ? &in_side : &out_side;
+  if (index >= s->count)
+    return false;
+  memset(info, 0, sizeof(*info));
+  info->id = index;
+  info->channel_count = s->channels[index];
+  info->flags = (s->flag_main && index == s->main) ? CLAP_AUDIO_PORT_IS_MAIN : 0;
+  info->port_type = CLAP_PORT_STEREO;
+  info->in_place_pair = CLAP_INVALID_ID;
+  return true;
+}
+
+static const clap_plugin_audio_ports_t ap_ext = {ap_count, ap_get};
+
+static bool fake_init(const clap_plugin_t *p) { return true; }
+static void fake_destroy(const clap_plugin_t *p) {}
+static bool fake_activate(const clap_plugin_t *p, double r, uint32_t a,
+                          uint32_t b) {
+  return true;
+}
+static void fake_deactivate(const clap_plugin_t *p) {}
+static bool fake_start(const clap_plugin_t *p) { return true; }
+static void fake_stop(const clap_plugin_t *p) {}
+static void fake_reset(const clap_plugin_t *p) {}
+static const void *fake_ext(const clap_plugin_t *p, const char *id) {
+  if (!strcmp(id, CLAP_EXT_AUDIO_PORTS))
+    return &ap_ext;
+  return NULL;
+}
+static void fake_on_main(const clap_plugin_t *p) {}
+
+// What a real sidechain plugin does: read every declared input channel for the
+// whole block and write every declared output channel for the whole block.
+static clap_process_status fake_process(const clap_plugin_t *p,
+                                        const clap_process_t *pr) {
+  seen_in_count = pr->audio_inputs_count;
+  seen_out_count = pr->audio_outputs_count;
+  float sum = 0;
+  for (uint32_t b = 0; b < pr->audio_inputs_count; ++b) {
+    const clap_audio_buffer_t *buf = &pr->audio_inputs[b];
+    assert(buf->data64 == NULL);  // a plugin preferring 64-bit must see none
+    for (uint32_t ch = 0; ch < buf->channel_count; ++ch) {
+      assert(buf->data32[ch] != NULL);
+      for (uint32_t f = 0; f < pr->frames_count; ++f)
+        sum += buf->data32[ch][f];
+    }
+  }
+  for (uint32_t b = 0; b < pr->audio_outputs_count; ++b) {
+    const clap_audio_buffer_t *buf = &pr->audio_outputs[b];
+    assert(buf->data64 == NULL);
+    for (uint32_t ch = 0; ch < buf->channel_count; ++ch) {
+      assert(buf->data32[ch] != NULL);
+      for (uint32_t f = 0; f < pr->frames_count; ++f)
+        buf->data32[ch][f] = sum + (float)f;
+    }
+  }
+  touched_every_bus = true;
+  return CLAP_PROCESS_CONTINUE;
+}
+
+static clap_plugin_t fake = {.plugin_data = NULL,
+                             .init = fake_init,
+                             .destroy = fake_destroy,
+                             .activate = fake_activate,
+                             .deactivate = fake_deactivate,
+                             .start_processing = fake_start,
+                             .stop_processing = fake_stop,
+                             .reset = fake_reset,
+                             .process = fake_process,
+                             .get_extension = fake_ext,
+                             .on_main_thread = fake_on_main};
+
+// --- the harness ------------------------------------------------------------
+
+static Clap *fresh(Host *h) {
+  Clap *c = calloc(1, sizeof(Clap));
+  assert(c);
+  c->h = h;
+  c->plugin = &fake;
+  c->quiet = calloc(MAX_FRAMES, sizeof(float));
+  c->discard = calloc(MAX_FRAMES, sizeof(float));
+  assert(c->quiet && c->discard);
+  h->impl = c;
+  return c;
+}
+
+static void release(Clap *c) {
+  free(c->quiet);
+  free(c->discard);
+  free(c);
+}
+
+static void run(Host *h, Clap *c, uint32_t frames) {
+  float *inbuf[MAX_CHANNELS], *outbuf[MAX_CHANNELS];
+  for (unsigned i = 0; i < h->channels; ++i) {
+    inbuf[i] = malloc(sizeof(float) * frames);
+    outbuf[i] = malloc(sizeof(float) * frames);
+    assert(inbuf[i] && outbuf[i]);
+    for (uint32_t f = 0; f < frames; ++f)
+      inbuf[i][f] = 0.25f;
+  }
+  clap_process_audio(h, frames, inbuf, outbuf);
+  // The fake plugin writes sum + f into every declared output channel. The
+  // chain's own output buffers must be the ones the main bus carried, so the
+  // audio has to land here and nowhere else.
+  float expect = 0.25f * (float)frames * (float)h->channels;
+  for (unsigned i = 0; i < h->channels; ++i)
+    for (uint32_t f = 0; f < frames; ++f)
+      assert(outbuf[i][f] == expect + (float)f);
+  for (unsigned i = 0; i < h->channels; ++i) {
+    assert(inbuf[i][0] == 0.25f);  // the plugin must not have scribbled input
+    free(inbuf[i]);
+    free(outbuf[i]);
+  }
+}
+
+int main(void) {
+  Host h = {.rate = 48000, .channels = 2};
+
+  // 1. main stereo in + stereo sidechain in, one stereo out.
+  in_side = (Side){.count = 2, .channels = {2, 2}, .main = 0, .flag_main = true};
+  out_side = (Side){.count = 1, .channels = {2}, .main = 0, .flag_main = true};
+  Clap *c = fresh(&h);
+  assert(clap_map_ports(c, &h, &ap_ext, true));
+  assert(clap_map_ports(c, &h, &ap_ext, false));
+  assert(c->in_bus_count == 2 && c->out_bus_count == 1);
+  assert(c->main_in == 0 && c->main_out == 0);
+  touched_every_bus = false;
+  run(&h, c, MAX_FRAMES);
+  assert(touched_every_bus && seen_in_count == 2 && seen_out_count == 1);
+  release(c);
+  puts("PASS: a sidechain input bus gets real silence for a full block");
+
+  // 2. the main bus is not port 0: sidechain first, main second.
+  in_side = (Side){.count = 2, .channels = {1, 2}, .main = 1, .flag_main = true};
+  out_side = (Side){.count = 2, .channels = {2, 4}, .main = 0, .flag_main = true};
+  c = fresh(&h);
+  assert(clap_map_ports(c, &h, &ap_ext, true));
+  assert(clap_map_ports(c, &h, &ap_ext, false));
+  assert(c->main_in == 1 && c->main_out == 0);
+  run(&h, c, 1024);
+  assert(seen_in_count == 2 && seen_out_count == 2);
+  release(c);
+  puts("PASS: a main bus behind a spare one is found and carried");
+
+  // 3. nothing flagged main: port 0 is it.
+  in_side = (Side){.count = 2, .channels = {2, 2}, .flag_main = false};
+  out_side = (Side){.count = 1, .channels = {2}, .flag_main = false};
+  c = fresh(&h);
+  assert(clap_map_ports(c, &h, &ap_ext, true));
+  assert(c->main_in == 0);
+  release(c);
+  puts("PASS: with nothing flagged, port 0 is the main one");
+
+  // 4. refusals.
+  in_side = (Side){.count = 0};
+  c = fresh(&h);
+  assert(!clap_map_ports(c, &h, &ap_ext, true));
+  in_side = (Side){.count = MAX_PORTS + 1, .channels = {2, 2, 2, 2, 2, 2, 2, 2},
+                   .flag_main = false};
+  assert(!clap_map_ports(c, &h, &ap_ext, true));
+  in_side = (Side){.count = 2, .channels = {2, MAX_PORT_CHANNELS + 1},
+                   .main = 0, .flag_main = true};
+  assert(!clap_map_ports(c, &h, &ap_ext, true));
+  in_side = (Side){.count = 1, .channels = {1}, .main = 0, .flag_main = true};
+  assert(!clap_map_ports(c, &h, &ap_ext, true));
+  assert(!clap_map_ports(c, &h, NULL, true));
+  release(c);
+  puts("PASS: the refusals hold");
+
+  // 5. two cycles in a row: the main pointers move, the spare ones stay.
+  in_side = (Side){.count = 2, .channels = {2, 2}, .main = 0, .flag_main = true};
+  out_side = (Side){.count = 2, .channels = {2, 2}, .main = 1, .flag_main = true};
+  c = fresh(&h);
+  assert(clap_map_ports(c, &h, &ap_ext, true));
+  assert(clap_map_ports(c, &h, &ap_ext, false));
+  run(&h, c, 512);
+  run(&h, c, 256);
+  assert(c->in_channels[1][0] == c->quiet && c->in_channels[1][1] == c->quiet);
+  assert(c->out_channels[0][0] == c->discard);
+  release(c);
+  puts("PASS: repeated cycles keep the spare buses pointed at their buffers");
+
+  // 5b. the widest spare output bus this host carries, at a full block.
+  in_side = (Side){.count = 1, .channels = {2}, .main = 0, .flag_main = true};
+  out_side = (Side){.count = 2, .channels = {2, MAX_PORT_CHANNELS},
+                    .main = 0, .flag_main = true};
+  c = fresh(&h);
+  assert(clap_map_ports(c, &h, &ap_ext, true));
+  assert(clap_map_ports(c, &h, &ap_ext, false));
+  run(&h, c, MAX_FRAMES);
+  release(c);
+  puts("PASS: eight spare output channels at a full block stay in bounds");
+
+  // 6. a mono chain.
+  Host mono = {.rate = 48000, .channels = 1};
+  in_side = (Side){.count = 2, .channels = {1, 2}, .main = 0, .flag_main = true};
+  out_side = (Side){.count = 1, .channels = {1}, .main = 0, .flag_main = true};
+  c = fresh(&mono);
+  assert(clap_map_ports(c, &mono, &ap_ext, true));
+  assert(clap_map_ports(c, &mono, &ap_ext, false));
+  run(&mono, c, MAX_FRAMES);
+  release(c);
+  puts("PASS: a mono chain carries a stereo sidechain");
+
+  // 7. the scanner and the loader read the layout the same way. The scan
+  // passes 0 for the chain's width, because it does not know what the plugin
+  // would be inserted into; everything else about what can be carried has to
+  // be the same verdict, in the same words, or the catalogue offers a plugin
+  // the loader then turns away.
+  static const Side refused[] = {
+      {.count = 0},
+      {.count = MAX_PORTS + 1, .channels = {2, 2, 2, 2, 2, 2, 2, 2}},
+      {.count = 2, .channels = {2, MAX_PORT_CHANNELS + 1}, .main = 0, .flag_main = true},
+  };
+  for (unsigned i = 0; i < sizeof(refused) / sizeof(*refused); ++i) {
+    in_side = refused[i];
+    PortLayout scanned, loaded;
+    char scan_why[256] = "", load_why[256] = "";
+    assert(!clap_layout(&fake, &ap_ext, true, 0, &scanned, scan_why, sizeof(scan_why)));
+    assert(!clap_layout(&fake, &ap_ext, true, 2, &loaded, load_why, sizeof(load_why)));
+    assert(!strcmp(scan_why, load_why) && scan_why[0]);
+  }
+  // A layout both accept, with the width the catalogue would show.
+  in_side = (Side){.count = 2, .channels = {2, 2}, .main = 0, .flag_main = true};
+  PortLayout scanned, loaded;
+  char scan_why[256] = "", load_why[256] = "";
+  assert(clap_layout(&fake, &ap_ext, true, 0, &scanned, scan_why, sizeof(scan_why)));
+  assert(clap_layout(&fake, &ap_ext, true, 2, &loaded, load_why, sizeof(load_why)));
+  assert(scanned.count == loaded.count && scanned.main == loaded.main);
+  assert(scanned.main_channels == 2 && loaded.main_channels == 2);
+  // The one thing only the loader can judge: the chain's own width. A scan
+  // still describes the plugin, and the catalogue matches widths itself.
+  assert(clap_layout(&fake, &ap_ext, true, 0, &scanned, scan_why, sizeof(scan_why)));
+  assert(!clap_layout(&fake, &ap_ext, true, 1, &loaded, load_why, sizeof(load_why)));
+  puts("PASS: the scanner and the loader refuse the same layouts, in the same words");
+  return 0;
+}

--- a/src/OpenXLR.Core/Mixing/ClapCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/ClapCatalog.cs
@@ -220,7 +220,7 @@ internal static class HostScan
     /// <summary>One plugin, from the object the reader stands on to its end.</summary>
     private static PluginInfo? ReadPlugin(ref Utf8JsonReader reader, string kind, string file)
     {
-        string? id = null, name = null;
+        string? id = null, name = null, layoutRefused = null;
         var features = new List<string>();
         var parameters = new List<PluginParam>();
         int ins = 0, outs = 0;
@@ -232,6 +232,11 @@ internal static class HostScan
             else if (reader.ValueTextEquals("audioIns"u8)) { reader.Read(); ins = Whole(ref reader); }
             else if (reader.ValueTextEquals("audioOuts"u8)) { reader.Read(); outs = Whole(ref reader); }
             else if (reader.ValueTextEquals("gui"u8)) { reader.Read(); gui = reader.TokenType == JsonTokenType.True; }
+            // The helper says so when the plugin's port layout is one it
+            // would refuse to load, in the words it would print. Carrying
+            // that here keeps the picker from offering a plugin that cannot
+            // be inserted, on the same footing as a missing host feature.
+            else if (reader.ValueTextEquals("layoutRefused"u8)) { reader.Read(); layoutRefused = Text(ref reader); }
             else if (reader.ValueTextEquals("features"u8))
             {
                 reader.Read();
@@ -261,6 +266,7 @@ internal static class HostScan
         {
             HasNativeUi = gui,
             Path = file,
+            UnsupportedFeatures = string.IsNullOrWhiteSpace(layoutRefused) ? [] : [layoutRefused],
         };
     }
 

--- a/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
+++ b/src/OpenXLR.Core/Mixing/LiveMixerLayout.cs
@@ -445,6 +445,7 @@ public sealed partial class Mixer
             _levels.Remove(cell);
             if (_muted.Remove(cell)) snapshot.Muted.Add(cell);
             if (_legIndex.Remove(cell, out int index)) snapshot.Legs[cell] = index;
+            _pendingCells.Remove(cell);
         }
         if (mixId is not null) { _mixVolume.Remove(mixId); _mixMuted.Remove(mixId); }
         return snapshot;
@@ -459,6 +460,7 @@ public sealed partial class Mixer
             _levels.Remove(cell);
             _muted.Remove(cell);
             _legIndex.Remove(cell);
+            _pendingCells.Remove(cell);
         }
     }
 
@@ -470,6 +472,7 @@ public sealed partial class Mixer
             _levels.Remove(cell);
             _muted.Remove(cell);
             _legIndex.Remove(cell);
+            _pendingCells.Remove(cell);
         }
         _mixVolume.Remove(mixId);
         _mixMuted.Remove(mixId);

--- a/src/OpenXLR.Core/Mixing/MeterReader.cs
+++ b/src/OpenXLR.Core/Mixing/MeterReader.cs
@@ -33,24 +33,29 @@ public sealed class MeterReader : IDisposable
     /// <summary>Begin metering a sink by monitoring its output.</summary>
     public void Add(string id, string sinkName)
     {
+        var psi = new ProcessStartInfo("parec")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        psi.ArgumentList.Add("-d"); psi.ArgumentList.Add($"{sinkName}.monitor");
+        psi.ArgumentList.Add("--format=float32le");
+        psi.ArgumentList.Add($"--rate={SampleRate}");
+        psi.ArgumentList.Add("--channels=2");
+        // Without an explicit latency parec batches its output in ~1 s
+        // chunks, which turns a steady signal into a once-a-second spike
+        // followed by decay. 50 ms delivers fragments faster than the
+        // 15 Hz poll, so bars track the signal.
+        psi.ArgumentList.Add("--latency-msec=50");
+        Add(id, psi);
+    }
+
+    /// <summary>Begin metering with a capture process of the caller's choosing.</summary>
+    internal void Add(string id, ProcessStartInfo psi)
+    {
         lock (_gate)
         {
             if (_disposed || _meters.ContainsKey(id)) return;
-
-            var psi = new ProcessStartInfo("parec")
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-            };
-            psi.ArgumentList.Add("-d"); psi.ArgumentList.Add($"{sinkName}.monitor");
-            psi.ArgumentList.Add("--format=float32le");
-            psi.ArgumentList.Add($"--rate={SampleRate}");
-            psi.ArgumentList.Add("--channels=2");
-            // Without an explicit latency parec batches its output in ~1 s
-            // chunks, which turns a steady signal into a once-a-second spike
-            // followed by decay. 50 ms delivers fragments faster than the
-            // 15 Hz poll, so bars track the signal.
-            psi.ArgumentList.Add("--latency-msec=50");
 
             Process? p;
             try { p = Process.Start(psi); }
@@ -59,10 +64,18 @@ public sealed class MeterReader : IDisposable
 
             var meter = new Meter { Process = p };
             _meters[id] = meter;
-            new Thread(() => Pump(meter)) { IsBackground = true, Name = $"meter-{id}" }.Start();
+            // Take both streams here, while the gate still holds the process:
+            // Remove and Dispose can retire the meter before either thread is
+            // scheduled, and Process.StandardOutput on a disposed process
+            // throws, on a raw thread with no handler above it. Reading a
+            // stream that was closed underneath fails inside the loops, where
+            // it is caught.
+            Stream output = p.StandardOutput.BaseStream;
+            Stream errors = p.StandardError.BaseStream;
+            new Thread(() => Pump(meter, output)) { IsBackground = true, Name = $"meter-{id}" }.Start();
             // stderr must be drained: parec blocks once the pipe fills with
             // warnings, which silently freezes its audio output mid-stream.
-            new Thread(() => Drain(p)) { IsBackground = true, Name = $"meter-err-{id}" }.Start();
+            new Thread(() => Drain(errors)) { IsBackground = true, Name = $"meter-err-{id}" }.Start();
         }
     }
 
@@ -102,21 +115,20 @@ public sealed class MeterReader : IDisposable
         return (sumL, sumR, frames, rest);
     }
 
-    private static void Drain(Process p)
+    private static void Drain(Stream errors)
     {
         var buf = new byte[4096];
-        try { while (p.StandardError.BaseStream.Read(buf, 0, buf.Length) > 0) { } }
+        try { while (errors.Read(buf, 0, buf.Length) > 0) { } }
         catch (Exception) { /* process ended */ }
     }
 
-    private void Pump(Meter meter)
+    private void Pump(Meter meter, Stream stdout)
     {
         // A pipe read can end anywhere inside an 8-byte stereo frame; the
         // remainder is carried into the next read so the stream never goes
         // out of alignment (which would turn the meters into noise).
         var buf = new byte[8192];
         int carry = 0;
-        Stream stdout = meter.Process.StandardOutput.BaseStream;
         while (!_disposed)
         {
             int read;

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -89,6 +89,16 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
     /// <summary>Every channel combine feeds every mix sink, present or future.</summary>
     private const string MixSinkPattern = "~" + MixDefinition.SinkPrefix;
     private readonly Dictionary<string, int> _legIndex = [];
+    // Cells whose combine leg was not there when their fader was last pushed.
+    // A leg that turns up afterwards carries PipeWire's defaults, full level
+    // and unmuted, so the sweep pushes the stored fader onto it as soon as it
+    // appears. See EnsureCellLevels.
+    private readonly HashSet<string> _pendingCells = [];
+    /// <summary>Rounds run on consecutive sweeps before backing off; a late leg is up in one or two.</summary>
+    private const int CellPromptRounds = 3;
+    /// <summary>The longest the sweep waits between rounds, so a send still waiting is tried at least once a minute.</summary>
+    private const int CellMaxGapSweeps = 60;
+    private int _cellRounds, _cellWait;
 
     /// <summary>Map every combine's internal streams to their (channel, mix) cells.</summary>
     private void DiscoverLegsLocked()
@@ -892,8 +902,46 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
                 AuxPortEnabled = _auxPortEnabled,
                 LowCutHz = _lowCutHz,
                 SoftClipGuard = _softClipGuard,
-                Inserts = _inserts.ToDictionary(e => e.Key, e => e.Value.ToList()),
+                Inserts = CopyInsertsLocked(),
             };
+        }
+    }
+
+    /// <summary>
+    /// The insert chains as a snapshot nothing else can change. An insert's
+    /// Params dictionary is written in place (a control move, an editor edit)
+    /// under this lock, while an export is serialized outside it, so handing
+    /// the live dictionary out would let a save enumerate a dictionary that
+    /// gains a key mid-write. That throws inside a timer callback, which ends
+    /// the daemon.
+    /// </summary>
+    private Dictionary<string, List<InsertDefinition>> CopyInsertsLocked() => CopyInserts(_inserts);
+
+    /// <inheritdoc cref="CopyInsertsLocked"/>
+    internal static Dictionary<string, List<InsertDefinition>> CopyInserts(
+        IReadOnlyDictionary<string, List<InsertDefinition>> inserts)
+        => inserts.ToDictionary(e => e.Key,
+            e => e.Value.Select(i => i with { Params = new Dictionary<string, double>(i.Params) }).ToList());
+
+    /// <summary>
+    /// Apply the mutes a saved scene or settings file carries, leaving alone
+    /// every entry it does not mention. A channel or a mix added after the
+    /// file was written is not in it, and those start muted with their sends
+    /// at unity, so clearing the whole set and re-adding would open a send
+    /// the file never described: the microphone into a mix a profile predates.
+    /// An entry the file describes (it carries a level for it, or lists it as
+    /// muted) is set exactly as the file says.
+    /// </summary>
+    internal static void RecallMutes(HashSet<string> muted, IEnumerable<string> entries,
+        IEnumerable<string> described, IEnumerable<string> savedMuted)
+    {
+        var wanted = new HashSet<string>(savedMuted, StringComparer.Ordinal);
+        var known = new HashSet<string>(wanted, StringComparer.Ordinal);
+        known.UnionWith(described);
+        foreach (string entry in entries)
+        {
+            if (wanted.Contains(entry)) muted.Add(entry);
+            else if (known.Contains(entry)) muted.Remove(entry);
         }
     }
 
@@ -906,14 +954,11 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
 
             foreach ((string mixId, double vol) in s.MixVolumes)
                 if (_mixVolume.ContainsKey(mixId)) _mixVolume[mixId] = Math.Clamp(vol, 0, 1);
-            _mixMuted.Clear();
-            foreach (string mixId in s.MixMuted) _mixMuted.Add(mixId);
+            RecallMutes(_mixMuted, _config.Mixes.Select(m => m.Id), s.MixVolumes.Keys, s.MixMuted);
 
             foreach ((string cell, double lvl) in s.Levels)
                 if (_cells.Contains(cell)) _levels[cell] = Math.Clamp(lvl, 0, 1);
-            _muted.Clear();
-            foreach (string cell in s.ChannelMuted)
-                if (_cells.Contains(cell)) _muted.Add(cell);
+            RecallMutes(_muted, _cells, s.Levels.Keys, s.ChannelMuted);
 
             foreach ((string identity, string channelId) in StreamMatcher.MigrateOverrides(s.AppOverrides))
                 Matcher.SetOverride(identity, _config.ResolveApplicationChannel(channelId));
@@ -1000,7 +1045,7 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
                 OutputVolume = _outputVolume,
                 LowCutHz = _lowCutHz,
                 SoftClipGuard = _softClipGuard,
-                Inserts = _inserts.ToDictionary(e => e.Key, e => e.Value.ToList()),
+                Inserts = CopyInsertsLocked(),
             };
         }
     }
@@ -1018,14 +1063,14 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
 
             foreach ((string mixId, double vol) in s.MixVolumes)
                 if (_mixVolume.ContainsKey(mixId)) _mixVolume[mixId] = Math.Clamp(vol, 0, 1);
-            _mixMuted.Clear();
-            foreach (string mixId in s.MixMuted) _mixMuted.Add(mixId);
+            // A profile saved before a channel or a mix existed says nothing
+            // about its sends, and those sends sit at unity behind a mute.
+            // Recalling it must not open them.
+            RecallMutes(_mixMuted, _config.Mixes.Select(m => m.Id), s.MixVolumes.Keys, s.MixMuted);
 
             foreach ((string cell, double lvl) in s.Levels)
                 if (_cells.Contains(cell)) _levels[cell] = Math.Clamp(lvl, 0, 1);
-            _muted.Clear();
-            foreach (string cell in s.ChannelMuted)
-                if (_cells.Contains(cell)) _muted.Add(cell);
+            RecallMutes(_muted, _cells, s.Levels.Keys, s.ChannelMuted);
 
             foreach (MixDefinition mix in _config.Mixes) ReapplyMixLocked(mix.Id);
 
@@ -1745,11 +1790,20 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         if (_hardwareMicMonitor && channelId == "xlr1" && MonitorFeed.Includes(JackFeedLocked(), mixId))
             muted = true;   // the hardware direct path carries it to the jacks
 
-        if (!_legIndex.TryGetValue(cell, out int idx)) { DiscoverLegsLocked(); if (!_legIndex.TryGetValue(cell, out idx)) return; }
+        if (!_legIndex.TryGetValue(cell, out int idx))
+        {
+            DiscoverLegsLocked();
+            // A leg that has not grown yet sits at PipeWire's defaults, which
+            // are full level and unmuted. Remember the cell so the sweep can
+            // push the stored fader the moment the leg appears; leaving it
+            // would open a send the user had closed.
+            if (!_legIndex.TryGetValue(cell, out idx)) { MarkCellPendingLocked(cell); return; }
+        }
         try
         {
             _pw.SetSinkInputVolume(idx, level);
             _pw.SetSinkInputMuted(idx, muted);
+            _pendingCells.Remove(cell);
         }
         catch (InvalidOperationException)
         {
@@ -1757,9 +1811,78 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
             DiscoverLegsLocked();
             if (_legIndex.TryGetValue(cell, out idx))
             {
-                try { _pw.SetSinkInputVolume(idx, level); _pw.SetSinkInputMuted(idx, muted); }
-                catch (InvalidOperationException) { /* give up until next change */ }
+                try { _pw.SetSinkInputVolume(idx, level); _pw.SetSinkInputMuted(idx, muted); _pendingCells.Remove(cell); }
+                catch (InvalidOperationException) { MarkCellPendingLocked(cell); }
             }
+            else MarkCellPendingLocked(cell);
+        }
+    }
+
+    /// <summary>A cell that could not be pushed, and a fresh round of tries for it.</summary>
+    private void MarkCellPendingLocked(string cell)
+    {
+        if (_pendingCells.Add(cell)) _cellRounds = _cellWait = 0;
+    }
+
+    /// <summary>
+    /// Drop from the pending set every cell that no longer exists. A deleted
+    /// channel or mix is not waiting for a leg, and its cells must not keep
+    /// the reconciliation running on its own account.
+    /// </summary>
+    internal static void ForgetRemovedCells(HashSet<string> pending, IReadOnlySet<string> cells)
+    {
+        if (pending.Count > 0) pending.RemoveWhere(cell => !cells.Contains(cell));
+    }
+
+    /// <summary>
+    /// Sweeps to wait before reconciliation round <paramref name="rounds"/>.
+    /// The first rounds go on consecutive sweeps, because a leg that is
+    /// merely late is up within a second or two. After that the gap doubles
+    /// and settles at <see cref="CellMaxGapSweeps"/>, and there it stays: a
+    /// send whose leg has still not appeared is a send sitting at full level
+    /// and unmuted, so it is tried again for as long as the cell exists.
+    /// The cost in the steady state is one leg discovery a minute, and only
+    /// while something is actually waiting.
+    /// </summary>
+    internal static int CellRoundGap(int rounds)
+    {
+        if (rounds <= 0) return 0;                     // the first round runs at once
+        if (rounds < CellPromptRounds) return 1;       // then the next sweep, twice
+        return Math.Min(2 << Math.Min(rounds - CellPromptRounds, 16), CellMaxGapSweeps);
+    }
+
+    /// <summary>
+    /// Push the stored fader onto every send whose combine leg was missing
+    /// when it was last set. A combine grows its legs a moment after its
+    /// module loads, and the build does not wait for them, so a leg can turn
+    /// up after its cell was applied; until this runs it carries PipeWire's
+    /// defaults, full level and unmuted. A cell stays on this list until its
+    /// fader is on the leg or the cell itself is gone, on the backoff
+    /// <see cref="CellRoundGap"/> sets. Called from the sweep, and free
+    /// while nothing is waiting.
+    /// </summary>
+    public bool EnsureCellLevels()
+    {
+        lock (_gate)
+        {
+            ForgetRemovedCells(_pendingCells, _cells);
+            if (!_built || _pendingCells.Count == 0) { _cellRounds = _cellWait = 0; return false; }
+            if (_cellWait > 0) { _cellWait--; return false; }
+            DiscoverLegsLocked();
+            bool applied = false;
+            foreach (string cell in _pendingCells.ToList())
+            {
+                int bar = cell.IndexOf('|', StringComparison.Ordinal);
+                if (bar <= 0) { _pendingCells.Remove(cell); continue; }
+                if (!_legIndex.ContainsKey(cell)) continue;   // still not there; try again next round
+                ApplyCellLocked(cell[..bar], cell[(bar + 1)..]);
+                applied = true;
+            }
+            _cellRounds++;
+            // The gap is a distance between rounds; the wait counts the
+            // sweeps skipped in between, which is one fewer.
+            _cellWait = Math.Max(0, CellRoundGap(_cellRounds) - 1);
+            return applied;
         }
     }
 
@@ -1790,6 +1913,8 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         _virtualMicModules.Clear();
         _renamedSinceBuild = false;
         _legIndex.Clear();
+        _pendingCells.Clear();
+        _cellRounds = _cellWait = 0;
         _streams.Clear();
         _cells.Clear();
         _levels.Clear();

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -33,6 +33,16 @@ internal sealed class NativePluginHost : IDisposable
             catch (InvalidOperationException) { return false; }
         }
     }
+    /// <summary>
+    /// The instance is worth keeping. The helper's beat says its audio is
+    /// moving, not merely that its process is alive: it stops beating when
+    /// the plugin has been inside one process callback for several seconds,
+    /// because an instance that is neither dead nor processing would
+    /// otherwise sit in the chain passing nothing. A node with no callback
+    /// outstanding, idle or suspended, keeps beating. The chain healing in
+    /// the sweep reads this and replaces the process, with the restart
+    /// policy's backoff behind it.
+    /// </summary>
     public bool IsHealthy => IsRunning
         && Stopwatch.GetElapsedTime(Interlocked.Read(ref _lastHeartbeat)) < _patience;
 
@@ -193,12 +203,53 @@ internal sealed class NativePluginHost : IDisposable
         }
     }
 
+    /// <summary>How much of a line the helper writes to stderr is kept, and all that is ever held.</summary>
+    private const int ErrorLineCap = 2048;
+
+    /// <summary>
+    /// Fold one block of helper output into the line being assembled and
+    /// return the last complete line in it, or null when the block held no
+    /// newline. <paramref name="line"/> never grows past
+    /// <see cref="ErrorLineCap"/> characters, whatever the block contains:
+    /// everything past that is dropped where it arrives, so a plugin writing
+    /// without newlines cannot make the daemon hold its output.
+    /// </summary>
+    internal static string? FoldErrorBlock(System.Text.StringBuilder line, ReadOnlySpan<char> block)
+    {
+        string? complete = null;
+        foreach (char c in block)
+        {
+            if (c != '\n')
+            {
+                if (line.Length < ErrorLineCap) line.Append(c);
+                continue;
+            }
+            complete = line.ToString().TrimEnd('\r');
+            line.Clear();
+        }
+        return complete;
+    }
+
+    /// <summary>
+    /// Drain the helper's stderr without letting a plugin decide how much
+    /// memory the daemon uses. ReadLineAsync buffers a whole line before it
+    /// hands one over, so a plugin that logs through the helper and never
+    /// writes a newline would grow that buffer without a limit, while its
+    /// heartbeats keep the process looking healthy. Reading in blocks keeps
+    /// the drain going, so the helper never blocks on a full pipe, and holds
+    /// only the bounded head of the line in hand.
+    /// </summary>
     private async Task ReadErrorsAsync()
     {
+        var block = new char[1024];
+        var line = new System.Text.StringBuilder(ErrorLineCap);
         try
         {
-            while (await Process.StandardError.ReadLineAsync(_stop.Token).ConfigureAwait(false) is string line)
-                _error = line.Length > 2048 ? line[..2048] : line;
+            int read;
+            while ((read = await Process.StandardError.ReadAsync(block.AsMemory(), _stop.Token).ConfigureAwait(false)) > 0)
+                if (FoldErrorBlock(line, block.AsSpan(0, read)) is string complete) _error = complete;
+            // A helper that dies mid-sentence still gets to explain itself.
+            if (line.Length > 0) _error = line.ToString();
         }
         catch (Exception ex) when (ex is OperationCanceledException or IOException) { }
     }

--- a/src/OpenXLR.Core/Mixing/PluginCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/PluginCatalog.cs
@@ -39,7 +39,8 @@ public static class PluginCatalog
     /// <summary>
     /// Read every source again, for plugins installed since. What was
     /// learnt about a bundle that did not change comes from the scan cache,
-    /// so only new bundles cost a scan. Blocks until the new list is ready.
+    /// so only new bundles cost a scan, and every bundle once after the
+    /// native helper itself changes. Blocks until the new list is ready.
     ///
     /// The old catalogue is dropped first and the heap swept before the new
     /// one is built: the daemon runs under a firm heap limit, and holding

--- a/src/OpenXLR.Core/Mixing/PluginInstaller.cs
+++ b/src/OpenXLR.Core/Mixing/PluginInstaller.cs
@@ -270,21 +270,50 @@ public sealed class PluginInstaller
             destinations.Add(destination);
             return;
         }
+        // Replacing a plugin must not be able to lose the working one. The new
+        // copy is built beside the destination under a name nothing looks at,
+        // the installed bundle is moved aside only once that copy is complete,
+        // and the swap is two renames inside one directory. A failure anywhere
+        // puts the old bundle back and leaves nothing half-written behind: an
+        // unreadable file or a full disk costs the update, not the plugin.
+        string staged = destination + ".openxlr-new";
+        string retired = destination + ".openxlr-old";
         try
         {
             Directory.CreateDirectory(directory);
-            if (Directory.Exists(destination)) Directory.Delete(destination, recursive: true);
-            else if (File.Exists(destination)) File.Delete(destination);
-            if (Directory.Exists(source)) CopyTree(source, destination);
-            else File.Copy(source, destination);
+            Remove(staged);
+            Remove(retired);
+            if (Directory.Exists(source)) CopyTree(source, staged);
+            else File.Copy(source, staged);
+            bool replacing = Directory.Exists(destination) || File.Exists(destination);
+            if (replacing) Move(destination, retired);
+            try { Move(staged, destination); }
+            catch { if (replacing) Move(retired, destination); throw; }
+            // The new bundle is in place; the old one is only litter now.
+            try { Remove(retired); } catch (Exception) { /* removed on the next install */ }
             installed.Add(name);
             destinations.Add(destination);
             notes.Add($"Installed {name} in {Shorten(directory)}.");
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            try { Remove(staged); } catch (Exception) { /* the note already says the install failed */ }
             notes.Add($"Could not copy {name} to {Shorten(directory)}: {ex.Message}");
         }
+    }
+
+    /// <summary>Delete a path whether it is a bundle directory or a single file.</summary>
+    private static void Remove(string path)
+    {
+        if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+        else if (File.Exists(path)) File.Delete(path);
+    }
+
+    /// <summary>Rename within one directory, for either kind of bundle.</summary>
+    private static void Move(string from, string to)
+    {
+        if (Directory.Exists(from)) Directory.Move(from, to);
+        else File.Move(from, to, overwrite: true);
     }
 
     private static void CopyTree(string source, string destination)

--- a/src/OpenXLR.Core/Mixing/ScanCache.cs
+++ b/src/OpenXLR.Core/Mixing/ScanCache.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -8,26 +9,48 @@ namespace OpenXLR.Core.Mixing;
 /// What the native host said about each bundle, kept between daemon runs.
 /// Describing a module means creating every plugin in it, and one with two
 /// hundred takes a quarter of a minute, which is too long to spend at every
-/// start. A bundle is read again only when its file changes.
+/// start. A bundle is read again only when it changes, or when the helper
+/// that reads it does.
 ///
 /// One module's description can run to megabytes, and the daemon lives
 /// under a firm heap limit, so the descriptions stay as bytes in a file
 /// each; only a small index of stamps is ever held whole.
+///
+/// A description is also only what one helper had to say, so each entry
+/// records which helper wrote it. When the helper changes it may describe
+/// the same bundle differently, and without this an updated OpenXLR would
+/// keep answering from what the old one learnt about every plugin already
+/// installed, for as long as those bundles sat untouched.
 /// </summary>
 public sealed class ScanCache
 {
-    /// <summary>One bundle as it was when scanned, and where its description is.</summary>
-    public sealed record Entry(long Modified, long Size, string File);
+    /// <summary>One bundle as it was when scanned, where its description is, and what wrote it.</summary>
+    public sealed record Entry(long Modified, long Size, string File, string? Scanner = null);
 
     private readonly string _directory;
+    private readonly string _scanner;
     private readonly Dictionary<string, Entry> _index;
     private bool _dirty;
 
-    public ScanCache(string directory)
+    public ScanCache(string directory, string? scanner = null)
     {
         _directory = directory;
+        _scanner = string.IsNullOrEmpty(scanner) ? ScannerStamp : scanner;
         _index = Load(Path.Combine(directory, "index.json"));
     }
+
+    /// <summary>
+    /// The helper that does the scanning, as its file on disk: an OpenXLR
+    /// that ships a new one asks it about every bundle again. Entries
+    /// written before this was recorded carry no stamp and match nothing,
+    /// so each of them costs one scan and is then kept as usual.
+    /// </summary>
+    public static string ScannerStamp => StampText(NativePluginHost.Executable);
+
+    /// <summary>One file's stamp as a word, or "none" where there is no such file.</summary>
+    internal static string StampText(string path) => Stamp(path) is (long modified, long size)
+        ? size.ToString(CultureInfo.InvariantCulture) + "-" + modified.ToString(CultureInfo.InvariantCulture)
+        : "none";
 
     /// <summary>Where the daemon keeps it: under the user's cache directory.</summary>
     public static string DefaultDirectory
@@ -41,10 +64,11 @@ public sealed class ScanCache
         }
     }
 
-    /// <summary>The description of a bundle that has not changed since, or null.</summary>
+    /// <summary>The description of a bundle that has not changed since, read by this same helper, or null.</summary>
     public byte[]? Lookup(string bundle)
     {
-        if (!_index.TryGetValue(bundle, out Entry? entry) || Stamp(bundle) is not (long modified, long size)
+        if (!_index.TryGetValue(bundle, out Entry? entry) || !string.Equals(entry.Scanner, _scanner, StringComparison.Ordinal)
+            || Stamp(bundle) is not (long modified, long size)
             || entry.Modified != modified || entry.Size != size)
             return null;
         try { return File.ReadAllBytes(Path.Combine(_directory, entry.File)); }
@@ -64,7 +88,7 @@ public sealed class ScanCache
             File.Move(temporary, Path.Combine(_directory, file), overwrite: true);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return; }
-        _index[bundle] = new Entry(modified, size, file);
+        _index[bundle] = new Entry(modified, size, file, _scanner);
         _dirty = true;
     }
 

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -22,7 +22,6 @@ public sealed class MixerService : IHostedService, IDisposable
     private volatile bool _checkingProgress;
     internal bool IsResponsive(TimeSpan limit) => !_checkingProgress || _progress.IsRecent(limit);
     private Timer? _streamSweep;
-    private Timer? _saveDebounce;
     private Timer? _meterPush;
     // The default-device defense after a build: stored and cancellable, so a
     // stop never leaves a pass behind that would override a default the
@@ -43,6 +42,13 @@ public sealed class MixerService : IHostedService, IDisposable
     private readonly IHostApplicationLifetime? _lifetime;
     private int _graphMissing;
 
+    /// <summary>
+    /// The debounced writer for the mixer settings. It stops writing as soon
+    /// as the graph is on its way out, so nothing can export a torn-down
+    /// mixer over the user's file.
+    /// </summary>
+    private readonly SettingsSaver _saves;
+
     public MixerService(ILogger<MixerService> log, IConfiguration config, DeviceManager devices,
         IHostApplicationLifetime? lifetime = null)
     {
@@ -51,6 +57,14 @@ public sealed class MixerService : IHostedService, IDisposable
         _devices = devices;
         _lifetime = lifetime;
         _mixer = new(new PipeWireAdapter(_progress.Mark));
+        _saves = new SettingsSaver(
+            () => _mixer.ExportSettings().Save(),
+            error =>
+            {
+                if (error is null) _log.LogInformation("mixer settings saved again");
+                else _log.LogWarning("mixer settings not saved: {err}; retrying", error);
+            },
+            () => Changed?.Invoke());
     }
 
     /// <summary>
@@ -66,11 +80,9 @@ public sealed class MixerService : IHostedService, IDisposable
         if (_mixer.GraphPresent() is not false) { _graphMissing = 0; return false; }
         if (++_graphMissing < 2) return false;
         _log.LogWarning("the submixer graph is gone (pipewire-pulse restarted?); restarting the daemon to rebuild it");
-        lock (_saveGate)
-        {
-            if (_saveDirty && _mixer.ExportSettings().Save() is string err) _log.LogWarning("settings not saved before the restart: {err}", err);
-            _saveDirty = false;
-        }
+        // ForgetGraph empties the mixer, so this is the last chance to write
+        // and the end of writing, exactly as at a clean stop.
+        if (_saves.Close(write: _saves.Pending) is string err) _log.LogWarning("settings not saved before the restart: {err}", err);
         _mixer.ForgetGraph();
         RestartRequest.Ask(RestartRequest.TemporaryFailure);
         _lifetime?.StopApplication();
@@ -243,6 +255,10 @@ public sealed class MixerService : IHostedService, IDisposable
                         ScheduleSave();
                         Changed?.Invoke();
                     }
+                    // A combine leg that appeared after its cell was applied
+                    // sits at PipeWire's defaults, full level and unmuted,
+                    // until the stored fader is pushed onto it.
+                    _mixer.EnsureCellLevels();
                     if (_mixer.SyncStreams() | _mixer.SyncDeviceVolumes() | _mixer.EnforceDefaults()
                         | _mixer.EnsureInputFeeds() | _mixer.EnsureAuxRoute()
                         | _mixer.EnsureFilterRoutes()
@@ -334,10 +350,15 @@ public sealed class MixerService : IHostedService, IDisposable
         catch (Exception ex) when (ex is TimeoutException or OperationCanceledException) { _log.LogWarning("default defense did not stop in time"); }
         if (_mixer.Built)
         {
-            if (_mixer.ExportSettings().Save() is string stopErr) _log.LogWarning("settings not saved at stop: {err}", stopErr);
+            // The final save and the end of saving are one step. Tearing the
+            // graph down empties the levels, mutes and monitor routing, so a
+            // debounced save still pending here, or the flush in Dispose,
+            // would write that empty state over the user's settings.
+            if (_saves.Close(write: true) is string stopErr) _log.LogWarning("settings not saved at stop: {err}", stopErr);
             _mixer.TearDown();
             _log.LogInformation("submix graph torn down");
         }
+        else _saves.Close(write: false);
     }
 
     /// <summary>Apply a mixer command. Returns null on success, else an error.</summary>
@@ -360,7 +381,7 @@ public sealed class MixerService : IHostedService, IDisposable
                     // Layout commands save synchronously, under the same gate
                     // as the debounced fader saves, and succeed only once the
                     // new layout is on disk.
-                    lock (_saveGate)
+                    _saves.RunSaved(() =>
                     {
                         Func<MixerSettings, string?> save = settings => settings.Save();
                         switch (cmd.Cmd)
@@ -373,11 +394,7 @@ public sealed class MixerService : IHostedService, IDisposable
                             case "deleteMix": _mixer.DeleteVirtualMix(cmd.Mix!, save); break;
                             default: _mixer.SetLayoutOrder(cmd.Channels!, cmd.Mixes!, save); break;
                         }
-                        _saveDirty = false;
-                        _lastSaveError = null;
-                        _retryDelay = SaveDelay;
-                        _saveDebounce?.Change(Timeout.Infinite, Timeout.Infinite);
-                    }
+                    });
                     Changed?.Invoke();
                     return null;
                 case "setLevel":
@@ -490,16 +507,11 @@ public sealed class MixerService : IHostedService, IDisposable
         return null;
     }
 
-    /// <summary>
-    /// Persist a moment after the last change, so dragging a fader writes once
-    /// instead of on every pixel of travel.
-    /// </summary>
-    private readonly object _saveGate = new();
-    private bool _saveDirty;
-    private static readonly TimeSpan SaveDelay = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(60);
-    private TimeSpan _retryDelay = SaveDelay;
-    private string? _lastSaveError;
+    private int _sweepCount;
+    private string? _resourceWarning;
+
+    /// <summary>pipewire-pulse close to its open-file limit, or null.</summary>
+    public string? ResourceWarning => Volatile.Read(ref _resourceWarning);
 
     /// <summary>
     /// Why the mixer settings are not on disk, or null while they are. A
@@ -508,70 +520,15 @@ public sealed class MixerService : IHostedService, IDisposable
     /// state so the user knows the window's changes would not survive a
     /// restart yet.
     /// </summary>
-    private int _sweepCount;
-    private string? _resourceWarning;
-
-    /// <summary>pipewire-pulse close to its open-file limit, or null.</summary>
-    public string? ResourceWarning => Volatile.Read(ref _resourceWarning);
-
     public string? PersistenceWarning
-    {
-        get { lock (_saveGate) return _lastSaveError is null ? null : $"Mixer settings are not being saved ({_lastSaveError}); retrying."; }
-    }
+        => _saves.Error is string err ? $"Mixer settings are not being saved ({err}); retrying." : null;
 
-    private void ScheduleSave()
-    {
-        lock (_saveGate)
-        {
-            _saveDirty = true;
-            _saveDebounce ??= new Timer(_ => SaveNow(), null, Timeout.Infinite, Timeout.Infinite);
-            _saveDebounce.Change(SaveDelay, Timeout.InfiniteTimeSpan);
-        }
-    }
-
-    // One writer at a time, and only when something changed since the last
-    // write; Dispose flushes a pending save so a change made just before
-    // shutdown is not lost. A failed write stays dirty and is retried with
-    // backoff; the failure is logged once per distinct reason and shown to
-    // clients until a write succeeds.
-    private void SaveNow()
-    {
-        bool changed = false;
-        lock (_saveGate)
-        {
-            if (!_saveDirty) return;
-            string? err = _mixer.ExportSettings().Save();
-            if (err is null)
-            {
-                _saveDirty = false;
-                _retryDelay = SaveDelay;
-                if (_lastSaveError is not null)
-                {
-                    _log.LogInformation("mixer settings saved again");
-                    _lastSaveError = null;
-                    changed = true;
-                }
-            }
-            else
-            {
-                if (err != _lastSaveError)
-                {
-                    _log.LogWarning("mixer settings not saved: {err}; retrying", err);
-                    _lastSaveError = err;
-                    changed = true;
-                }
-                _retryDelay = TimeSpan.FromTicks(Math.Min(_retryDelay.Ticks * 2, MaxRetryDelay.Ticks));
-                _saveDebounce?.Change(_retryDelay, Timeout.InfiniteTimeSpan);
-            }
-        }
-        if (changed) Changed?.Invoke();
-    }
+    private void ScheduleSave() => _saves.Schedule();
 
     public void Dispose()
     {
         _streamSweep?.Dispose();
-        _saveDebounce?.Dispose();
         _meterPush?.Dispose();
-        SaveNow();
+        _saves.Dispose();
     }
 }

--- a/src/OpenXLR.Daemon/SettingsSaver.cs
+++ b/src/OpenXLR.Daemon/SettingsSaver.cs
@@ -1,0 +1,132 @@
+namespace OpenXLR.Daemon;
+
+/// <summary>
+/// The mixer settings writer, debounced. It persists a moment after the last
+/// change, so dragging a fader writes once instead of on every pixel of
+/// travel. A failed write (a full disk, a read-only home) stays pending and
+/// is retried with backoff, and the reason is reported once per distinct
+/// message so clients can say the change would not survive a restart.
+///
+/// The last rule is the important one at shutdown: once <see cref="Close"/>
+/// has run, no later write may happen. The graph is torn down right after the
+/// final save, and a torn-down mixer exports empty levels, mutes and monitor
+/// routing, so a debounced tick still in flight, or the flush in Dispose,
+/// would otherwise replace the user's settings with that empty state.
+/// </summary>
+internal sealed class SettingsSaver : IDisposable
+{
+    public static readonly TimeSpan SaveDelay = TimeSpan.FromSeconds(2);
+    public static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(60);
+
+    private readonly object _gate = new();
+    private readonly Func<string?> _write;   // export and save; null on success, else the reason
+    private readonly Action<string?> _report;
+    private readonly Action? _changed;
+    private Timer? _debounce;
+    private bool _dirty;
+    private bool _closed;
+    private TimeSpan _retry = SaveDelay;
+    private string? _error;
+
+    /// <param name="write">Export the current settings and save them; null on success.</param>
+    /// <param name="report">Called when the failure reason changes, outside the gate.</param>
+    /// <param name="changed">Called when clients should see the new failure state, outside the gate.</param>
+    public SettingsSaver(Func<string?> write, Action<string?> report, Action? changed = null)
+    {
+        _write = write;
+        _report = report;
+        _changed = changed;
+    }
+
+    /// <summary>Why the settings are not on disk, or null while they are.</summary>
+    public string? Error { get { lock (_gate) return _error; } }
+
+    /// <summary>Whether a change is waiting to be written.</summary>
+    public bool Pending { get { lock (_gate) return _dirty; } }
+
+    /// <summary>Whether the writer is closed and will not write again.</summary>
+    public bool Closed { get { lock (_gate) return _closed; } }
+
+    /// <summary>Note a change and start the debounce.</summary>
+    public void Schedule()
+    {
+        lock (_gate)
+        {
+            if (_closed) return;
+            _dirty = true;
+            _debounce ??= new Timer(_ => Flush(), null, Timeout.Infinite, Timeout.Infinite);
+            _debounce.Change(SaveDelay, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    /// <summary>
+    /// Run a change that writes the settings itself (the layout commands save
+    /// under this gate and succeed only once the file is there), then treat
+    /// the settings as written: nothing is pending and the debounce is off.
+    /// The change runs under the gate, so no debounced write can interleave.
+    /// </summary>
+    public void RunSaved(Action change)
+    {
+        ArgumentNullException.ThrowIfNull(change);
+        bool cleared = false;
+        lock (_gate)
+        {
+            change();
+            _dirty = false;
+            _retry = SaveDelay;
+            _debounce?.Change(Timeout.Infinite, Timeout.Infinite);
+            if (_error is not null) { _error = null; cleared = true; }
+        }
+        if (cleared) _changed?.Invoke();
+    }
+
+    /// <summary>Write a pending change now. Called by the debounce and by Dispose.</summary>
+    public void Flush()
+    {
+        bool changed = false;
+        lock (_gate)
+        {
+            if (_closed || !_dirty) return;
+            string? error = _write();
+            if (error is null)
+            {
+                _dirty = false;
+                _retry = SaveDelay;
+                if (_error is not null) { _report(null); _error = null; changed = true; }
+            }
+            else
+            {
+                if (error != _error) { _report(error); _error = error; changed = true; }
+                _retry = TimeSpan.FromTicks(Math.Min(_retry.Ticks * 2, MaxRetryDelay.Ticks));
+                _debounce?.Change(_retry, Timeout.InfiniteTimeSpan);
+            }
+        }
+        if (changed) _changed?.Invoke();
+    }
+
+    /// <summary>
+    /// The final write, and the end of writing. The debounce is stopped first
+    /// so no tick can run against a mixer that is about to be torn down, the
+    /// pending change is written while the graph is still up, and every later
+    /// call is refused. Returns the reason the last write failed, or null.
+    /// </summary>
+    public string? Close(bool write)
+    {
+        lock (_gate)
+        {
+            _debounce?.Change(Timeout.Infinite, Timeout.Infinite);
+            string? error = write && !_closed ? _write() : null;
+            _dirty = false;
+            _closed = true;
+            return error;
+        }
+    }
+
+    public void Dispose()
+    {
+        Timer? debounce;
+        lock (_gate) debounce = _debounce;
+        debounce?.Dispose();
+        Flush();
+    }
+}

--- a/src/OpenXLR.Daemon/SocketGuard.cs
+++ b/src/OpenXLR.Daemon/SocketGuard.cs
@@ -30,8 +30,24 @@ internal static class SocketGuard
     public static async Task<(Outcome Outcome, byte[]? Message)> ReceiveMessageAsync(
         WebSocket socket, byte[] buf, int maxBytes, TimeSpan messageDeadline, CancellationToken stopping)
     {
+        // One clock for the whole message, not one per fragment. A timer and a
+        // cancellation registration per fragment would let a peer that sends
+        // many small (or empty, which the byte count cannot see) continuation
+        // frames pile both up until the deadline passed, on every connection
+        // at once. Cancelling it on the way out releases the timer at once,
+        // rather than leaving it armed until the deadline it never needed.
+        using var clock = CancellationTokenSource.CreateLinkedTokenSource(stopping);
+        try { return await ReceiveMessageAsync(socket, buf, maxBytes, messageDeadline, stopping, clock.Token); }
+        finally { clock.Cancel(); }
+    }
+
+    private static async Task<(Outcome Outcome, byte[]? Message)> ReceiveMessageAsync(
+        WebSocket socket, byte[] buf, int maxBytes, TimeSpan messageDeadline, CancellationToken stopping,
+        CancellationToken clock)
+    {
         using var ms = new MemoryStream();
-        long? due = null;   // monotonic ms, set by the first fragment of a multi-frame message
+        Task? expired = null;   // started by the first fragment of a multi-frame message
+        int fragments = 0;
         WebSocketReceiveResult res;
         do
         {
@@ -39,13 +55,12 @@ internal static class SocketGuard
             try
             {
                 recv = socket.ReceiveAsync(buf, stopping);
-                if (due is long d)
+                if (expired is not null)
                 {
                     // Cancelling a pending receive would abort the socket
                     // without a word to the peer, so race it with the clock
                     // and close properly when the clock wins.
-                    TimeSpan left = TimeSpan.FromMilliseconds(d - Environment.TickCount64);
-                    if (left <= TimeSpan.Zero || await Task.WhenAny(recv, Task.Delay(left, stopping)) != recv)
+                    if (expired.IsCompleted || await Task.WhenAny(recv, expired) != recv)
                     {
                         if (stopping.IsCancellationRequested)
                         {
@@ -74,15 +89,21 @@ internal static class SocketGuard
                 await CloseAsync(socket, WebSocketCloseStatus.InvalidMessageType, "text messages only");
                 return (Outcome.NotText, null);
             }
-            if (ms.Length + res.Count > maxBytes)
+            // An empty continuation frame carries no bytes, so the size limit
+            // cannot see it. Count the frames as well, or a peer could hold a
+            // handler and a connection slot busy with nothing at all until the
+            // deadline. One frame per byte of the limit is far more than any
+            // real client sends and still bounds the loop.
+            if (ms.Length + res.Count > maxBytes || ++fragments > maxBytes)
             {
                 await CloseAsync(socket, WebSocketCloseStatus.MessageTooBig, $"command exceeds {maxBytes} bytes");
                 return (Outcome.TooBig, null);
             }
             ms.Write(buf, 0, res.Count);
             // The clock starts with the first fragment, so a quiet client
-            // between commands is never on it.
-            if (due is null && !res.EndOfMessage) due = Environment.TickCount64 + (long)messageDeadline.TotalMilliseconds;
+            // between commands is never on it, and it runs once for the whole
+            // message rather than once per fragment.
+            if (expired is null && !res.EndOfMessage) expired = Task.Delay(messageDeadline, clock);
         } while (!res.EndOfMessage);
         return (Outcome.Message, ms.ToArray());
     }

--- a/src/OpenXLR.Tests/ClapCatalogTests.cs
+++ b/src/OpenXLR.Tests/ClapCatalogTests.cs
@@ -20,6 +20,52 @@ public sealed class ClapCatalogTests
         ]}
         """;
 
+    // A bundle whose plugins the helper would refuse to load. Both are real
+    // LSP layouts: a mixer declares more input buses than the host carries,
+    // a crossover more output buses.
+    private const string RefusedScan = """
+        {"file":"/usr/lib/clap/lsp-plugins.clap","plugins":[
+          {"id":"in.lsp-plug.mixer_x8_mono","name":"Mixer x8 Mono","vendor":"LSP",
+           "features":["audio-effect","mono"],"audioIns":0,"audioOuts":1,"gui":true,
+           "layoutRefused":"the plugin declares 9 audio input ports; this host carries 1 to 8","params":[]},
+          {"id":"in.lsp-plug.crossover_stereo","name":"Crossover Stereo","vendor":"LSP",
+           "features":["audio-effect","stereo"],"audioIns":2,"audioOuts":0,"gui":true,
+           "layoutRefused":"the plugin declares 9 audio output ports; this host carries 1 to 8","params":[]},
+          {"id":"in.lsp-plug.comp_stereo","name":"Compressor Stereo","vendor":"LSP",
+           "features":["audio-effect","stereo"],"audioIns":2,"audioOuts":2,"gui":true,"params":[]}
+        ]}
+        """;
+
+    [Fact]
+    public void APortLayoutTheHostWouldRefuseKeepsThePluginOutOfThePicker()
+    {
+        // The helper refuses a layout it cannot hand a buffer for, and says
+        // so in the scan. The catalogue carries that through as an
+        // unsupported feature, so the picker never offers a plugin that would
+        // then be turned away, and the reason is the loader's own words.
+        IReadOnlyList<PluginInfo> found = ClapCatalog.Parse(RefusedScan);
+        Assert.Equal(3, found.Count);
+
+        Assert.False(found[0].Supported);
+        Assert.Equal(["the plugin declares 9 audio input ports; this host carries 1 to 8"],
+            found[0].UnsupportedFeatures);
+        Assert.False(found[1].Supported);
+        Assert.Equal(["the plugin declares 9 audio output ports; this host carries 1 to 8"],
+            found[1].UnsupportedFeatures);
+
+        // Both directions are still described. A refusal in one used to leave
+        // the other reading uninitialised stack in the helper, which reached
+        // the catalogue as a nonsense width.
+        Assert.Equal((0, 1), (found[0].AudioIns, found[0].AudioOuts));
+        Assert.Equal((2, 0), (found[1].AudioIns, found[1].AudioOuts));
+
+        // A plugin from the same bundle with a layout the host carries is
+        // offered as usual.
+        Assert.True(found[2].Supported);
+        Assert.Empty(found[2].UnsupportedFeatures);
+        Assert.Equal((2, 2), (found[2].AudioIns, found[2].AudioOuts));
+    }
+
     [Fact]
     public void TheScannersJsonBecomesPluginsThePickerCanOffer()
     {
@@ -193,6 +239,70 @@ public sealed class ClapCatalogTests
             later.Save();
             Assert.DoesNotContain("Thing.vst3", File.ReadAllText(Path.Combine(cacheDir, "index.json")));
             Assert.Single(Directory.GetFiles(cacheDir));   // only the index is left
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void AScanIsReadAgainWhenTheHelperThatWroteItChanged()
+    {
+        string dir = Directory.CreateTempSubdirectory("openxlr-scan-scanner-").FullName;
+        try
+        {
+            string bundle = Path.Combine(dir, "Thing.clap");
+            File.WriteAllText(bundle, "not really");
+            string cacheDir = Path.Combine(dir, "cache", "plugin-scans");
+            string index = Path.Combine(cacheDir, "index.json");
+            byte[] description = System.Text.Encoding.UTF8.GetBytes("{\"file\":\"x\",\"plugins\":[]}");
+
+            var first = new ScanCache(cacheDir, "helper-one");
+            first.Store(bundle, description);
+            first.Save();
+
+            // The same helper answers from the cache; another one does not,
+            // however untouched the bundle is.
+            Assert.Equal(description, new ScanCache(cacheDir, "helper-one").Lookup(bundle));
+            Assert.Null(new ScanCache(cacheDir, "helper-two").Lookup(bundle));
+
+            // What the daemon uses when it is not told: the helper's own file,
+            // which says something else as soon as another one is installed.
+            Assert.Equal(ScanCache.StampText(NativePluginHost.Executable), ScanCache.ScannerStamp);
+            string helper = Path.Combine(dir, "openxlr-lv2-host");
+            Assert.Equal("none", ScanCache.StampText(helper));
+            File.WriteAllText(helper, "one helper");
+            string oneHelper = ScanCache.StampText(helper);
+            File.WriteAllText(helper, "a helper that is longer");
+            Assert.NotEqual(oneHelper, ScanCache.StampText(helper));
+
+            Assert.Null(new ScanCache(cacheDir).Lookup(bundle));
+            var stamped = new ScanCache(cacheDir);
+            stamped.Store(bundle, description);
+            stamped.Save();
+            Assert.Equal(description, new ScanCache(cacheDir).Lookup(bundle));
+            Assert.Equal(description, new ScanCache(cacheDir, ScanCache.ScannerStamp).Lookup(bundle));
+
+            // An index written before any of this was recorded: one scan each,
+            // and then it is kept like any other.
+            string written = File.ReadAllText(index);
+            Assert.Contains("\"scanner\":", written);
+            File.WriteAllText(index, System.Text.RegularExpressions.Regex.Replace(written, ",\"scanner\":\"[^\"]*\"", ""));
+            Assert.Null(new ScanCache(cacheDir, "helper-one").Lookup(bundle));
+            var rescanned = new ScanCache(cacheDir, "helper-one");
+            rescanned.Store(bundle, description);
+            rescanned.Save();
+            Assert.Equal(description, new ScanCache(cacheDir, "helper-one").Lookup(bundle));
+
+            // The bridge keeps its own index beside it, and neither reaches
+            // into the other, with or without a helper of the same name.
+            string bridgeDir = Path.Combine(cacheDir, "bridge-ABC");
+            byte[] bridged = System.Text.Encoding.UTF8.GetBytes("{\"file\":\"y\",\"plugins\":[]}");
+            Assert.Null(new ScanCache(bridgeDir, "helper-one").Lookup(bundle));
+            var bridge = new ScanCache(bridgeDir, "helper-one");
+            bridge.Store(bundle, bridged);
+            bridge.Save();
+            Assert.Equal(bridged, new ScanCache(bridgeDir, "helper-one").Lookup(bundle));
+            Assert.Null(new ScanCache(bridgeDir, "helper-two").Lookup(bundle));
+            Assert.Equal(description, new ScanCache(cacheDir, "helper-one").Lookup(bundle));
         }
         finally { Directory.Delete(dir, true); }
     }

--- a/src/OpenXLR.Tests/NativeHostProtocolTests.cs
+++ b/src/OpenXLR.Tests/NativeHostProtocolTests.cs
@@ -61,6 +61,76 @@ public sealed class NativeHostProtocolTests
     }
 
     [Fact]
+    public async Task AHelperThatStopsBeatingIsUnhealthyWhileItIsStillAlive()
+    {
+        // The helper stops beating once the plugin has been inside one audio
+        // callback for several seconds. It is still a live process with a
+        // turning editor loop, so nothing else would notice; this is what
+        // tells the chain healing in the sweep to replace it.
+        using var host = Start("""
+            import sys
+            print('ready')
+            print('heartbeat')
+            print('ui-heartbeat')
+            for line in sys.stdin:
+                pass
+            """, patience: TimeSpan.FromMilliseconds(500));
+
+        bool noticed = false;
+        for (int attempt = 0; attempt < 40 && !noticed; attempt++)
+        {
+            noticed = host.IsRunning && !host.IsHealthy;
+            if (!noticed) await Task.Delay(100);
+        }
+        Assert.True(noticed, "a live helper that stopped beating should read as unhealthy");
+    }
+
+    [Fact]
+    public async Task AStalledHostMakesItsChainStageReadAsDead()
+    {
+        // The step that turns a silent helper into a replaced one: the chain
+        // stage carrying it stops reading as alive, which is what the sweep's
+        // healing pass looks at. A stage whose helper is beating stays alive,
+        // so a working plugin is never rebuilt underneath the user.
+        using var beating = Start("""
+            import sys, threading, time
+            lock = threading.Lock()
+            def say(line):
+                with lock:
+                    sys.stdout.write(line + '\n')
+                    sys.stdout.flush()
+            say('ready')
+            def beat():
+                while True:
+                    say('heartbeat')
+                    time.sleep(0.05)
+            threading.Thread(target=beat, daemon=True).start()
+            for line in sys.stdin:
+                pass
+            """, patience: TimeSpan.FromMilliseconds(500));
+        using var stalled = Start("""
+            import sys
+            print('ready')
+            print('heartbeat')
+            for line in sys.stdin:
+                pass
+            """, patience: TimeSpan.FromMilliseconds(500));
+
+        var live = new FilterHandle("live", "sink", "source", beating.Process) { NativeHost = beating };
+        var stuck = new FilterHandle("stuck", "sink", "source", stalled.Process) { NativeHost = stalled };
+
+        bool noticed = false;
+        for (int attempt = 0; attempt < 40 && !noticed; attempt++)
+        {
+            noticed = !stuck.IsAlive;
+            if (!noticed) await Task.Delay(100);
+        }
+        Assert.True(noticed, "a stage whose helper stopped beating should read as dead");
+        Assert.True(stalled.IsRunning, "and it is a live process, which is what made this invisible before");
+        Assert.True(live.IsAlive, "a stage whose helper is still beating must not be rebuilt");
+    }
+
+    [Fact]
     public async Task AFrozenEditorLoopIsReportedWithoutCondemningTheAudio()
     {
         // The helper's two beats mean different things: one says the process

--- a/src/OpenXLR.Tests/PluginInstallerTests.cs
+++ b/src/OpenXLR.Tests/PluginInstallerTests.cs
@@ -129,6 +129,46 @@ public sealed class PluginInstallerTests : IDisposable
     }
 
     [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("linux")]   // file modes are a Unix matter; the daemon only runs there
+    public void AFailedReplacementLeavesTheInstalledPluginWhereItWas()
+    {
+        // The installed bundle used to be deleted before the new copy was
+        // made, so an unreadable download or a full disk cost the working
+        // plugin. The copy is built beside it now and the two are swapped
+        // only once it is complete.
+        if (Environment.IsPrivilegedProcess) return;   // root reads an unreadable directory anyway
+        PluginInstaller installer = Installer();
+        Assert.True(installer.Install(Lv2("gate.lv2")).Ok);
+        string installed = Path.Combine(_lv2, "gate.lv2");
+        Assert.True(File.Exists(Path.Combine(installed, "manifest.ttl")));
+
+        // A second copy of the same bundle, with a directory inside it that
+        // cannot be read: the copy fails part way through.
+        string broken = Path.Combine(_picked, "broken", "gate.lv2");
+        Directory.CreateDirectory(Path.Combine(broken, "presets"));
+        File.WriteAllText(Path.Combine(broken, "manifest.ttl"), "replacement");
+        File.SetUnixFileMode(Path.Combine(broken, "presets"), UnixFileMode.None);
+        try
+        {
+            InstallOutcome failed = installer.Install(broken);
+            Assert.False(failed.Ok);
+            Assert.Contains("Could not copy gate.lv2", failed.Message);
+        }
+        finally
+        {
+            File.SetUnixFileMode(Path.Combine(broken, "presets"),
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        // The plugin that was working is still there, still itself, and
+        // nothing half-copied was left beside it.
+        Assert.True(Directory.Exists(installed));
+        Assert.StartsWith("@prefix", File.ReadAllText(Path.Combine(installed, "manifest.ttl")));
+        Assert.True(File.Exists(Path.Combine(installed, "plugin.so")));
+        Assert.Equal(["gate.lv2"], Directory.GetDirectories(_lv2).Select(Path.GetFileName));
+    }
+
+    [Fact]
     public void ABundleAlreadyInPlaceIsOnlyRescanned()
     {
         Directory.CreateDirectory(_clap);

--- a/src/OpenXLR.Tests/PluginScanDiagnosticsTests.cs
+++ b/src/OpenXLR.Tests/PluginScanDiagnosticsTests.cs
@@ -67,6 +67,15 @@ public sealed class PluginScanDiagnosticsTests
             report = PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind);
             Assert.Equal(2, report.Entries.Count(e => e.Outcome == "ok" && e.Cached));
             Assert.Contains(report.Entries, e => e.Outcome == "invalid-description" && e.Cached);
+
+            // A cache filled by an older helper answers nothing: whatever the
+            // scanner has learnt since reaches bundles that never changed.
+            result = HostScan.Run(kind, "unused", [dir], _ => bundles, Describe,
+                new ScanCache(Path.Combine(dir, "cache"), "another-helper"));
+            Assert.Single(result);
+            Assert.Equal(4, goodCalls);
+            report = PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind);
+            Assert.DoesNotContain(report.Entries, e => e.Cached);
         }
         finally { Directory.Delete(dir, recursive: true); }
     }

--- a/src/OpenXLR.Tests/ReliabilityFixesTests.cs
+++ b/src/OpenXLR.Tests/ReliabilityFixesTests.cs
@@ -1,0 +1,294 @@
+using System.Diagnostics;
+using System.Net.WebSockets;
+using System.Text;
+using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
+
+namespace OpenXLR.Tests;
+
+/// <summary>
+/// Quiet failure modes in routing, settings and plugin hosting, each with
+/// the case that showed it. They are unrelated to each other; what they
+/// share is that every one of them was quiet, and would have stayed quiet
+/// until it cost a user their settings, their mutes, or the daemon.
+/// </summary>
+public sealed class ReliabilityFixesTests
+{
+    // --- recalling a profile that predates a channel or a mix -------------------
+
+    [Fact]
+    public void RecallingAnOlderProfileLeavesUnknownSendsMuted()
+    {
+        // The profile was saved when only "stream" existed. "podcast" was
+        // added afterwards, so every send into it sits at unity behind the
+        // mute a new mix starts with. Recalling the profile must not open it:
+        // that is the microphone into a mix the profile never knew about.
+        var muted = new HashSet<string> { "xlr1|podcast", "game|podcast", "xlr1|stream" };
+        string[] cells = ["xlr1|stream", "game|stream", "xlr1|podcast", "game|podcast"];
+        var savedLevels = new Dictionary<string, double> { ["xlr1|stream"] = 0.8, ["game|stream"] = 0.5 };
+
+        Mixer.RecallMutes(muted, cells, savedLevels.Keys, ["game|stream"]);
+
+        Assert.Contains("xlr1|podcast", muted);   // never named by the profile: left as it was
+        Assert.Contains("game|podcast", muted);
+        Assert.Contains("game|stream", muted);    // named and muted by the profile
+        Assert.DoesNotContain("xlr1|stream", muted);   // named by the profile, not in its mute list
+    }
+
+    [Fact]
+    public void RecallingAProfileStillSetsEverySendItNames()
+    {
+        // The safety rule must not turn into "mutes are never cleared". A
+        // send the profile carries a level for is set exactly as it says.
+        var muted = new HashSet<string> { "xlr1|stream", "game|stream" };
+        string[] cells = ["xlr1|stream", "game|stream"];
+        Mixer.RecallMutes(muted, cells, new[] { "xlr1|stream", "game|stream" }, ["game|stream"]);
+        Assert.Equal(["game|stream"], muted);
+
+        // A mix master works the same way: named, so it follows the profile.
+        var mixMuted = new HashSet<string> { "stream", "podcast" };
+        Mixer.RecallMutes(mixMuted, ["stream", "chat", "podcast"], new[] { "stream", "chat" }, []);
+        Assert.Equal(["podcast"], mixMuted);   // podcast is not in the profile, so its mute stays
+    }
+
+    // --- a combine leg that appears after its fader was pushed ------------------
+
+    /// <summary>The sweeps a reconciliation round falls on, over a run of sweeps.</summary>
+    private static List<int> ReconciliationRounds(int sweeps, Func<int, bool> applied)
+    {
+        var rounds = new List<int>();
+        for (int sweep = 0, wait = 0; sweep < sweeps; sweep++)
+        {
+            if (wait > 0) { wait--; continue; }
+            rounds.Add(sweep);
+            if (applied(sweep)) break;
+            wait = Math.Max(0, Mixer.CellRoundGap(rounds.Count) - 1);
+        }
+        return rounds;
+    }
+
+    [Fact]
+    public void AMissingSendIsRetriedPromptlyThenLessOftenButNeverGivenUp()
+    {
+        // A leg that is merely late is up within a sweep or two, so the first
+        // rounds run back to back. After that the gap doubles and settles at a
+        // minute, and there it stays: a send whose leg has not appeared is a
+        // send sitting at full level and unmuted, so giving up on it would
+        // leave it open for as long as the daemon runs.
+        var rounds = ReconciliationRounds(4000, _ => false);
+
+        Assert.Equal([0, 1, 2], rounds.Take(3));                     // three prompt rounds
+        Assert.Equal([2, 4, 8, 16, 32], rounds.Skip(3).Take(5).Select((s, i) => s - rounds[i + 2]));
+        Assert.All(rounds.Zip(rounds.Skip(1)), pair => Assert.True(pair.Second - pair.First <= 60,
+            "no two rounds should be more than a minute of sweeps apart"));
+        Assert.True(rounds[^1] > 3900, "rounds should still be running an hour of sweeps in");
+
+        // And the steady state stays cheap: a round a minute, not a round a
+        // second, for as long as the send is waiting.
+        Assert.InRange(rounds.Count, 8, 80);
+    }
+
+    [Fact]
+    public void ASendWhoseLegArrivesLateIsSetWhenItDoes()
+    {
+        // Well past where a twelve-round budget would have expired. The
+        // sweep has to still be looking, and has to catch it inside one
+        // steady-state gap.
+        const int legAppears = 900;
+        var rounds = ReconciliationRounds(4000, sweep => sweep >= legAppears);
+        Assert.InRange(rounds[^1], legAppears, legAppears + 60);
+    }
+
+    [Fact]
+    public void ASendWhoseChannelOrMixWasDeletedStopsBeingRetried()
+    {
+        // The other way a cell leaves the list: it no longer exists. A
+        // deleted channel or mix is not waiting for a leg, and its cells must
+        // not keep the sweep looking for one.
+        var pending = new HashSet<string> { "gone|stream", "xlr1|gone", "xlr1|stream" };
+        Mixer.ForgetRemovedCells(pending, new HashSet<string> { "xlr1|stream" });
+        Assert.Equal(["xlr1|stream"], pending);
+
+        Mixer.ForgetRemovedCells(pending, new HashSet<string>());
+        Assert.Empty(pending);   // nothing waiting, so the sweep stands down
+    }
+
+    // --- exporting settings while a plugin control moves ------------------------
+
+    [Fact]
+    public void AnExportedInsertDoesNotShareTheLiveParameterDictionary()
+    {
+        // Controls are written in place under the mixer's lock while the
+        // debounced save serializes the export outside it. Sharing the
+        // dictionary let a save enumerate one that gained a key mid-write,
+        // which throws inside a timer callback and ends the daemon.
+        var live = new Dictionary<string, List<InsertDefinition>>
+        {
+            ["xlr1"] = [new InsertDefinition { Id = "i1", Kind = "lv2", Plugin = "urn:test", Params = { ["gain"] = 0.5 } }],
+        };
+        var exported = Mixer.CopyInserts(live);
+
+        live["xlr1"][0].Params["threshold"] = 0.25;   // an editor edit during the save
+        live["xlr1"][0].Params["gain"] = 0.9;
+
+        Assert.Equal(0.5, exported["xlr1"][0].Params["gain"]);
+        Assert.DoesNotContain("threshold", exported["xlr1"][0].Params.Keys);
+        Assert.NotSame(live["xlr1"][0].Params, exported["xlr1"][0].Params);
+    }
+
+    // --- the last save before the graph goes ------------------------------------
+
+    [Fact]
+    public void NothingIsWrittenOnceTheWriterIsClosed()
+    {
+        // The graph is torn down right after the final save, and a torn-down
+        // mixer exports empty levels, mutes and monitor routing. A debounced
+        // tick still in flight, or the flush in Dispose, used to write that
+        // empty state over the user's settings.
+        var written = new List<string>();
+        string state = "the user's mixer";
+        var saver = new SettingsSaver(() => { written.Add(state); return null; }, _ => { });
+
+        saver.Schedule();
+        Assert.True(saver.Pending);
+        Assert.Null(saver.Close(write: true));
+        Assert.Equal(["the user's mixer"], written);
+        Assert.True(saver.Closed);
+        Assert.False(saver.Pending);
+
+        state = "";                 // the graph is gone; an export would be empty now
+        saver.Schedule();           // a change arriving during teardown
+        saver.Flush();              // the pending debounce tick
+        saver.Dispose();            // and the flush on the way out
+        Assert.Equal(["the user's mixer"], written);
+    }
+
+    [Fact]
+    public void APendingChangeIsStillWrittenAtTheLastMoment()
+    {
+        var written = new List<string>();
+        var saver = new SettingsSaver(() => { written.Add("settings"); return null; }, _ => { });
+        saver.Schedule();
+        saver.Close(write: true);
+        Assert.Equal(["settings"], written);
+    }
+
+    [Fact]
+    public void AFailedWriteStaysPendingAndIsReportedOnce()
+    {
+        var reported = new List<string?>();
+        string? failure = "read-only file system";
+        var saver = new SettingsSaver(() => failure, reported.Add, null);
+
+        saver.Schedule();
+        saver.Flush();
+        saver.Flush();
+        Assert.True(saver.Pending);
+        Assert.Equal("read-only file system", saver.Error);
+        Assert.Equal(["read-only file system"], reported);   // once per distinct reason
+
+        failure = null;
+        saver.Flush();
+        Assert.False(saver.Pending);
+        Assert.Null(saver.Error);
+        Assert.Equal(["read-only file system", null], reported);
+        saver.Dispose();
+    }
+
+    [Fact]
+    public void ALayoutCommandThatSavesItselfLeavesNothingPending()
+    {
+        var written = new List<string>();
+        var saver = new SettingsSaver(() => { written.Add("debounced"); return null; }, _ => { });
+        saver.Schedule();
+        saver.RunSaved(() => written.Add("layout"));
+        Assert.False(saver.Pending);
+        saver.Flush();
+        Assert.Equal(["layout"], written);   // the debounce was cancelled by the layout save
+        saver.Dispose();
+        Assert.Equal(["layout"], written);
+    }
+
+    // --- a helper that writes to stderr without newlines ------------------------
+
+    [Fact]
+    public void AHelperCannotMakeTheDaemonHoldItsOutput()
+    {
+        // ReadLineAsync buffers a whole line before it hands one over, so a
+        // plugin logging through the helper and never writing a newline grew
+        // that buffer without a limit while its heartbeats kept the process
+        // looking healthy.
+        var line = new StringBuilder();
+        var flood = new string('x', 4096);
+        for (int block = 0; block < 256; block++)
+            Assert.Null(NativePluginHost.FoldErrorBlock(line, flood));   // no newline, so no line yet
+        Assert.Equal(2048, line.Length);   // a megabyte in, and this is all that is held
+
+        Assert.Equal(new string('x', 2048), NativePluginHost.FoldErrorBlock(line, "\n"));
+        Assert.Equal(0, line.Length);
+    }
+
+    [Fact]
+    public void CompleteLinesStillArriveWholeAndTrimmed()
+    {
+        var line = new StringBuilder();
+        Assert.Equal("second", NativePluginHost.FoldErrorBlock(line, "first\r\nsecond\r\nthird"));
+        Assert.Equal("third", line.ToString());
+        Assert.Null(NativePluginHost.FoldErrorBlock(line, " part"));
+        Assert.Equal("third part", NativePluginHost.FoldErrorBlock(line, "\n"));
+    }
+
+    // --- retiring a meter while its pump thread starts up -----------------------
+
+    [Fact]
+    public void RetiringAMeterWhileItsPumpStartsDoesNotThrowOnItsThread()
+    {
+        // Add released the gate before the pump thread had taken the process's
+        // output stream, so a Remove in between could dispose the process
+        // first. Process.StandardOutput then throws ObjectDisposedException,
+        // on a raw background thread with no handler above it, which ends the
+        // daemon. Both streams are taken under the gate now, and a stream
+        // closed underneath fails inside the loops where it is caught. The
+        // original window is narrow (the pump thread usually runs before Add
+        // even returns), so this covers the lifecycle rather than reproducing
+        // the race: there is nothing to assert but the run itself, since an
+        // unhandled exception on those threads takes the test host with it.
+        using var meters = new MeterReader();
+        for (int i = 0; i < 50; i++)
+        {
+            var psi = new ProcessStartInfo("sleep") { RedirectStandardOutput = true, RedirectStandardError = true };
+            psi.ArgumentList.Add("30");
+            meters.Add($"m{i}", psi);
+            meters.Remove($"m{i}");
+        }
+        Thread.Sleep(200);   // give every pump and drain thread time to reach its first read
+        Assert.Empty(meters.Read());
+    }
+
+    // --- a peer that sends nothing, in many frames ------------------------------
+
+    [Fact]
+    public async Task AMessageThatArrivesInMoreFramesThanItsLimitIsRefused()
+    {
+        // An empty continuation frame carries no bytes, so the size limit
+        // cannot see it. Counting the frames bounds the loop, and the one
+        // deadline for the whole message replaces the timer and cancellation
+        // registration that used to be created per frame.
+        var served = new TaskCompletionSource<SocketGuard.Outcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            var result = await SocketGuard.ReceiveMessageAsync(socket, new byte[64], 16, TimeSpan.FromSeconds(5), stop);
+            served.TrySetResult(result.Outcome);
+        });
+        using var client = new ClientWebSocket();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        await client.ConnectAsync(new Uri(server.Url), cts.Token);
+        try
+        {
+            for (int frame = 0; frame < 64 && !served.Task.IsCompleted; frame++)
+                await client.SendAsync(ReadOnlyMemory<byte>.Empty, WebSocketMessageType.Text, endOfMessage: false, cts.Token);
+        }
+        catch (WebSocketException) { /* the server closed on us, which is the point */ }
+        Assert.Equal(SocketGuard.Outcome.TooBig, await served.Task.WaitAsync(cts.Token));
+    }
+}


### PR DESCRIPTION
## Summary

Accepted on hardware (Wave XLR Pro) on 2026-09-11; results at the end.

### Routing and settings

- Preserve the current mute state of sends and mix masters absent from an older profile instead of opening newer routes at unity.
- Reconcile late combine legs with saved levels and mutes. Pending cells use bounded backoff without a terminal retry cutoff, and disappear when their channel or mix is removed.
- Deep-copy insert parameter dictionaries when exporting settings and scenes so concurrent edits cannot invalidate serialization.
- Close the settings saver before mixer teardown so a pending debounce or disposal cannot overwrite the final snapshot with cleared state.
- Capture meter streams before starting their reader threads, avoiding process-disposal races at startup.

### Plugin safety and recovery

- Drain native plugin stderr with bounded buffering, including output without newlines.
- Stage plugin replacements beside the installed bundle, with rollback if copying or replacement fails.
- Supply CLAP plugins with their declared audio-bus arrays, silent spare inputs and discard outputs. Share bus-layout validation between scanning and loading so unsupported layouts are not offered as usable inserts.
- Reject oversized audio quanta before writing fixed-size fallback buffers.
- Detect a plugin stuck inside the same audio callback rather than treating independent helper heartbeats as proof of processing progress. Idle and suspended nodes remain healthy.

### Transport and regression coverage

- Use one fragment deadline per WebSocket message and cap fragment count instead of allocating a timer per fragment.
- Add managed reliability and native audio/CLAP regression tests, and run the new native suites in CI.
- Document profile recall, replacement safety and stalled-plugin recovery.

No version, API or layout-format changes.

## Automated verification

- Locked restore: passed.
- Release build with warnings as errors, both ordinary and native-host-enabled: 0 warnings, 0 errors.
- .NET tests: 387 passed, 0 failed, 2 skipped (the Xvfb-gated window tests, which pass when run under their env gates). Baseline on main is 368.
- Native clean build and tests: 26 passed (7 audio, 9 CLAP, 10 editor), 0 failed.
- CLAP layout harness: passed with AddressSanitizer and UndefinedBehaviorSanitizer.
- OpenDeck plugin tests: 5 passed. JavaScript syntax and manifest checks passed.
- Shellcheck, version agreement, locked packaging restores, OpenAPI and RPM checks: passed.

## Rebased onto main after 0.1.32

Rebased onto `0960f17` (the 0.1.32 release, #80 to #84). No conflicts; the only merged lines are the native test command in `ci.yml`, `CONTRIBUTING.md` and `AGENTS.md`, and disjoint manual sections. `SettingsSaver` (daemon settings) and the window's startup writers from #83 touch different files in different processes. The full check list was re-run on the rebased branch, including the two Xvfb-gated window tests. The tray test command was added to `CONTRIBUTING.md` and `AGENTS.md`, which listed only the layout one. #84 (saved inserts resolved against the full catalogue) landed during the acceptance setup and is in the base; `Mixer.cs`, `MixerService.cs` and the manual merged without conflict and the suite was re-run.

## Scan cache follows the scanner

The hardware pass showed the new CLAP refusals never reaching an existing install: scans are cached per bundle by size and mtime, so a bundle scanned before this change kept its old description and the picker still offered the layouts the helper refuses. A cache entry now records the helper that produced it (its size and mtime stamp), and an entry from another helper counts as absent, so the first start after a helper change rescans every bundle once. Legacy entries without the field are rescanned once and then reused; the yabridge bridge subdirectory keeps its own index. Tests cover reuse, another scanner, the legacy form and the bridge directory, and go red with the comparison removed.

## CI scanner correction

The first CI run caught an uninitialized output layout when input-layout validation short-circuited. The scanner now reads both directions unconditionally and retains the input-first refusal reason. A pattern-initialized build reproduced garbage output widths for four installed LSP mixers before the fix; afterward those entries carry their true output widths. Added native refusal-layout and managed catalogue-filtering checks. The fixed native tree also builds with `-O1 -Werror`, the local configuration that reproduced CI's diagnostic.

## Isolated acceptance completed

These checks used private PipeWire infrastructure with hardware monitors disabled, not the running microphone chain.

- Scanned the installed LSP CLAP bundle and verified unsupported bus layouts receive catalogue refusal reasons.
- Loaded the real LSP stereo sidechain compressor into the native helper.
- Under Xvfb, opened, resized, moved, hid and reopened its editor. Minimum-size clamping worked and helper heartbeats continued while the editor was hidden.
- Ran a test CLAP plugin that deliberately blocks inside processing. Native heartbeats stopped, managed health and chain liveness became false, the old helper was disposed, and a replacement helper was built and healthy through the real PipeWireAdapter path.
- The user's live daemon, audio services, existing plugin helpers and mixer settings remained unchanged. Isolated services and test processes were stopped afterward.

The recovery acceptance used a disposable harness, not a persistent automated full-app test. It verifies helper/adapter recovery, not the complete running daemon sweep and desktop workflow.

## Hardware acceptance (Wave XLR Pro, 2026-09-11)

Run on the desk with the daemon and window built from this branch, native host included, on the live chains (LSP Gate on XLR 1, Valhalla and TDR Nova through yabridge on Stream, Dragonfly on Monitor A).

- Editors on both bridged VST3 inserts: open, resize, move, close, reopen; audio clean throughout.
- Ten seconds of continuous parameter drags on TDR Nova while the daemon saved behind it: no restart, nothing logged; the values persisted.
- Profile recall with a virtual microphone added after the profile was saved: all nine sends into the new mix stayed closed, in the daemon and in PipeWire.
- After a graph build: 45 of 45 legs carried the saved levels and mutes, none missing or extra. After a channel rename both ways: all five reloaded legs correct.
- A level set just before `systemctl stop`: on disk after the stop, live after the start.
- LSP Sidechain Compressor Stereo (CLAP, second input bus) on XLR 1: audio passed, controls worked, editor opened, resized and reopened. The refused LSP layouts (Mixer x8/x16, Crossover x8) show as unsupported with the loader's words, after the one-time rescan the scanner stamp forces.
- Plugin reinstall over itself from Options: usable afterwards, no staging leftovers.
- Stream Deck keys and dials and the window responded normally throughout.
- Settings after the pass matched the pre-session backup apart from the parameters edited on purpose.

Found during the pass and handled outside this PR: saved inserts dropped by the client catalogue budget (#84, merged, in the base) and the 45 s Wine wait on daemon stop after a bridged VST3 ran (#85).

## Notes

The meter-startup race is fixed structurally but has no deterministic pre-fix reproducer. Several routing and persistence tests cover extracted logic rather than a live hardware mixer. This change does not constitute an equivalent VST3 or LV2 bus-layout audit.




