### PR TITLE
Window: repair mixer autostart and clarify login options

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -514,13 +514,21 @@ cards keep working. Turn it on again the same way.
 
 Options, STARTUP:
 
-- "Start the daemon at login" enables the daemon's systemd user
-  service. On a packaged install this is the package's own unit.
-- "Start the mixer UI at login" adds an autostart entry for the window.
+- "Start audio service at login (background only)" enables the daemon's
+  systemd user service. On a packaged install this is the package's own
+  unit. This does not start the mixer window or create a tray icon.
+- "Start mixer window and tray icon at login" adds a desktop autostart
+  entry for the window, including on KDE Plasma and CachyOS. When this
+  preference is on, a manual launch repairs a missing entry or updates
+  its executable path after an installation moves. Desktop-specific
+  settings, including an external `Hidden=true` disable, are preserved.
+  Failed changes show an error in Options and keep the previous preference.
 - With "Close button minimizes to tray", the window hides instead of
   quitting; the tray icon's menu shows it again or quits. "Start
   minimized to tray" starts with no window at all; the tray icon shows
-  it the first time you click it.
+  it the first time you click it. This changes how the window opens; it
+  does not enable autostart. For a tray icon at login, enable both the
+  mixer-at-login option and "Start minimized to tray".
 - Only one window runs per user. Starting OpenXLR again, from the menu
   or a shell, brings the running window to the front (out of the tray
   if it is hidden there) instead of opening a second one.

