### PR TITLE
Window: prevent narrow layout overlaps and fill wide mixer windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Lint shell scripts
         run: shellcheck --severity=error tools/check-version.sh tools/check-locked-restore.sh packaging/ppa/make-source.sh
 
+      - name: Window layout at narrow and wide sizes
+        run: OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~WindowLayoutTests
+
       - name: Locked restore enforced on every packaging path
         run: tools/check-locked-restore.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,13 @@ tools/check-openapi.py docs/openapi-v1.json     # the HTTP API document keeps it
 tools/check-spec.py packaging/rpm/openxlr.spec  # every installed file is in %files
 make -C native  # C/C++, PipeWire, lilv, LV2 and X11 development headers
 xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
+OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~WindowLayoutTests
 ```
+
+The window layout test runs in its own process using X11 and isolated
+configuration, runtime and session-bus settings. It checks narrow plugin
+windows and mixer widths from 760 to 2400 logical pixels. Set
+`OPENXLR_LAYOUT_ARTIFACTS` to a directory to save rendered previews.
 
 If you add or change a NuGet package, regenerate the lock files with a
 plain `dotnet restore src/OpenXLR.slnx` (the linux-x64 graph is part of

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -109,6 +109,13 @@ on the original Wave XLR. See [hardware support](hardware-support.md).
 <a name="tasks"></a>
 ## 3. Tasks
 
+The mixer cards fill the window width when it is enlarged. The main
+window has a minimum width of 760 logical pixels; shorter windows scroll
+vertically. Mix master cards wrap onto additional rows when needed.
+Long plugin names are shortened with an ellipsis, with the full name in
+the tooltip. Plugin control and chain windows keep actions below their
+headings, and actions wrap when space is limited.
+
 <a name="mic-to-call"></a>
 ### 3.1 Send your microphone to a call or a recording
 

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -1,0 +1,194 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+[Collection("xdg-config")]
+public sealed class WindowLayoutTests
+{
+    [LayoutFact]
+    public void NarrowPluginWindowsKeepActionsSeparateAndMixerFillsWideWindows()
+    {
+        string config = Path.Combine(Path.GetTempPath(), "openxlr-layout-" + Guid.NewGuid());
+        string? oldConfig = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        string? oldRuntime = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+        string? oldBus = Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS");
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            List<Window> windows = [];
+            try
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", config);
+                Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent");
+                Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", config);
+                AppBuilder.Configure<App>().UseSkia().UseHarfBuzz().UseX11().SetupWithoutStarting();
+                Application.Current!.RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Dark;
+                var main = new MainWindow();
+                windows.Add(main);
+                // Stop the window's background connection before supplying a fixed fixture.
+                ((DaemonClient)typeof(MainWindow).GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(main)!).DisposeAsync().AsTask().GetAwaiter().GetResult();
+                Dispatcher.UIThread.RunJobs();
+                var vm = new MainViewModel(new DaemonClient());
+                main.DataContext = vm;
+                typeof(MainViewModel).GetMethod("ApplyMixer", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(vm, [JsonNode.Parse("""{"mixes":[],"channels":[],"inserts":{}}""")]);
+                AddInsert(vm.Inserts);
+                AddInsert(vm.Inserts2);
+                for (int i = 0; i < 8; i++)
+                {
+                    var mix = new MixViewModel(new DaemonClient(), "mix" + i, "Monitor " + i);
+                    AddInsert(mix.Inserts);
+                    vm.Mixes.Add(mix);
+                }
+                main.Show();
+                foreach (double width in new[] { 760d, 1040, 1800, 2400 })
+                {
+                    Layout(main, width, 900);
+                    var content = main.FindControl<StackPanel>("MixerContent")!;
+                    Assert.True(Math.Abs(content.Bounds.Width - (width - 32)) < 28,
+                        $"Requested {width}, window {main.Width}/{main.Bounds.Width}, client {main.ClientSize.Width}, content {content.Bounds.Width}");
+                    foreach (var name in main.GetVisualDescendants().OfType<TextBlock>()
+                                 .Where(t => t.Classes.Contains("insertName")))
+                    {
+                        AssertInside(name, (Control)name.Parent!);
+                        AssertNoOverlap(((Grid)name.Parent!).Children.Where(c => c.IsVisible).ToArray());
+                    }
+                    var masters = main.GetVisualDescendants().OfType<Border>()
+                        .Where(b => b.DataContext is MixViewModel && b.Width == 232).ToArray();
+                    Assert.Equal(8, masters.Length);
+                    AssertNoOverlap(masters);
+                    foreach (var master in masters) AssertInside(master, (Control)master.Parent!);
+                    Capture(main, "mixer-" + width);
+                    var page = main.GetVisualDescendants().OfType<ScrollViewer>().First();
+                    page.Offset = new Vector(0, page.Extent.Height);
+                    main.UpdateLayout();
+                    Capture(main, "mixes-" + width);
+                    page.Offset = default;
+                }
+                Assert.True(main.MinWidth >= 700);
+
+                var insert = vm.Inserts.Items[0];
+                var controls = new InsertControlsWindow { DataContext = insert };
+                windows.Add(controls);
+                controls.Show();
+                foreach (double width in new[] { 420d, 620, 1000 })
+                {
+                    Layout(controls, width, 560);
+                    var title = controls.FindControl<TextBlock>("PluginTitle")!;
+                    var actions = controls.FindControl<WrapPanel>("PluginActions")!;
+                    Assert.True(title.TranslatePoint(default, controls)!.Value.Y + title.Bounds.Height <=
+                                actions.TranslatePoint(default, controls)!.Value.Y);
+                    Assert.Equal(5, actions.Children.Count(c => c.IsVisible));
+                    Assert.Single(controls.GetVisualDescendants().OfType<Slider>());
+                    foreach (var button in actions.Children.Where(c => c.IsVisible))
+                        AssertInside(button, actions);
+                    Assert.True(actions.Children.Where(c => c.IsVisible).All(c => c.Bounds.Width > 20));
+                    AssertNoOverlap(actions.Children.Where(c => c.IsVisible).ToArray());
+                    var slider = controls.GetVisualDescendants().OfType<Slider>().Single();
+                    AssertNoOverlap(((Grid)slider.Parent!).Children.Where(c => c.IsVisible).ToArray());
+                    Capture(controls, "plugin-" + width);
+                }
+                insert.ApplyFromDaemon(JsonNode.Parse("{\"nativeHost\":true}")!,
+                    "The plugin could not start. " + new string('x', 160), false);
+                Layout(controls, 420, controls.MinHeight);
+                Assert.True(controls.GetVisualDescendants().OfType<ScrollViewer>().First().Bounds.Height > 50);
+                Capture(controls, "plugin-error-minimum");
+
+                var chain = new MixInsertsWindow { DataContext = vm.Inserts };
+                windows.Add(chain);
+                chain.Show();
+                Layout(chain, 440, 360);
+                var label = chain.GetVisualDescendants().OfType<TextBlock>()
+                    .Single(t => t.Classes.Contains("insertName"));
+                AssertInside(label, (Control)label.Parent!);
+                foreach (var actions in chain.GetVisualDescendants().OfType<WrapPanel>())
+                    foreach (var button in actions.Children)
+                        AssertInside(button, actions);
+                Capture(chain, "chain-440");
+            }
+            catch (Exception ex) { failure = ex; }
+            finally
+            {
+                foreach (var window in windows) window.Close();
+                Dispatcher.UIThread.RunJobs();
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", oldConfig);
+                Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", oldRuntime);
+                Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", oldBus);
+                if (Directory.Exists(config)) Directory.Delete(config, true);
+            }
+        }) { IsBackground = true };
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(45)), "Window layout hung.");
+        if (failure is not null) System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    private static void AddInsert(InsertsViewModel owner)
+    {
+        const string uri = "http://lsp-plug.in/plugins/lv2/graphic_equalizer_x16_mono";
+        owner.PluginChoices.Add(new(uri, "LSP Graphic Equalizer x16 Mono", "EQ",
+            JsonNode.Parse("""[{"symbol":"gain","name":"A very long parameter name for input gain","min":-60,"max":12,"default":0}]""")!, true, true));
+        owner.Apply(JsonNode.Parse("""
+            [{"insert":{"id":"eq","plugin":"http://lsp-plug.in/plugins/lv2/graphic_equalizer_x16_mono",
+            "label":"LSP Graphic Equalizer x16 Mono with a very long preset name","nativeHost":true},"nativeHostRunning":true}]
+            """));
+    }
+
+    private static void Layout(Window window, double width, double height)
+    {
+        // Resize the native surface, then let its size notification run.
+        window.PlatformImpl!.GetType().GetMethod("Resize", [typeof(Size), typeof(WindowResizeReason)])!
+            .Invoke(window.PlatformImpl, [new Size(width, height), WindowResizeReason.User]);
+        using var stop = new CancellationTokenSource();
+        DispatcherTimer.RunOnce(stop.Cancel, TimeSpan.FromMilliseconds(100));
+        Dispatcher.UIThread.MainLoop(stop.Token);
+        window.UpdateLayout();
+    }
+
+    private static void AssertInside(Control child, Control parent)
+    {
+        Assert.True(child.Bounds.Width > 0);
+        Assert.InRange(child.Bounds.Left, -0.1, parent.Bounds.Width);
+        Assert.InRange(child.Bounds.Right, 0, parent.Bounds.Width + 0.1);
+        Assert.InRange(child.Bounds.Bottom, 0, parent.Bounds.Height + 0.1);
+    }
+
+    private static void AssertNoOverlap(IReadOnlyList<Control> controls)
+    {
+        for (int i = 0; i < controls.Count; i++)
+            for (int j = i + 1; j < controls.Count; j++)
+            {
+                var root = (Visual)TopLevel.GetTopLevel(controls[i])!;
+                var first = new Rect(controls[i].TranslatePoint(default, root)!.Value, controls[i].Bounds.Size);
+                var second = new Rect(controls[j].TranslatePoint(default, root)!.Value, controls[j].Bounds.Size);
+                var intersection = first.Intersect(second);
+                Assert.True(intersection.Width <= 0 || intersection.Height <= 0,
+                    $"{controls[i].GetType().Name} overlaps {controls[j].GetType().Name}.");
+            }
+    }
+
+    private static void Capture(Window window, string name)
+    {
+        if (Environment.GetEnvironmentVariable("OPENXLR_LAYOUT_ARTIFACTS") is not { Length: > 0 } directory) return;
+        Directory.CreateDirectory(directory);
+        using var bitmap = new RenderTargetBitmap(new PixelSize((int)window.Bounds.Width, (int)window.Bounds.Height));
+        bitmap.Render(window);
+        bitmap.Save(Path.Combine(directory, name + ".png"), PngBitmapEncoderOptions.Default);
+    }
+}
+
+public sealed class LayoutFactAttribute : FactAttribute
+{
+    public LayoutFactAttribute()
+    {
+        if (Environment.GetEnvironmentVariable("OPENXLR_TEST_LAYOUT") != "1")
+            Skip = "Run separately with OPENXLR_TEST_LAYOUT=1 under xvfb-run, filtered to WindowLayoutTests.";
+    }
+}

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml
@@ -3,7 +3,7 @@
         xmlns:vm="using:OpenXLR.UI"
         x:Class="OpenXLR.UI.InsertControlsWindow"
         x:DataType="vm:InsertViewModel"
-        Title="{Binding Label}" Width="620" Height="560" MinWidth="420" MinHeight="240"
+        Title="{Binding Label}" Width="620" Height="560" MinWidth="420" MinHeight="320"
         WindowStartupLocation="CenterOwner"
         Background="#16181d">
 
@@ -38,47 +38,43 @@
   </Window.Styles>
 
   <DockPanel Margin="16">
-    <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,10">
-      <StackPanel>
-        <StackPanel Orientation="Horizontal" Spacing="8">
-          <Ellipse Width="10" Height="10" VerticalAlignment="Center"
-                   Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
-          <TextBlock Text="{Binding Label}" FontSize="16" FontWeight="Bold" Foreground="#e6e9f0"/>
-          <TextBlock Text="{Binding StateText}" Classes="h" VerticalAlignment="Center"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Spacing="8">
-          <TextBlock Text="{Binding Plugin}" Classes="h" FontSize="11" VerticalAlignment="Center"/>
-          <Border Background="#2a2e38" CornerRadius="4" Padding="6,1" VerticalAlignment="Center">
-            <TextBlock Text="{Binding Format}" Foreground="#8b93a7" FontSize="10" FontWeight="SemiBold"/>
-          </Border>
-        </StackPanel>
-        <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
-      </StackPanel>
-      <!-- Every button lives on the right, in two rows when this plugin can
-           be hosted natively. -->
-      <StackPanel Grid.Column="1" Spacing="6" VerticalAlignment="Top" HorizontalAlignment="Right">
-        <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right">
-          <Button Content="Plugin UI" Padding="12,4" Click="OnNativeEditor"
-                  IsVisible="{Binding NativeEditorSupported}"
-                  IsEnabled="{Binding NativeEditorAvailable}"
-                  ToolTip.Tip="Open this plugin's own editor on the live audio instance"/>
-          <Button Content="Defaults" Padding="12,4" Click="OnDefaults"
-                  ToolTip.Tip="Put every control back to the plugin's own defaults"/>
-          <ToggleButton Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}" Padding="12,4"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right"
-                    IsVisible="{Binding CanChooseNativeHost}">
-          <ToggleButton Content="Native host" IsChecked="{Binding NativeHost, Mode=TwoWay}" Padding="12,4"
-                        ToolTip.Tip="Run this insert in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
-          <Button Content="Manual" Padding="10,4" Click="OnEditorManual"
-                  ToolTip.Tip="Open the manual section on plugin editors"/>
-        </StackPanel>
-      </StackPanel>
-    </Grid>
+    <StackPanel DockPanel.Dock="Top" Spacing="8" Margin="0,0,0,12">
+      <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+        <Ellipse Width="10" Height="10" VerticalAlignment="Center"
+                 Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
+        <TextBlock Grid.Column="1" Name="PluginTitle" Text="{Binding Label}" FontSize="16" FontWeight="Bold"
+                   Foreground="#e6e9f0" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
+        <TextBlock Grid.Column="2" Text="{Binding StateText}" Classes="h" VerticalAlignment="Center"/>
+      </Grid>
+      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+        <TextBlock Text="{Binding Plugin}" Classes="h" FontSize="11" VerticalAlignment="Center"
+                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Plugin}"/>
+        <Border Grid.Column="1" Background="#2a2e38" CornerRadius="4" Padding="6,1" VerticalAlignment="Center">
+          <TextBlock Text="{Binding Format}" Foreground="#8b93a7" FontSize="10" FontWeight="SemiBold"/>
+        </Border>
+      </Grid>
+      <!-- Actions get their own row and wrap instead of competing with the title. -->
+      <WrapPanel Name="PluginActions">
+        <Button Content="Plugin UI" Padding="12,4" Margin="0,0,6,6" Click="OnNativeEditor"
+                IsVisible="{Binding NativeEditorSupported}" IsEnabled="{Binding NativeEditorAvailable}"
+                ToolTip.Tip="Open this plugin's own editor on the live audio instance"/>
+        <Button Content="Defaults" Padding="12,4" Margin="0,0,6,6" Click="OnDefaults"
+                ToolTip.Tip="Put every control back to the plugin's own defaults"/>
+        <ToggleButton Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}" Padding="12,4" Margin="0,0,6,6"/>
+        <ToggleButton Content="Native host" IsChecked="{Binding NativeHost, Mode=TwoWay}" Padding="12,4" Margin="0,0,6,6"
+                      IsVisible="{Binding CanChooseNativeHost}"
+                      ToolTip.Tip="Run this insert in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
+        <Button Content="Manual" Padding="10,4" Margin="0,0,6,6" Click="OnEditorManual"
+                IsVisible="{Binding CanChooseNativeHost}" ToolTip.Tip="Open the manual section on plugin editors"/>
+      </WrapPanel>
+    </StackPanel>
     <Button DockPanel.Dock="Bottom" Content="Close" HorizontalAlignment="Right" Padding="18,6" Margin="0,10,0,0" Click="OnClose"/>
     <!-- AllowAutoHide off: the scrollbar reserves its own column instead
          of floating over the value readouts -->
     <ScrollViewer VerticalScrollBarVisibility="Auto" AllowAutoHide="False">
+      <StackPanel>
+      <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" TextWrapping="Wrap"
+                 Margin="0,0,0,8" IsVisible="{Binding HasError}"/>
       <ItemsControl ItemsSource="{Binding Groups}" Margin="0,0,10,0">
         <ItemsControl.ItemTemplate>
           <DataTemplate x:DataType="vm:InsertParamGroup">
@@ -90,7 +86,7 @@
               <ItemsControl ItemsSource="{Binding Params}">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate x:DataType="vm:InsertParamViewModel">
-                    <Grid ColumnDefinitions="200,*,72" Margin="0,0,0,4">
+                    <Grid ColumnDefinitions="*,2*,72" ColumnSpacing="8" Margin="0,0,0,4">
                       <TextBlock Text="{Binding Name}" Classes="h" VerticalAlignment="Center"
                                  TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Symbol}"/>
                       <Slider Grid.Column="1" Minimum="{Binding Min}" Maximum="{Binding Max}"
@@ -99,7 +95,8 @@
                       <CheckBox Grid.Column="1" IsChecked="{Binding On, Mode=TwoWay}" IsVisible="{Binding Toggled}"
                                 MinHeight="0" VerticalAlignment="Center"/>
                       <TextBlock Grid.Column="2" Text="{Binding ValueText}" Classes="val" FontSize="12"
-                                 VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                                 VerticalAlignment="Center" HorizontalAlignment="Right"
+                                 TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding ValueText}"/>
                     </Grid>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -108,6 +105,7 @@
           </DataTemplate>
         </ItemsControl.ItemTemplate>
       </ItemsControl>
+      </StackPanel>
     </ScrollViewer>
   </DockPanel>
 </Window>

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -3,7 +3,7 @@
         xmlns:vm="using:OpenXLR.UI"
         x:Class="OpenXLR.UI.MainWindow"
         x:DataType="vm:MainViewModel"
-        Title="OpenXLR" Width="1040" Height="900" MinHeight="640"
+        Title="OpenXLR" Width="1040" Height="900" MinWidth="760" MinHeight="480"
         Icon="avares://OpenXLR.UI/Assets/icon.png"
         Background="#16181d">
 
@@ -143,11 +143,9 @@
     </Style>
   </Window.Styles>
 
-  <!-- MaxWidth keeps sliders and dropdowns a sane length on an ultrawide or when
-       maximized; without it a fader stretches across the whole screen. Every
-       card sizes to its content; the page scrolls when the window is shorter. -->
+  <!-- Cards follow the available width. The page scrolls when it is shorter. -->
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-  <StackPanel Margin="16" MaxWidth="1300" HorizontalAlignment="Center">
+  <StackPanel Name="MixerContent" Margin="16" HorizontalAlignment="Stretch">
 
     <!-- header -->
     <Border Classes="card" Margin="0,0,0,8">
@@ -322,11 +320,14 @@
                 <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,0,0,3">
                   <Ellipse Width="9" Height="9" VerticalAlignment="Center" Margin="0,0,8,0"
                            Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
-                  <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Label}" Foreground="#e6e9f0" FontSize="12"/>
-                    <TextBlock Text="{Binding StateText}" Classes="h" FontSize="11"/>
-                    <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
-                  </StackPanel>
+                  <Grid Grid.Column="1" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto"
+                        ColumnSpacing="8" VerticalAlignment="Center" ClipToBounds="True">
+                    <TextBlock Text="{Binding Label}" Classes="insertName" Foreground="#e6e9f0" FontSize="12"
+                               TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
+                    <TextBlock Grid.Column="1" Text="{Binding StateText}" Classes="h" FontSize="11"/>
+                    <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding Error}" Foreground="#e0a05a"
+                               FontSize="11" TextWrapping="Wrap" IsVisible="{Binding HasError}"/>
+                  </Grid>
                   <ToggleButton Grid.Column="2" Content="N" Classes="insertmini"
                                 IsChecked="{Binding NativeHost, Mode=TwoWay}"
                                 IsVisible="{Binding CanChooseNativeHost}"
@@ -384,11 +385,14 @@
                 <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,0,0,3">
                   <Ellipse Width="9" Height="9" VerticalAlignment="Center" Margin="0,0,8,0"
                            Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
-                  <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Label}" Foreground="#e6e9f0" FontSize="12"/>
-                    <TextBlock Text="{Binding StateText}" Classes="h" FontSize="11"/>
-                    <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
-                  </StackPanel>
+                  <Grid Grid.Column="1" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto"
+                        ColumnSpacing="8" VerticalAlignment="Center" ClipToBounds="True">
+                    <TextBlock Text="{Binding Label}" Classes="insertName" Foreground="#e6e9f0" FontSize="12"
+                               TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
+                    <TextBlock Grid.Column="1" Text="{Binding StateText}" Classes="h" FontSize="11"/>
+                    <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding Error}" Foreground="#e0a05a"
+                               FontSize="11" TextWrapping="Wrap" IsVisible="{Binding HasError}"/>
+                  </Grid>
                   <ToggleButton Grid.Column="2" Content="N" Classes="insertmini"
                                 IsChecked="{Binding NativeHost, Mode=TwoWay}"
                                 IsVisible="{Binding CanChooseNativeHost}"
@@ -572,15 +576,16 @@
         <ItemsControl DockPanel.Dock="Bottom" ItemsSource="{Binding Mixes}" IsVisible="{Binding HasMixer}"
                       Margin="0,10,0,0">
           <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate><UniformGrid Rows="1"/></ItemsPanelTemplate>
+            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
           </ItemsControl.ItemsPanel>
           <ItemsControl.ItemTemplate>
             <DataTemplate x:DataType="vm:MixViewModel">
-              <Border Background="#23262f" CornerRadius="6" Padding="10" Margin="0,0,8,0"
+              <Border Background="#23262f" CornerRadius="6" Padding="10" Margin="0,0,8,8" Width="232"
                       IsVisible="{Binding Visible}">
                 <StackPanel Spacing="6">
                   <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Text="{Binding Name}" Foreground="#e6e9f0" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Name}" Foreground="#e6e9f0" FontWeight="SemiBold"
+                               TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Name}" Margin="0,0,8,0"/>
                     <TextBlock Grid.Column="1" Text="{Binding VolumeText}" Classes="val"/>
                   </Grid>
                   <StackPanel Spacing="1">

--- a/src/OpenXLR.UI/MixInsertsWindow.axaml
+++ b/src/OpenXLR.UI/MixInsertsWindow.axaml
@@ -16,10 +16,11 @@
   </Window.Styles>
 
   <DockPanel Margin="16">
-    <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,10">
+    <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" ColumnSpacing="12" Margin="0,0,0,10">
       <StackPanel>
-        <TextBlock Text="{Binding Title}" FontSize="16" FontWeight="Bold" Foreground="#e6e9f0"/>
-        <TextBlock Text="{Binding ChainHint}" Classes="h" FontSize="11"/>
+        <TextBlock Text="{Binding Title}" FontSize="16" FontWeight="Bold" Foreground="#e6e9f0"
+                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Title}"/>
+        <TextBlock Text="{Binding ChainHint}" Classes="h" FontSize="11" TextWrapping="Wrap"/>
       </StackPanel>
       <Button Grid.Column="1" Content="Add plugin…" Padding="12,4" VerticalAlignment="Top" Click="OnAddInsert"/>
     </Grid>
@@ -29,21 +30,30 @@
       <ItemsControl ItemsSource="{Binding Items}" Margin="0,0,10,0">
         <ItemsControl.ItemTemplate>
           <DataTemplate x:DataType="vm:InsertViewModel">
-            <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,4">
-              <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                <Ellipse Width="9" Height="9" VerticalAlignment="Center"
-                         Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
-                <TextBlock Text="{Binding Label}" Foreground="#e6e9f0" FontSize="12"/>
-                <TextBlock Text="{Binding StateText}" Classes="h" FontSize="11"/>
-                <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" IsVisible="{Binding HasError}"/>
+            <Border Background="#23262f" CornerRadius="6" Padding="10" Margin="0,0,0,8">
+              <StackPanel Spacing="8">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                  <Ellipse Width="9" Height="9" VerticalAlignment="Center"
+                           Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
+                  <TextBlock Grid.Column="1" Text="{Binding Label}" Classes="insertName" Foreground="#e6e9f0" FontSize="12"
+                             TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
+                  <TextBlock Grid.Column="2" Text="{Binding StateText}" Classes="h" FontSize="11"/>
+                </Grid>
+                <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11"
+                           TextWrapping="Wrap" IsVisible="{Binding HasError}"/>
+                <WrapPanel>
+                  <Button Content="Controls" Padding="8,3" MinHeight="0" FontSize="11" Margin="0,0,6,0" Click="OnInsertControls"/>
+                  <ToggleButton Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}"
+                                Padding="8,3" MinHeight="0" FontSize="11" Margin="0,0,6,0"/>
+                  <Button Content="▲" Padding="6,3" MinHeight="0" FontSize="10" Margin="0,0,4,0" Click="OnInsertUp"
+                          AutomationProperties.Name="Move plugin up" ToolTip.Tip="Move up"/>
+                  <Button Content="▼" Padding="6,3" MinHeight="0" FontSize="10" Margin="0,0,6,0" Click="OnInsertDown"
+                          AutomationProperties.Name="Move plugin down" ToolTip.Tip="Move down"/>
+                  <Button Content="✕" Padding="6,3" MinHeight="0" FontSize="10" Click="OnInsertRemove"
+                          AutomationProperties.Name="Remove plugin" ToolTip.Tip="Remove plugin"/>
+                </WrapPanel>
               </StackPanel>
-              <Button Grid.Column="1" Content="Controls" Padding="8,1" MinHeight="0" FontSize="11" Margin="0,0,4,0" Click="OnInsertControls"/>
-              <ToggleButton Grid.Column="2" Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}"
-                            Padding="8,1" MinHeight="0" FontSize="11" Margin="0,0,4,0"/>
-              <Button Grid.Column="3" Content="▲" Padding="6,1" MinHeight="0" FontSize="10" Margin="0,0,2,0" Click="OnInsertUp"/>
-              <Button Grid.Column="4" Content="▼" Padding="6,1" MinHeight="0" FontSize="10" Margin="0,0,4,0" Click="OnInsertDown"/>
-              <Button Grid.Column="5" Content="✕" Padding="6,1" MinHeight="0" FontSize="10" Click="OnInsertRemove"/>
-            </Grid>
+            </Border>
           </DataTemplate>
         </ItemsControl.ItemTemplate>
       </ItemsControl>


### PR DESCRIPTION
Narrow mixer and plugin windows can let long plugin names and status text paint over their controls. Enlarging the mixer also leaves the content capped at 1300 logical pixels.

Let the main cards stretch with the window, set a 760-pixel minimum width, and keep vertical scrolling available down to a 480-pixel window height. Constrain input insert names with ellipsis and full-name tooltips, give errors their own wrapping row, and wrap mix master cards instead of squeezing every mix into one row.

In generated plugin controls and insert-chain windows, put actions below the heading and let them wrap. Keep plugin metadata constrained, give parameter labels and sliders proportional space, and put long error messages inside the scrollable area. No changes to native plugin editor implementations or audio processing.

Validation:
- Release build with warnings as errors: zero warnings and zero errors.
- All 333 existing .NET tests pass.
- New isolated X11/Xvfb layout test passes separately and is included in CI. It resizes native windows and checks content width, bounds and non-overlap at mixer widths 760, 1040, 1800 and 2400, plugin-control widths 420, 620 and 1000, and a 440-pixel chain window. Fixtures include eight mixes, long plugin names, all five plugin actions, parameter controls and a long error at minimum height.
- Rendered narrow and wide previews were inspected.

Real Wayland compositor interaction, fractional desktop scaling and native plugin editor/hardware acceptance have not been verified. This is independent of the close-to-tray fix in #80.
