### PR TITLE
Window: defer close-to-tray and restore minimized windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
           test -x native/openxlr-lv2-host
           xvfb-run -a make -C native test-editor
 
+      - name: Tray window lifecycle
+        run: OPENXLR_TEST_DESKTOP=1 xvfb-run -a dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~TrayWindowTests
+
       - name: Lint shell scripts
         run: shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,14 @@ tools/check-openapi.py docs/openapi-v1.json     # the HTTP API document keeps it
 tools/check-spec.py packaging/rpm/openxlr.spec  # every installed file is in %files
 make -C native  # C/C++, PipeWire, lilv, LV2 and X11 development headers
 xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
+OPENXLR_TEST_DESKTOP=1 xvfb-run -a dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~TrayWindowTests
 ```
+
+The tray window test runs in a separate process because Avalonia owns one
+UI thread. It uses an isolated configuration and disconnects from the
+session bus, so it does not add icons to the developer's desktop tray.
+It checks window visibility, restoration and shutdown; checking the real
+tray menu and compositor still requires a desktop session.
 
 If you add or change a NuGet package, regenerate the lock files with a
 plain `dotnet restore src/OpenXLR.slnx` (the linux-x64 graph is part of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ OPENXLR_TEST_DESKTOP=1 xvfb-run -a dotnet test src/OpenXLR.Tests/OpenXLR.Tests.c
 ```
 
 The tray window test runs in a separate process because Avalonia owns one
-UI thread. It uses an isolated configuration and disconnects from the
+UI thread. It uses X11 with isolated configuration and runtime directories and disconnects from the
 session bus, so it does not add icons to the developer's desktop tray.
 It checks window visibility, restoration and shutdown; checking the real
 tray menu and compositor still requires a desktop session.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -518,7 +518,10 @@ Options, STARTUP:
   service. On a packaged install this is the package's own unit.
 - "Start the mixer UI at login" adds an autostart entry for the window.
 - With "Close button minimizes to tray", the window hides instead of
-  quitting; the tray icon's menu shows it again or quits. "Start
+  quitting; the tray icon's "Show mixer" menu item restores it, including
+  when the window was minimized. "Quit OpenXLR" exits even with
+  close-to-tray enabled. Closing only hides the window when its tray
+  icon was created successfully. "Start
   minimized to tray" starts with no window at all; the tray icon shows
   it the first time you click it.
 - Only one window runs per user. Starting OpenXLR again, from the menu