--- a/src/OpenXLR.Tests/WindowAutostartTests.cs
+++ b/src/OpenXLR.Tests/WindowAutostartTests.cs
@@ -1,0 +1,155 @@
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+[Collection("xdg-config")]
+public sealed class WindowAutostartTests : IDisposable
+{
+    private readonly string _home = Path.Combine(Path.GetTempPath(), "openxlr-autostart-" + Guid.NewGuid());
+    private readonly string? _oldConfig = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+    private string Entry => Path.Combine(_home, "autostart", "openxlr.desktop");
+    private string Executable => Path.Combine(_home, "My Build", "OpenXLR.UI");
+
+    public WindowAutostartTests()
+    {
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", _home);
+        Directory.CreateDirectory(Path.GetDirectoryName(Executable)!);
+        File.WriteAllText(Executable, "#!/bin/sh\nexit 0\n");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", _oldConfig);
+        Directory.Delete(_home, true);
+    }
+
+    [Fact]
+    public void EnablingCreatesAQuotedDesktopEntryAndDisablingRemovesIt()
+    {
+        Assert.True(StartupIntegration.SetWindowAtLogin(true, Executable));
+        string entry = File.ReadAllText(Entry);
+        Assert.Contains("[Desktop Entry]", entry);
+        Assert.Contains("Type=Application", entry);
+        Assert.Contains("Exec=" + StartupIntegration.DesktopExec(Executable), entry);
+        Assert.DoesNotContain("OnlyShowIn", entry);
+        Assert.DoesNotContain("Hidden=true", entry);
+        Assert.True(StartupIntegration.SetWindowAtLogin(false, Executable));
+        Assert.False(File.Exists(Entry));
+        Assert.True(StartupIntegration.SetWindowAtLogin(false, Executable));
+    }
+
+    [Fact]
+    public void EnabledPreferenceRepairsAMissingEntryAndIsIdempotent()
+    {
+        var settings = new UiSettings { OpenWindowAtLogin = true };
+        Assert.True(StartupIntegration.RepairWindowAutostart(settings, Executable));
+        string entry = File.ReadAllText(Entry);
+        var marker = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(Entry, marker);
+        Assert.True(StartupIntegration.RepairWindowAutostart(settings, Executable));
+        Assert.Equal(entry, File.ReadAllText(Entry));
+        Assert.Equal(marker, File.GetLastWriteTimeUtc(Entry));
+    }
+
+    [Fact]
+    public void DaemonAndMinimizedPreferencesDoNotEnableWindowAutostart()
+    {
+        var settings = new UiSettings { StartDaemonAtLogin = true, StartMinimized = true };
+        settings.Save();
+        Assert.True(StartupIntegration.RepairWindowAutostart(settings, Executable));
+        Assert.False(File.Exists(Entry));
+        var client = new DaemonClient();
+        var options = new OptionsViewModel(client, new MainViewModel(client));
+        Assert.True(options.StartDaemonAtLogin);
+        Assert.True(options.StartMinimized);
+        Assert.False(options.OpenWindowAtLogin);
+        Assert.Contains("does not enable autostart", options.StartupHint);
+    }
+
+    [Theory]
+    [InlineData("Exec=\"/old/build/OpenXLR.UI\"\n")]
+    [InlineData("")]
+    public void RepairsLaunchPathWithoutRemovingDesktopPreferences(string exec)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Entry)!);
+        File.WriteAllText(Entry, "[Desktop Entry]\nType=Application\n" + exec +
+            "Hidden=true\nX-KDE-autostart-after=panel\n[Desktop Action Manual]\nExec=manual-command\n");
+        Assert.True(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable));
+        string entry = File.ReadAllText(Entry);
+        Assert.Contains("Exec=" + StartupIntegration.DesktopExec(Executable), entry);
+        Assert.Contains("Hidden=true", entry);
+        Assert.Contains("X-KDE-autostart-after=panel", entry);
+        Assert.Contains("[Desktop Action Manual]\nExec=manual-command", entry);
+    }
+
+    [Fact]
+    public void MissingBinaryDoesNotOverwriteAnExistingEntry()
+    {
+        Assert.True(StartupIntegration.SetWindowAtLogin(true, Executable));
+        string before = File.ReadAllText(Entry);
+        Assert.False(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable + ".missing"));
+        Assert.False(StartupIntegration.SetWindowAtLogin(true, Executable + ".missing"));
+        Assert.Equal(before, File.ReadAllText(Entry));
+    }
+
+    [Fact]
+    public void FailedDisableKeepsTheSavedPreferenceAndReportsTheFailure()
+    {
+        new UiSettings { OpenWindowAtLogin = true }.Save();
+        Directory.CreateDirectory(Entry); // A directory cannot be removed as a desktop file.
+        var client = new DaemonClient();
+        var options = new OptionsViewModel(client, new MainViewModel(client));
+        options.OpenWindowAtLogin = false;
+        Assert.True(options.OpenWindowAtLogin);
+        Assert.True(UiSettings.Load().OpenWindowAtLogin);
+        Assert.NotNull(options.StartupError);
+
+        Directory.Delete(Entry);
+        options.OpenWindowAtLogin = false;
+        Assert.False(options.OpenWindowAtLogin);
+        Assert.False(UiSettings.Load().OpenWindowAtLogin);
+        Assert.Null(options.StartupError);
+    }
+
+    [Fact]
+    public void WriteFailureReturnsFalseInsteadOfCrashing()
+    {
+        File.WriteAllText(Path.Combine(_home, "autostart"), "not a directory");
+        Assert.False(StartupIntegration.SetWindowAtLogin(true, Executable));
+        Assert.False(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable));
+    }
+
+    [Theory]
+    [InlineData("lib/openxlr/ui")]
+    [InlineData("lib/openxlr")]
+    public void PackagedInstallsUseTheStableWrapper(string relativeBase)
+    {
+        string prefix = Path.Combine(_home, "prefix");
+        string wrapper = Path.Combine(prefix, "bin", "openxlr");
+        Directory.CreateDirectory(Path.GetDirectoryName(wrapper)!);
+        File.WriteAllText(wrapper, "#!/bin/sh\n");
+        Assert.Equal(wrapper, StartupIntegration.ResolveUiBinary(Path.Combine(prefix, relativeBase)));
+    }
+
+    [Fact]
+    public void SourceBuildUsesItsOwnAppHost()
+        => Assert.Equal(Executable, StartupIntegration.ResolveUiBinary(Path.GetDirectoryName(Executable)!));
+
+    [Fact]
+    public void SourceBuildDoesNotPickAnUnrelatedAncestorWrapper()
+    {
+        string source = Path.Combine(_home, "src", "build");
+        Directory.CreateDirectory(Path.Combine(_home, "bin"));
+        File.WriteAllText(Path.Combine(_home, "bin", "openxlr"), "#!/bin/sh\n");
+        Assert.Equal(Path.Combine(source, "OpenXLR.UI"), StartupIntegration.ResolveUiBinary(source));
+    }
+
+    [Fact]
+    public void EnabledPreferenceReplacesAnEntryWithoutADesktopGroup()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Entry)!);
+        File.WriteAllText(Entry, "incomplete file");
+        Assert.True(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable));
+        Assert.Contains("[Desktop Entry]", File.ReadAllText(Entry));
+    }
+}

--- a/src/OpenXLR.UI/App.axaml.cs
+++ b/src/OpenXLR.UI/App.axaml.cs
@@ -21,6 +21,10 @@ public partial class App : Application
             if (UiSettings.Load().StartDaemonAtLogin)
                 StartupIntegration.RepairDaemonUnit();
 
+            // A moved installation or deleted desktop entry must not leave
+            // an enabled mixer-at-login preference pointing nowhere.
+            StartupIntegration.RepairWindowAutostart();
+
             var window = new MainWindow();
             // A later launch asks for the window through the single-instance
             // socket: bring it up, from the tray or from behind other windows.

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -159,11 +159,26 @@ public sealed class OptionsViewModel : ViewModelBase
         get => _openWindowAtLogin;
         set
         {
-            if (!Set(ref _openWindowAtLogin, value)) return;
-            StartupIntegration.SetWindowAtLogin(value);
+            if (_openWindowAtLogin == value) return;
+            if (!StartupIntegration.SetWindowAtLogin(value))
+            {
+                StartupError = "Could not update mixer autostart. Check that OpenXLR is installed and the autostart folder is writable.";
+                Raise(nameof(OpenWindowAtLogin));
+                return;
+            }
+            StartupError = null;
+            Set(ref _openWindowAtLogin, value);
+            Raise(nameof(StartupHint));
             Persist();
         }
     }
+
+    private string? _startupError;
+    public string? StartupError { get => _startupError; private set => Set(ref _startupError, value); }
+
+    public string StartupHint => OpenWindowAtLogin
+        ? "The mixer and tray icon will start when you sign in."
+        : "The mixer and tray icon will not start at login. Starting minimized does not enable autostart.";
 
     private bool _minimizeToTray;
     public bool MinimizeToTray

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -37,10 +37,13 @@
     <Border Classes="card">
       <StackPanel Spacing="6">
         <TextBlock Text="STARTUP" Classes="h"/>
-        <CheckBox Content="Start the daemon at login (systemd user service)"
+        <CheckBox Content="Start audio service at login (background only)"
                   IsChecked="{Binding StartDaemonAtLogin, Mode=TwoWay}"/>
-        <CheckBox Content="Start the mixer UI at login"
+        <CheckBox Content="Start mixer window and tray icon at login"
                   IsChecked="{Binding OpenWindowAtLogin, Mode=TwoWay}"/>
+        <TextBlock Text="{Binding StartupHint}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="26,0,0,4"/>
+        <TextBlock Text="{Binding StartupError}" FontSize="11" Foreground="#e0a05a" TextWrapping="Wrap"
+                   IsVisible="{Binding StartupError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
         <CheckBox Content="Close button minimizes to tray instead of quitting"
                   IsChecked="{Binding MinimizeToTray, Mode=TwoWay}"/>
         <CheckBox Content="Start minimized to tray"

--- a/src/OpenXLR.UI/UiSettings.cs
+++ b/src/OpenXLR.UI/UiSettings.cs
@@ -131,10 +131,22 @@ public static class StartupIntegration
         Path.Combine("..", "..", "..", "..", "OpenXLR.Daemon", "bin", "Release", "net10.0", "OpenXLR.Daemon"));
 
     /// <summary>The window for the autostart entry: the installed wrapper, else this binary.</summary>
-    private static string UiBinary => FirstExisting(
-        Path.Combine("..", "..", "bin", "openxlr"),
-        Path.Combine("..", "..", "..", "bin", "openxlr"))
-        ?? Path.Combine(AppContext.BaseDirectory, "OpenXLR.UI");
+    private static string UiBinary => ResolveUiBinary(AppContext.BaseDirectory);
+
+    internal static string ResolveUiBinary(string baseDirectory)
+    {
+        var directory = new DirectoryInfo(baseDirectory);
+        var package = directory.Name == "ui" ? directory.Parent : directory;
+        // Only packaged lib/openxlr[/ui] layouts have a sibling bin wrapper.
+        // Walking upward from an arbitrary build can select another install.
+        if (package?.Name == "openxlr" && package.Parent?.Name == "lib"
+            && package.Parent.Parent is { } prefix)
+        {
+            string wrapper = Path.Combine(prefix.FullName, "bin", "openxlr");
+            if (File.Exists(wrapper)) return wrapper;
+        }
+        return Path.Combine(baseDirectory, "OpenXLR.UI");
+    }
 
     private static string? FirstExisting(params string[] relativeToBaseDir) =>
         relativeToBaseDir
@@ -313,26 +325,66 @@ public static class StartupIntegration
         }
     }
 