--- a/src/OpenXLR.Tests/TrayWindowTests.cs
+++ b/src/OpenXLR.Tests/TrayWindowTests.cs
@@ -1,0 +1,105 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+[Collection("xdg-config")]
+public sealed class TrayWindowTests
+{
+    private static bool NativeClose(Window window, WindowCloseReason reason)
+        => (bool)typeof(Window).GetMethod("HandleClosing",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(window, [reason])!;
+
+    // Run in a separate test process under Xvfb: Avalonia owns one UI thread.
+    [DesktopFact]
+    public void CloseDefersHidingAndMixerCanBeRestoredOrQuit()
+    {
+        string config = Path.Combine(Path.GetTempPath(), "openxlr-tray-" + Guid.NewGuid());
+        string? previous = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        string? previousBus = Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS");
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            MainWindow? window = null;
+            try
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", config);
+                // Exercise the window lifecycle without registering icons in
+                // the developer's real desktop tray.
+                Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent");
+                new UiSettings { MinimizeToTray = true }.Save();
+                AppBuilder.Configure<App>().UsePlatformDetect().SetupWithoutStarting();
+                window = new MainWindow();
+                window.ShowMixer();
+                bool closed = false;
+                window.Closed += (_, _) => closed = true;
+
+                for (int i = 0; i < 3; i++)
+                {
+                    // Exercise the platform's close callback, as the title-bar X does.
+                    Assert.True(NativeClose(window, WindowCloseReason.WindowClosing));
+                    Assert.True(window.IsVisible);
+                    Assert.False(closed);
+                    Dispatcher.UIThread.RunJobs();
+                    Assert.False(window.IsVisible);
+                    Assert.False(closed);
+                    window.ShowMixer();
+                    Assert.True(window.IsVisible);
+                }
+
+                window.WindowState = WindowState.Minimized;
+                window.ShowMixer();
+                Assert.Equal(WindowState.Normal, window.WindowState);
+
+                // A new launch arriving before the deferred hide keeps the mixer open.
+                window.Close();
+                window.ShowMixer();
+                Dispatcher.UIThread.RunJobs();
+                Assert.True(window.IsVisible);
+
+                // Quit wins even when a hide is still queued.
+                window.Close();
+                window.Quit();
+                Dispatcher.UIThread.RunJobs();
+                Assert.True(closed);
+                Assert.False(window.IsVisible);
+
+                window = new MainWindow();
+                window.ShowMixer();
+                Assert.False(NativeClose(window, WindowCloseReason.ApplicationShutdown));
+                window.ShowMixer();
+                Assert.False(window.IsVisible);
+
+                new UiSettings { MinimizeToTray = false }.Save();
+                window = new MainWindow();
+                window.ShowMixer();
+                window.Close();
+                Assert.False(window.IsVisible);
+            }
+            catch (Exception ex) { failure = ex; }
+            finally
+            {
+                window?.Quit();
+                Dispatcher.UIThread.RunJobs();
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", previous);
+                Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", previousBus);
+                if (Directory.Exists(config)) Directory.Delete(config, recursive: true);
+            }
+        }) { IsBackground = true };
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(30)), "The window lifecycle hung.");
+        if (failure is not null) System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+}
+
+public sealed class DesktopFactAttribute : FactAttribute
+{
+    public DesktopFactAttribute()
+    {
+        if (Environment.GetEnvironmentVariable("OPENXLR_TEST_DESKTOP") != "1")
+            Skip = "Run separately with OPENXLR_TEST_DESKTOP=1 under xvfb-run, filtered to TrayWindowTests.";
+    }
+}

--- a/src/OpenXLR.Tests/TrayWindowTests.cs
+++ b/src/OpenXLR.Tests/TrayWindowTests.cs
@@ -19,6 +19,7 @@ public sealed class TrayWindowTests
     {
         string config = Path.Combine(Path.GetTempPath(), "openxlr-tray-" + Guid.NewGuid());
         string? previous = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        string? previousRuntime = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
         string? previousBus = Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS");
         Exception? failure = null;
         var thread = new Thread(() =>
@@ -30,8 +31,9 @@ public sealed class TrayWindowTests
                 // Exercise the window lifecycle without registering icons in
                 // the developer's real desktop tray.
                 Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent");
+                Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", config);
                 new UiSettings { MinimizeToTray = true }.Save();
-                AppBuilder.Configure<App>().UsePlatformDetect().SetupWithoutStarting();
+                AppBuilder.Configure<App>().UseSkia().UseHarfBuzz().UseX11().SetupWithoutStarting();
                 window = new MainWindow();
                 window.ShowMixer();
                 bool closed = false;
@@ -85,6 +87,7 @@ public sealed class TrayWindowTests
                 window?.Quit();
                 Dispatcher.UIThread.RunJobs();
                 Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", previous);
+                Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", previousRuntime);
                 Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", previousBus);
                 if (Directory.Exists(config)) Directory.Delete(config, recursive: true);
             }

--- a/src/OpenXLR.UI/App.axaml.cs
+++ b/src/OpenXLR.UI/App.axaml.cs
@@ -25,12 +25,7 @@ public partial class App : Application
             // A later launch asks for the window through the single-instance
             // socket: bring it up, from the tray or from behind other windows.
             if (Program.Instance is { } instance)
-                instance.ShowRequested = () => Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                {
-                    window.Show();
-                    if (window.WindowState == WindowState.Minimized) window.WindowState = WindowState.Normal;
-                    window.Activate();
-                });
+                instance.ShowRequested = () => Avalonia.Threading.Dispatcher.UIThread.Post(window.ShowMixer);
             if (window.StartsHidden)
             {
                 // Starting in the tray means the window must never be

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
 using Avalonia.Platform;
+using Avalonia.Threading;
 
 namespace OpenXLR.UI;
 
@@ -16,6 +17,7 @@ public partial class MainWindow : Window
     private readonly MainViewModel _vm;
     private TrayIcon? _tray;
     private bool _reallyExit;
+    private bool _hideToTrayPending;
     private readonly CancellationTokenSource _lifetime = new();
     private bool _automaticUpdateCheckStarted;
 
@@ -48,15 +50,26 @@ public partial class MainWindow : Window
             // user-initiated window close is intercepted: cancelling an
             // OS/application shutdown request here blocks the whole system
             // from logging out or rebooting.
-            if (_vm.MinimizeToTray && !_reallyExit &&
+            if (_vm.MinimizeToTray && _tray is not null && !_reallyExit &&
                 e.CloseReason == WindowCloseReason.WindowClosing)
             {
                 e.Cancel = true;
-                Hide();
+                if (_hideToTrayPending) return;
+                _hideToTrayPending = true;
+                // Finish the native close callback before unmapping the
+                // window and stopping its renderer.
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (!_hideToTrayPending) return;
+                    _hideToTrayPending = false;
+                    Hide();
+                });
             }
         };
         Closed += async (_, _) =>
         {
+            _reallyExit = true;
+            _hideToTrayPending = false;
             _lifetime.Cancel();
             _tray?.Dispose();
             await _client.DisposeAsync();
@@ -72,15 +85,31 @@ public partial class MainWindow : Window
     /// <summary>True when the window should stay unshown until the tray asks for it.</summary>
     public bool StartsHidden { get; }
 
+    internal void ShowMixer()
+    {
+        _hideToTrayPending = false;
+        if (_reallyExit) return;
+        Show();
+        if (WindowState == WindowState.Minimized) WindowState = WindowState.Normal;
+        Activate();
+    }
+
+    internal void Quit()
+    {
+        _hideToTrayPending = false;
+        _reallyExit = true;
+        Close();
+    }
+
     private void SetupTray()
     {
         try
         {
             var menu = new NativeMenu();
             var show = new NativeMenuItem("Show mixer");
-            show.Click += (_, _) => { Show(); Activate(); };
+            show.Click += (_, _) => Dispatcher.UIThread.Post(ShowMixer);
             var quit = new NativeMenuItem("Quit OpenXLR");
-            quit.Click += (_, _) => { _reallyExit = true; Close(); };
+            quit.Click += (_, _) => Dispatcher.UIThread.Post(Quit);
             menu.Items.Add(show);
             menu.Items.Add(new NativeMenuItemSeparator());
             menu.Items.Add(quit);
@@ -91,7 +120,7 @@ public partial class MainWindow : Window
                 ToolTipText = "OpenXLR",
                 Menu = menu,
             };
-            _tray.Clicked += (_, _) => { Show(); Activate(); };
+            _tray.Clicked += (_, _) => Dispatcher.UIThread.Post(ShowMixer);
         }
         catch (Exception)
         {


### PR DESCRIPTION
Closing the mixer with close-to-tray enabled currently calls `Hide()` inside the native closing callback. Defer hiding until that callback returns, and cancel queued hides when the mixer is requested again or the application exits. Tray actions and subsequent launches share the same restore path, including restoring a minimized window.

Also allow a normal close if tray construction failed. Quit and application shutdown still close the window, and queued restore requests do not reopen a closed window.

Validation:
- Locked restore, Release build with warnings as errors, and all 333 existing .NET tests pass.
- The new isolated Xvfb window test passes separately and runs in CI. It covers repeated close/restore, minimized restoration, a pending hide followed by show or quit, application shutdown, and closing with the preference disabled.
- Plugin tests, native editor tests, and the complete fork CI pass: https://github.com/CarinaSchoppe/openxlr/actions/runs/34445816218

The reported freeze on the real Wayland compositor has not been directly reproduced. The window regression test disconnects from the desktop session bus and does not validate a real tray host. Desktop acceptance with the real tray menu and plugin editors, and hardware verification, remain outstanding.