-    public static void SetWindowAtLogin(bool enabled)
+    public static bool SetWindowAtLogin(bool enabled) => SetWindowAtLogin(enabled, UiBinary);
+
+    internal static bool SetWindowAtLogin(bool enabled, string executable)
     {
-        if (enabled)
+        try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(AutostartPath)!);
-            File.WriteAllText(AutostartPath, $"""
-                [Desktop Entry]
-                Type=Application
-                Name=OpenXLR
-                Comment=OpenXLR mixer window
-                Exec={DesktopExec(UiBinary)}
-                Icon=openxlr
-                Terminal=false
-                X-GNOME-Autostart-enabled=true
-                """);
+            if (!enabled) File.Delete(AutostartPath);
+            else
+            {
+                if (!File.Exists(executable)) return false;
+                OpenXlrPaths.WriteAtomic(AutostartPath, $"""
+                    [Desktop Entry]
+                    Type=Application
+                    Name=OpenXLR
+                    Comment=OpenXLR mixer window
+                    Exec={DesktopExec(executable)}
+                    Icon=openxlr
+                    Terminal=false
+                    X-GNOME-Autostart-enabled=true
+
+                    """);
+            }
+            return true;
         }
-        else
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return false; }
+    }
+
+    /// <summary>
+    /// Recreate a missing entry or update its launch path after an installation
+    /// moves. Keep desktop-specific settings, including an external disable.
+    /// A saved choice to start only the daemon never enables the window.
+    /// </summary>
+    public static bool RepairWindowAutostart()
+        => RepairWindowAutostart(UiSettings.Load(), UiBinary);
+
+    internal static bool RepairWindowAutostart(UiSettings settings, string executable)
+    {
+        if (!settings.OpenWindowAtLogin) return true;
+        try
         {
-            try { File.Delete(AutostartPath); } catch (IOException) { }
+            if (!File.Exists(executable)) return false;
+            if (!File.Exists(AutostartPath)) return SetWindowAtLogin(true, executable);
+            var lines = File.ReadAllLines(AutostartPath).ToList();
+            int start = lines.FindIndex(l => l.Trim() == "[Desktop Entry]");
+            if (start < 0) return SetWindowAtLogin(true, executable);
+            int end = lines.FindIndex(start + 1, l => l.TrimStart().StartsWith("[", StringComparison.Ordinal));
+            if (end < 0) end = lines.Count;
+            string expected = "Exec=" + DesktopExec(executable);
+            int exec = lines.FindIndex(start + 1, end - start - 1,
+                l => l.TrimStart().StartsWith("Exec=", StringComparison.Ordinal));
+            if (exec >= 0)
+            {
+                if (lines[exec] == expected) return true;
+                lines[exec] = expected;
+            }
+            else lines.Insert(end, expected);
+            OpenXlrPaths.WriteAtomic(AutostartPath, string.Join("\n", lines) + "\n");
+            return true;
         }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return false; }
     }
 
     /// <summary>


### PR DESCRIPTION
The login settings can leave users expecting a tray icon when only the audio service is enabled. In the reported CachyOS setup, the daemon was enabled and active, but `openWindowAtLogin` was false and no mixer autostart entry existed. `startMinimized` was true; that preference controls window visibility, not whether the desktop launches it.

Clarify the two login options and show an explanation in Options. When mixer autostart is enabled, a manual launch now recreates a missing desktop entry or repairs its executable path after the installation moves. Preserve desktop-specific keys and external disables such as `Hidden=true`. Resolve packaged wrappers only from supported `lib/openxlr[/ui]` layouts so source builds cannot accidentally select an unrelated ancestor installation.

Write the entry atomically, reject a missing executable, and report failed enable/disable operations without changing the saved preference. No changes to daemon startup policy or the meaning of start-minimized.

Validation:
- Locked restore and Release build with warnings as errors pass with zero warnings and errors.
- All 346 .NET tests pass, including 13 new autostart cases covering creation/removal, missing and stale entries, idempotence, independent preferences, desktop overrides, missing executables, write failures, retry after failure, packaged layouts and source builds.
- Plugin checks, native build/editor tests, shell lint, version consistency, locked restore, OpenAPI and RPM checks pass.
- On CachyOS, the installed wrapper exists; the generated desktop entry passes desktop-file-validate, and systemd-xdg-autostart-generator produces a login service with ExecStart=:/usr/bin/openxlr.

The local mixer autostart preference and entry were corrected separately from this source change. A reboot/logout login cycle and hardware acceptance were not performed. This branch is independent of #80 and #81.
