### PR TITLE
Window: repair autostart only where needed and keep the mixer sizing limits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/Op
 
 The window layout test runs in its own process using X11 and isolated
 configuration, runtime and session-bus settings. It checks narrow plugin
-windows and mixer widths from 760 to 2400 logical pixels. Set
+windows and mixer widths from 640 to 2400 logical pixels. Set
 `OPENXLR_LAYOUT_ARTIFACTS` to a directory to save rendered previews.
 
 If you add or change a NuGet package, regenerate the lock files with a

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -109,12 +109,15 @@ on the original Wave XLR. See [hardware support](hardware-support.md).
 <a name="tasks"></a>
 ## 3. Tasks
 
-The mixer cards fill the window width when it is enlarged. The main
-window has a minimum width of 760 logical pixels; shorter windows scroll
-vertically. Mix master cards wrap onto additional rows when needed.
-Long plugin names are shortened with an ellipsis, with the full name in
-the tooltip. Plugin control and chain windows keep actions below their
-headings, and actions wrap when space is limited.
+The mixer cards follow the window width, up to a limit of 1300 logical
+pixels, so faders and dropdowns keep a usable length on a maximized
+ultrawide instead of stretching across the screen. The window has no
+minimum width of its own: it squeezes down to about 640 pixels, where
+the widest row, the seven input toggles, still fits. A window shorter
+than its content scrolls vertically. Mix master cards wrap onto further
+rows when needed. Long plugin names are shortened with an ellipsis, with
+the full name in the tooltip. Plugin control and chain windows keep
+actions below their headings, and actions wrap when space is limited.
 
 <a name="mic-to-call"></a>
 ### 3.1 Send your microphone to a call or a recording
@@ -523,22 +526,39 @@ Options, STARTUP:
 
 - "Start audio service at login (background only)" enables the daemon's
   systemd user service. On a packaged install this is the package's own
-  unit. This does not start the mixer window or create a tray icon.
-- "Start mixer window and tray icon at login" adds a desktop autostart
-  entry for the window, including on KDE Plasma and CachyOS. When this
-  preference is on, a manual launch repairs a missing entry or updates
-  its executable path after an installation moves. Desktop-specific
-  settings, including an external `Hidden=true` disable, are preserved.
-  Failed changes show an error in Options and keep the previous preference.
+  unit. This does not start the mixer window or create a tray icon. If
+  the service cannot be enabled or disabled, Options says so and keeps
+  the previous preference rather than saving one the system does not have.
+- "Start mixer window and tray icon at login" writes a desktop autostart
+  entry for the window in `~/.config/autostart/openxlr.desktop`,
+  including on KDE Plasma and CachyOS. The file is written the way any
+  desktop application writes there: the folder keeps its own permissions,
+  the entry gets the ordinary permissions your system gives new files,
+  and an entry you turned into a symbolic link is never replaced. Failed
+  changes show an error in Options and keep the previous preference.
+- While that preference is on, a launch repairs the entry only where a
+  repair is needed, and only once per installation path:
+  - an entry whose command still exists is left exactly as it is, so a
+    command you edited yourself keeps working;
+  - an entry whose command points at a program that is gone gets this
+    installation's path, keeping every other line, including a
+    `Hidden=true` disable written by a desktop autostart editor;
+  - an entry that has disappeared is created again only when OpenXLR
+    moved since it last wrote one. If you removed the entry yourself
+    with a desktop tool, it stays removed and Options says so; turn the
+    option off and on again to get it back.
 - With "Close button minimizes to tray", the window hides instead of
   quitting; the tray icon's "Show mixer" menu item restores it, including
   when the window was minimized. "Quit OpenXLR" exits even with
-  close-to-tray enabled. Closing only hides the window when its tray
-  icon was created successfully. "Start
-  minimized to tray" starts with no window at all; the tray icon shows
-  it the first time you click it. This changes how the window opens; it
-  does not enable autostart. For a tray icon at login, enable both the
-  mixer-at-login option and "Start minimized to tray".
+  close-to-tray enabled. The close button always hides the window when
+  this option is on: a Linux desktop gives an application no way to find
+  out whether a system tray is there, so OpenXLR cannot fall back to
+  quitting when there is none. On a desktop with no tray, leave this
+  option off. "Start minimized to tray" starts with no window at all; the
+  tray icon shows it the first time you click it, and with no tray there
+  is nothing to click, so leave that off too. It changes how the window
+  opens; it does not enable autostart. For a tray icon at login, enable
+  both the mixer-at-login option and "Start minimized to tray".
 - Only one window runs per user. Starting OpenXLR again, from the menu
   or a shell, brings the running window to the front (out of the tray
   if it is hidden there) instead of opening a second one.

--- a/src/OpenXLR.Tests/TrayWindowTests.cs
+++ b/src/OpenXLR.Tests/TrayWindowTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
@@ -8,10 +9,23 @@ namespace OpenXLR.Tests;
 [Collection("xdg-config")]
 public sealed class TrayWindowTests
 {
+    /// <summary>
+    /// The entry point the X11 backend calls from its event loop when the
+    /// window manager asks the window to close. Used for the reasons no
+    /// window manager can send, such as a session shutdown.
+    /// </summary>
     private static bool NativeClose(Window window, WindowCloseReason reason)
         => (bool)typeof(Window).GetMethod("HandleClosing",
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .Invoke(window, [reason])!;
+
+    /// <summary>Run the platform loop briefly, so X11 events and posted jobs are delivered.</summary>
+    private static void Pump(TimeSpan duration)
+    {
+        using var stop = new CancellationTokenSource();
+        DispatcherTimer.RunOnce(stop.Cancel, duration);
+        Dispatcher.UIThread.MainLoop(stop.Token);
+    }
 
     // Run in a separate test process under Xvfb: Avalonia owns one UI thread.
     [DesktopFact]
@@ -34,52 +48,79 @@ public sealed class TrayWindowTests
                 Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", config);
                 new UiSettings { MinimizeToTray = true }.Save();
                 AppBuilder.Configure<App>().UseSkia().UseHarfBuzz().UseX11().SetupWithoutStarting();
-                window = new MainWindow();
+                window = NewWindow();
                 window.ShowMixer();
                 bool closed = false;
                 window.Closed += (_, _) => closed = true;
 
+                // The window's own Closing handler runs first, so this one
+                // sees what it left behind when the native callback returns.
+                bool? visibleWhenClosingReturned = null;
+                window.Closing += (_, _) => visibleWhenClosingReturned = window.IsVisible;
+
+                // The window manager's close request, as the title bar X sends
+                // it: a real WM_DELETE_WINDOW client message through the X11
+                // event loop, not a direct call into the window.
+                Pump(TimeSpan.FromMilliseconds(200));
+                SendDeleteWindow(window);
+                Pump(TimeSpan.FromMilliseconds(300));
+                Assert.True(visibleWhenClosingReturned,
+                    "The window was unmapped inside the native close callback instead of after it.");
+                Assert.False(window.IsVisible);
+                Assert.False(closed);
+
                 for (int i = 0; i < 3; i++)
                 {
-                    // Exercise the platform's close callback, as the title-bar X does.
+                    window.ShowMixer();
+                    Assert.True(window.IsVisible);
+                    visibleWhenClosingReturned = null;
                     Assert.True(NativeClose(window, WindowCloseReason.WindowClosing));
+                    Assert.True(visibleWhenClosingReturned);
                     Assert.True(window.IsVisible);
                     Assert.False(closed);
                     Dispatcher.UIThread.RunJobs();
                     Assert.False(window.IsVisible);
                     Assert.False(closed);
-                    window.ShowMixer();
-                    Assert.True(window.IsVisible);
                 }
 
-                window.WindowState = WindowState.Minimized;
+                // A new launch arriving before the deferred hide keeps the
+                // mixer open: the queued hide must find itself cancelled.
                 window.ShowMixer();
-                Assert.Equal(WindowState.Normal, window.WindowState);
-
-                // A new launch arriving before the deferred hide keeps the mixer open.
                 window.Close();
+                Assert.True(window.IsVisible, "The hide ran inside the close callback.");
                 window.ShowMixer();
                 Dispatcher.UIThread.RunJobs();
                 Assert.True(window.IsVisible);
 
                 // Quit wins even when a hide is still queued.
                 window.Close();
+                Assert.True(window.IsVisible, "The hide ran inside the close callback.");
                 window.Quit();
                 Dispatcher.UIThread.RunJobs();
                 Assert.True(closed);
                 Assert.False(window.IsVisible);
 
-                window = new MainWindow();
+                // A session shutdown is never intercepted: cancelling it would
+                // stop the machine from logging out.
+                window = NewWindow();
                 window.ShowMixer();
                 Assert.False(NativeClose(window, WindowCloseReason.ApplicationShutdown));
                 window.ShowMixer();
                 Assert.False(window.IsVisible);
 
+                // With close-to-tray off the close button really closes, and
+                // it does so with no tray host on this session bus: Avalonia
+                // reports none either way, so the option is taken at its word.
                 new UiSettings { MinimizeToTray = false }.Save();
-                window = new MainWindow();
+                window = NewWindow();
                 window.ShowMixer();
                 window.Close();
                 Assert.False(window.IsVisible);
+
+                // Starting minimized is honoured whether or not a tray is there.
+                new UiSettings { StartMinimized = true }.Save();
+                window = NewWindow();
+                Assert.True(window.StartsHidden);
             }
             catch (Exception ex) { failure = ex; }
             finally
@@ -95,6 +136,74 @@ public sealed class TrayWindowTests
         thread.Start();
         Assert.True(thread.Join(TimeSpan.FromSeconds(30)), "The window lifecycle hung.");
         if (failure is not null) System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    /// <summary>
+    /// A window whose daemon link points at a port nothing serves, so the
+    /// developer's running daemon never takes part in the test.
+    /// </summary>
+    private static MainWindow NewWindow() => new(new DaemonClient("ws://127.0.0.1:1/ws"));
+
+    // WindowState is not asserted here: with no window manager under Xvfb the
+    // property reads back Normal whatever it is set to, so a minimize and a
+    // restore cannot be told apart. That one belongs on a real desktop.
+
+    private const int ClientMessage = 33;
+    private const long NoEventMask = 0;
+
+    [DllImport("libX11.so.6")] private static extern IntPtr XOpenDisplay(string? name);
+    [DllImport("libX11.so.6")] private static extern int XCloseDisplay(IntPtr display);
+    [DllImport("libX11.so.6")] private static extern IntPtr XInternAtom(IntPtr display, string name, bool onlyIfExists);
+    [DllImport("libX11.so.6")] private static extern int XSendEvent(IntPtr display, IntPtr window, bool propagate, IntPtr mask, ref XClientMessageEvent e);
+    [DllImport("libX11.so.6")] private static extern int XFlush(IntPtr display);
+
+    /// <summary>
+    /// An XEvent carrying a ClientMessage. Padded to the size of the XEvent
+    /// union (24 machine words) because Xlib reads that much.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XClientMessageEvent
+    {
+        public int Type;
+        public IntPtr Serial;
+        public int SendEvent;
+        public IntPtr Display;
+        public IntPtr Window;
+        public IntPtr MessageType;
+        public int Format;
+        public IntPtr Data0;
+        public IntPtr Data1;
+        public IntPtr Data2;
+        public IntPtr Data3;
+        public IntPtr Data4;
+        private readonly IntPtr _pad0, _pad1, _pad2, _pad3, _pad4, _pad5, _pad6, _pad7, _pad8, _pad9, _pad10, _pad11;
+    }
+
+    /// <summary>
+    /// Send the window manager's close request to a mapped window, the way a
+    /// title bar X does. Xvfb runs no window manager, so the message comes
+    /// from here; the X11 backend cannot tell the difference.
+    /// </summary>
+    private static void SendDeleteWindow(Window window)
+    {
+        IntPtr handle = window.TryGetPlatformHandle()!.Handle;
+        IntPtr display = XOpenDisplay(null);
+        Assert.NotEqual(IntPtr.Zero, display);
+        try
+        {
+            var message = new XClientMessageEvent
+            {
+                Type = ClientMessage,
+                Format = 32,
+                Display = display,
+                Window = handle,
+                MessageType = XInternAtom(display, "WM_PROTOCOLS", false),
+                Data0 = XInternAtom(display, "WM_DELETE_WINDOW", false),
+            };
+            Assert.NotEqual(0, XSendEvent(display, handle, false, (IntPtr)NoEventMask, ref message));
+            XFlush(display);
+        }
+        finally { XCloseDisplay(display); }
     }
 }
 

--- a/src/OpenXLR.Tests/WindowAutostartTests.cs
+++ b/src/OpenXLR.Tests/WindowAutostartTests.cs
@@ -1,3 +1,5 @@
+using Avalonia.Controls;
+using Avalonia.Data;
 using OpenXLR.UI;
 
 namespace OpenXLR.Tests;
@@ -7,7 +9,8 @@ public sealed class WindowAutostartTests : IDisposable
 {
     private readonly string _home = Path.Combine(Path.GetTempPath(), "openxlr-autostart-" + Guid.NewGuid());
     private readonly string? _oldConfig = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-    private string Entry => Path.Combine(_home, "autostart", "openxlr.desktop");
+    private string AutostartDir => Path.Combine(_home, "autostart");
+    private string Entry => Path.Combine(AutostartDir, "openxlr.desktop");
     private string Executable => Path.Combine(_home, "My Build", "OpenXLR.UI");
 
     public WindowAutostartTests()
@@ -23,6 +26,24 @@ public sealed class WindowAutostartTests : IDisposable
         Directory.Delete(_home, true);
     }
 
+    /// <summary>Settings that ask for the window at login, with no entry written yet.</summary>
+    private static UiSettings Enabled(string? writtenFor = null)
+        => new() { OpenWindowAtLogin = true, AutostartExecutable = writtenFor };
+
+    /// <summary>The lines of the [Desktop Entry] group, in file order.</summary>
+    private string[] DesktopGroup()
+    {
+        string[] lines = File.ReadAllLines(Entry);
+        int start = Array.FindIndex(lines, l => l.Trim() == "[Desktop Entry]");
+        Assert.True(start >= 0, "The file has no [Desktop Entry] group.");
+        int end = Array.FindIndex(lines, start + 1, l => l.TrimStart().StartsWith('['));
+        return lines[(start + 1)..(end < 0 ? lines.Length : end)];
+    }
+
+    private string[] ExecValues()
+        => [.. DesktopGroup().Where(l => StartupIntegration.DesktopKey(l) == "Exec")
+            .Select(StartupIntegration.DesktopValue)];
+
     [Fact]
     public void EnablingCreatesAQuotedDesktopEntryAndDisablingRemovesIt()
     {
@@ -30,7 +51,7 @@ public sealed class WindowAutostartTests : IDisposable
         string entry = File.ReadAllText(Entry);
         Assert.Contains("[Desktop Entry]", entry);
         Assert.Contains("Type=Application", entry);
-        Assert.Contains("Exec=" + StartupIntegration.DesktopExec(Executable), entry);
+        Assert.Equal([StartupIntegration.DesktopExec(Executable)], ExecValues());
         Assert.DoesNotContain("OnlyShowIn", entry);
         Assert.DoesNotContain("Hidden=true", entry);
         Assert.True(StartupIntegration.SetWindowAtLogin(false, Executable));
@@ -38,17 +59,85 @@ public sealed class WindowAutostartTests : IDisposable
         Assert.True(StartupIntegration.SetWindowAtLogin(false, Executable));
     }
 
+    /// <summary>
+    /// Turning the option off with no ~/.config/autostart at all: File.Delete
+    /// reports a missing directory, and that is the state the caller asked for.
+    /// </summary>
+    [Fact]
+    public void DisablingSucceedsWithNoAutostartDirectory()
+    {
+        Assert.False(Directory.Exists(AutostartDir));
+        Assert.True(StartupIntegration.SetWindowAtLogin(false, Executable));
+        Assert.False(Directory.Exists(AutostartDir));
+    }
+
+    /// <summary>
+    /// ~/.config/autostart belongs to the desktop. Writing the entry must not
+    /// make the directory private, and the entry itself gets the mode the
+    /// umask gives any other file written there, not 0600.
+    /// </summary>
+    [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("linux")]   // file modes are a Unix matter
+    public void WritingTheEntryLeavesTheSharedDirectoryAndFileModesAlone()
+    {
+        Directory.CreateDirectory(AutostartDir);
+        UnixFileMode directoryBefore = File.GetUnixFileMode(AutostartDir);
+        string reference = Path.Combine(AutostartDir, "reference.desktop");
+        File.WriteAllText(reference, "reference\n");
+        UnixFileMode umaskMode = File.GetUnixFileMode(reference);
+
+        Assert.True(StartupIntegration.SetWindowAtLogin(true, Executable));
+
+        Assert.Equal(directoryBefore, File.GetUnixFileMode(AutostartDir));
+        Assert.Equal(umaskMode, File.GetUnixFileMode(Entry));
+        Assert.Empty(Directory.GetFiles(AutostartDir, "*.openxlr-tmp"));
+    }
+
+    /// <summary>
+    /// A symlinked entry points at a file somebody else manages. Replacing it
+    /// with a regular file, or writing through it, is not OpenXLR's call.
+    /// </summary>
+    [Fact]
+    public void ASymlinkedEntryIsRefusedRatherThanReplaced()
+    {
+        Directory.CreateDirectory(AutostartDir);
+        string managed = Path.Combine(_home, "managed.desktop");
+        File.WriteAllText(managed, "[Desktop Entry]\nType=Application\nExec=managed\n");
+        File.CreateSymbolicLink(Entry, managed);
+
+        Assert.False(StartupIntegration.SetWindowAtLogin(true, Executable));
+        Assert.Equal(managed, new FileInfo(Entry).LinkTarget);
+        Assert.Equal("[Desktop Entry]\nType=Application\nExec=managed\n", File.ReadAllText(managed));
+    }
+
     [Fact]
     public void EnabledPreferenceRepairsAMissingEntryAndIsIdempotent()
     {
-        var settings = new UiSettings { OpenWindowAtLogin = true };
-        Assert.True(StartupIntegration.RepairWindowAutostart(settings, Executable));
+        var settings = Enabled(writtenFor: Path.Combine(_home, "Older Build", "OpenXLR.UI"));
+        Assert.Equal(StartupIntegration.AutostartRepair.Repaired,
+            StartupIntegration.RepairWindowAutostart(settings, Executable));
         string entry = File.ReadAllText(Entry);
         var marker = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         File.SetLastWriteTimeUtc(Entry, marker);
-        Assert.True(StartupIntegration.RepairWindowAutostart(settings, Executable));
+        Assert.Equal(StartupIntegration.AutostartRepair.NotNeeded,
+            StartupIntegration.RepairWindowAutostart(settings, Executable));
         Assert.Equal(entry, File.ReadAllText(Entry));
         Assert.Equal(marker, File.GetLastWriteTimeUtc(Entry));
+    }
+
+    /// <summary>
+    /// The entry is gone and the recorded launch path is still this one, so
+    /// somebody removed it on purpose with a desktop tool. Putting it back
+    /// every launch would make that removal impossible.
+    /// </summary>
+    [Fact]
+    public void AnEntryRemovedOutsideOpenXlrIsNotRecreated()
+    {
+        Assert.Equal(StartupIntegration.AutostartRepair.RemovedOutside,
+            StartupIntegration.RepairWindowAutostart(Enabled(writtenFor: Executable), Executable));
+        Assert.False(File.Exists(Entry));
+        Assert.Contains("removed outside OpenXLR",
+            OptionsViewModel.RepairNote(StartupIntegration.AutostartRepair.RemovedOutside));
     }
 
     [Fact]
@@ -56,7 +145,8 @@ public sealed class WindowAutostartTests : IDisposable
     {
         var settings = new UiSettings { StartDaemonAtLogin = true, StartMinimized = true };
         settings.Save();
-        Assert.True(StartupIntegration.RepairWindowAutostart(settings, Executable));
+        Assert.Equal(StartupIntegration.AutostartRepair.NotNeeded,
+            StartupIntegration.RepairWindowAutostart(settings, Executable));
         Assert.False(File.Exists(Entry));
         var client = new DaemonClient();
         var options = new OptionsViewModel(client, new MainViewModel(client));
@@ -66,28 +156,105 @@ public sealed class WindowAutostartTests : IDisposable
         Assert.Contains("does not enable autostart", options.StartupHint);
     }
 
+    /// <summary>
+    /// An Exec whose program is gone is replaced in place, inside the entry's
+    /// own group, leaving every other key and every other group alone.
+    /// </summary>
     [Theory]
     [InlineData("Exec=\"/old/build/OpenXLR.UI\"\n")]
+    [InlineData("Exec = \"/old/build/OpenXLR.UI\"\n")]   // the spec allows space around '='
     [InlineData("")]
     public void RepairsLaunchPathWithoutRemovingDesktopPreferences(string exec)
     {
-        Directory.CreateDirectory(Path.GetDirectoryName(Entry)!);
+        Directory.CreateDirectory(AutostartDir);
         File.WriteAllText(Entry, "[Desktop Entry]\nType=Application\n" + exec +
             "Hidden=true\nX-KDE-autostart-after=panel\n[Desktop Action Manual]\nExec=manual-command\n");
-        Assert.True(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable));
+        Assert.Equal(StartupIntegration.AutostartRepair.Repaired,
+            StartupIntegration.RepairWindowAutostart(Enabled(), Executable));
+
+        // Exactly one Exec key in [Desktop Entry], naming this build:
+        // desktop-file-validate rejects a duplicated key.
+        Assert.Equal([StartupIntegration.DesktopExec(Executable)], ExecValues());
         string entry = File.ReadAllText(Entry);
-        Assert.Contains("Exec=" + StartupIntegration.DesktopExec(Executable), entry);
+        Assert.DoesNotContain("/old/build/OpenXLR.UI", entry);
         Assert.Contains("Hidden=true", entry);
         Assert.Contains("X-KDE-autostart-after=panel", entry);
         Assert.Contains("[Desktop Action Manual]\nExec=manual-command", entry);
     }
+
+    /// <summary>A duplicated Exec key, however it got there, leaves one behind.</summary>
+    [Fact]
+    public void RepairLeavesOneExecKeyWhenTheEntryAlreadyHadTwo()
+    {
+        Directory.CreateDirectory(AutostartDir);
+        File.WriteAllText(Entry, "[Desktop Entry]\nType=Application\nExec=/gone/one\nExec = /gone/two\nName=OpenXLR\n");
+        Assert.Equal(StartupIntegration.AutostartRepair.Repaired,
+            StartupIntegration.RepairWindowAutostart(Enabled(), Executable));
+        Assert.Equal([StartupIntegration.DesktopExec(Executable)], ExecValues());
+        Assert.Contains("Name=OpenXLR", File.ReadAllText(Entry));
+    }
+
+    /// <summary>
+    /// A command that still runs is the user's, whatever it is: a wrapper
+    /// script, a bare command on PATH, an Exec they edited by hand.
+    /// </summary>
+    [Theory]
+    [InlineData("Exec={0}\n")]
+    [InlineData("Exec = {0} --minimized\n")]
+    [InlineData("Exec=\"{0}\"\n")]
+    public void AnExecWhoseProgramStillExistsIsNeverRewritten(string template)
+    {
+        string theirs = Path.Combine(_home, "their-launcher");
+        File.WriteAllText(theirs, "#!/bin/sh\n");
+        Directory.CreateDirectory(AutostartDir);
+        string text = "[Desktop Entry]\nType=Application\n" + string.Format(template, theirs) + "Name=OpenXLR\n";
+        File.WriteAllText(Entry, text);
+        Assert.Equal(StartupIntegration.AutostartRepair.NotNeeded,
+            StartupIntegration.RepairWindowAutostart(Enabled(), Executable));
+        Assert.Equal(text, File.ReadAllText(Entry));
+    }
+
+    /// <summary>The same for a bare command the desktop resolves on PATH.</summary>
+    [Fact]
+    public void AnExecNamingACommandOnPathIsNeverRewritten()
+    {
+        string bin = Path.Combine(_home, "bin");
+        Directory.CreateDirectory(bin);
+        File.WriteAllText(Path.Combine(bin, "openxlr"), "#!/bin/sh\n");
+        string? oldPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", bin);
+        try
+        {
+            Directory.CreateDirectory(AutostartDir);
+            string text = "[Desktop Entry]\nType=Application\nExec=openxlr %U\n";
+            File.WriteAllText(Entry, text);
+            Assert.Equal(StartupIntegration.AutostartRepair.NotNeeded,
+                StartupIntegration.RepairWindowAutostart(Enabled(), Executable));
+            Assert.Equal(text, File.ReadAllText(Entry));
+        }
+        finally { Environment.SetEnvironmentVariable("PATH", oldPath); }
+    }
+
+    /// <summary>
+    /// What this window wrote reads back as the path it was given, through
+    /// both escaping layers: spaces, quotes, backslashes, '$' and '%'.
+    /// </summary>
+    [Theory]
+    [InlineData("/home/u/My Build/OpenXLR.UI")]
+    [InlineData("/home/u/100% mine/OpenXLR.UI")]
+    [InlineData("/home/u/$HOME `x`/OpenXLR.UI")]
+    [InlineData("/home/u/back\\slash/OpenXLR.UI")]
+    [InlineData("/home/u/quo\"te/OpenXLR.UI")]
+    public void AnExecThisWindowWroteReadsBackAsThePath(string path)
+        => Assert.Equal(path, StartupIntegration.DesktopExecBinary(StartupIntegration.DesktopExec(path)));
 
     [Fact]
     public void MissingBinaryDoesNotOverwriteAnExistingEntry()
     {
         Assert.True(StartupIntegration.SetWindowAtLogin(true, Executable));
         string before = File.ReadAllText(Entry);
-        Assert.False(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable + ".missing"));
+        Assert.Equal(StartupIntegration.AutostartRepair.Failed,
+            StartupIntegration.RepairWindowAutostart(Enabled(), Executable + ".missing"));
         Assert.False(StartupIntegration.SetWindowAtLogin(true, Executable + ".missing"));
         Assert.Equal(before, File.ReadAllText(Entry));
     }
@@ -111,12 +278,38 @@ public sealed class WindowAutostartTests : IDisposable
         Assert.Null(options.StartupError);
     }
 
+    /// <summary>
+    /// The check box itself has to go back, not just the view model: it has
+    /// already drawn the state the user asked for. This binds a real
+    /// CheckBox, which needs no windowing platform, and drives it the way the
+    /// control does when it is clicked.
+    /// </summary>
+    [Fact]
+    public void ARejectedToggleSnapsTheCheckBoxBack()
+    {
+        new UiSettings { OpenWindowAtLogin = true }.Save();
+        Directory.CreateDirectory(Entry); // Disabling cannot remove a directory.
+        var client = new DaemonClient();
+        var options = new OptionsViewModel(client, new MainViewModel(client));
+        var box = new CheckBox { DataContext = options };
+        box.Bind(CheckBox.IsCheckedProperty,
+            new Binding { Path = nameof(OptionsViewModel.OpenWindowAtLogin), Mode = BindingMode.TwoWay });
+        Assert.True(box.IsChecked);
+
+        box.IsChecked = false;   // what a click does before the binding writes back
+
+        Assert.True(options.OpenWindowAtLogin);
+        Assert.True(box.IsChecked);
+        Assert.NotNull(options.StartupError);
+    }
+
     [Fact]
     public void WriteFailureReturnsFalseInsteadOfCrashing()
     {
-        File.WriteAllText(Path.Combine(_home, "autostart"), "not a directory");
+        File.WriteAllText(AutostartDir, "not a directory");
         Assert.False(StartupIntegration.SetWindowAtLogin(true, Executable));
-        Assert.False(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable));
+        Assert.Equal(StartupIntegration.AutostartRepair.Failed,
+            StartupIntegration.RepairWindowAutostart(Enabled(), Executable));
     }
 
     [Theory]
@@ -147,9 +340,10 @@ public sealed class WindowAutostartTests : IDisposable
     [Fact]
     public void EnabledPreferenceReplacesAnEntryWithoutADesktopGroup()
     {
-        Directory.CreateDirectory(Path.GetDirectoryName(Entry)!);
+        Directory.CreateDirectory(AutostartDir);
         File.WriteAllText(Entry, "incomplete file");
-        Assert.True(StartupIntegration.RepairWindowAutostart(new() { OpenWindowAtLogin = true }, Executable));
+        Assert.Equal(StartupIntegration.AutostartRepair.Repaired,
+            StartupIntegration.RepairWindowAutostart(Enabled(), Executable));
         Assert.Contains("[Desktop Entry]", File.ReadAllText(Entry));
     }
 }

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -12,6 +12,15 @@ namespace OpenXLR.Tests;
 [Collection("xdg-config")]
 public sealed class WindowLayoutTests
 {
+    /// <summary>
+    /// The widest fixed row in the mixer, the seven input toggles, needs about
+    /// 660 logical pixels. The window must not refuse to go narrower than that.
+    /// </summary>
+    private const double WidestFixedRow = 660;
+
+    /// <summary>Faders and dropdowns stop growing here, however wide the screen is.</summary>
+    private const double ContentCap = 1300;
+
     [LayoutFact]
     public void NarrowPluginWindowsKeepActionsSeparateAndMixerFillsWideWindows()
     {
@@ -49,23 +58,60 @@ public sealed class WindowLayoutTests
                     vm.Mixes.Add(mix);
                 }
                 main.Show();
-                foreach (double width in new[] { 760d, 1040, 1800, 2400 })
+
+                // No floor above the widest row: the window squeezes to 640.
+                Assert.InRange(main.MinWidth, 0, WidestFixedRow);
+
+                foreach (double width in new[] { 640d, 760, 1040, 1800, 2400 })
                 {
                     Layout(main, width, 900);
+                    Assert.Equal(width, main.ClientSize.Width);
                     var content = main.FindControl<StackPanel>("MixerContent")!;
-                    Assert.True(Math.Abs(content.Bounds.Width - (width - 32)) < 28,
-                        $"Requested {width}, window {main.Width}/{main.Bounds.Width}, client {main.ClientSize.Width}, content {content.Bounds.Width}");
-                    foreach (var name in main.GetVisualDescendants().OfType<TextBlock>()
-                                 .Where(t => t.Classes.Contains("insertName")))
+                    string where = $"Requested {width}, window {main.Width}/{main.Bounds.Width}, "
+                        + $"client {main.ClientSize.Width}, content {content.Bounds.Width}";
+                    // Below the cap the cards follow the window; above it they
+                    // stop, so a fader does not stretch across an ultrawide.
+                    Assert.True(content.Bounds.Width <= ContentCap, where);
+                    if (width <= ContentCap) Assert.InRange(content.Bounds.Width, width - 72, width - 16);
+                    else Assert.InRange(content.Bounds.Width, ContentCap / 2, ContentCap);
+
+                    // Every input toggle keeps a usable width and stays in the window.
+                    foreach (var row in main.GetVisualDescendants().OfType<Avalonia.Controls.Primitives.UniformGrid>())
+                        foreach (var toggle in row.Children.Where(c => c.IsVisible))
+                        {
+                            Assert.True(toggle.Bounds.Width > 40, $"A toggle shrank to {toggle.Bounds.Width}. {where}");
+                            AssertInside(toggle, main);
+                        }
+
+                    // XLR 1, XLR 2, and the chain line inside each of the eight
+                    // mix cards. A template that loses the class loses a row here.
+                    var names = main.GetVisualDescendants().OfType<TextBlock>()
+                        .Where(t => t.Classes.Contains("insertName")).ToArray();
+                    Assert.Equal(10, names.Length);
+                    foreach (var name in names)
                     {
                         AssertInside(name, (Control)name.Parent!);
+                        AssertInside(name, main);
                         AssertNoOverlap(((Grid)name.Parent!).Children.Where(c => c.IsVisible).ToArray());
                     }
+
                     var masters = main.GetVisualDescendants().OfType<Border>()
                         .Where(b => b.DataContext is MixViewModel && b.Width == 232).ToArray();
                     Assert.Equal(8, masters.Length);
                     AssertNoOverlap(masters);
-                    foreach (var master in masters) AssertInside(master, (Control)master.Parent!);
+                    foreach (var master in masters)
+                    {
+                        AssertInside(master, content);
+                        // The card's own contents: the mix name, its fader and
+                        // its chain line all have to fit inside the card.
+                        var inside = master.GetVisualDescendants().OfType<Control>()
+                            .Where(c => c is TextBlock or Slider or Button && c.IsVisible && c.Bounds.Width > 0).ToArray();
+                        Assert.NotEmpty(inside);
+                        foreach (var child in inside) AssertInside(child, master);
+                        Assert.Single(master.GetVisualDescendants().OfType<TextBlock>(),
+                            t => t.Classes.Contains("insertName"));
+                        Assert.Single(master.GetVisualDescendants().OfType<Slider>());
+                    }
                     Capture(main, "mixer-" + width);
                     var page = main.GetVisualDescendants().OfType<ScrollViewer>().First();
                     page.Offset = new Vector(0, page.Extent.Height);
@@ -73,7 +119,6 @@ public sealed class WindowLayoutTests
                     Capture(main, "mixes-" + width);
                     page.Offset = default;
                 }
-                Assert.True(main.MinWidth >= 700);
 
                 var insert = vm.Inserts.Items[0];
                 var controls = new InsertControlsWindow { DataContext = insert };
@@ -86,12 +131,16 @@ public sealed class WindowLayoutTests
                     var actions = controls.FindControl<WrapPanel>("PluginActions")!;
                     Assert.True(title.TranslatePoint(default, controls)!.Value.Y + title.Bounds.Height <=
                                 actions.TranslatePoint(default, controls)!.Value.Y);
-                    Assert.Equal(5, actions.Children.Count(c => c.IsVisible));
+                    var buttons = actions.Children.Where(c => c.IsVisible).ToArray();
+                    Assert.Equal(5, buttons.Length);
                     Assert.Single(controls.GetVisualDescendants().OfType<Slider>());
-                    foreach (var button in actions.Children.Where(c => c.IsVisible))
-                        AssertInside(button, actions);
-                    Assert.True(actions.Children.Where(c => c.IsVisible).All(c => c.Bounds.Width > 20));
-                    AssertNoOverlap(actions.Children.Where(c => c.IsVisible).ToArray());
+                    // In one row the five actions need about 454 px, so at 420
+                    // they have to wrap rather than run off the window.
+                    foreach (var button in buttons)
+                    {
+                        Assert.True(button.Bounds.Width > 20);
+                        AssertInside(button, controls);
+                    }
                     var slider = controls.GetVisualDescendants().OfType<Slider>().Single();
                     AssertNoOverlap(((Grid)slider.Parent!).Children.Where(c => c.IsVisible).ToArray());
                     Capture(controls, "plugin-" + width);
@@ -109,9 +158,16 @@ public sealed class WindowLayoutTests
                 var label = chain.GetVisualDescendants().OfType<TextBlock>()
                     .Single(t => t.Classes.Contains("insertName"));
                 AssertInside(label, (Control)label.Parent!);
+                AssertInside(label, chain);
                 foreach (var actions in chain.GetVisualDescendants().OfType<WrapPanel>())
+                {
+                    Assert.NotEmpty(actions.Children);
                     foreach (var button in actions.Children)
+                    {
                         AssertInside(button, actions);
+                        AssertInside(button, chain);
+                    }
+                }
                 Capture(chain, "chain-440");
             }
             catch (Exception ex) { failure = ex; }
@@ -152,12 +208,21 @@ public sealed class WindowLayoutTests
         window.UpdateLayout();
     }
 
-    private static void AssertInside(Control child, Control parent)
+    /// <summary>
+    /// The control sits inside the box of one of its ancestors, measured in
+    /// that ancestor's own coordinates, so it works for a card, a panel or the
+    /// window itself. Height is only checked against an immediate parent: a
+    /// scrolled page is taller than its window on purpose.
+    /// </summary>
+    private static void AssertInside(Control child, Visual ancestor)
     {
-        Assert.True(child.Bounds.Width > 0);
-        Assert.InRange(child.Bounds.Left, -0.1, parent.Bounds.Width);
-        Assert.InRange(child.Bounds.Right, 0, parent.Bounds.Width + 0.1);
-        Assert.InRange(child.Bounds.Bottom, 0, parent.Bounds.Height + 0.1);
+        Assert.True(child.Bounds.Width > 0, $"{child.GetType().Name} has no width.");
+        var origin = child.TranslatePoint(default, ancestor)!.Value;
+        Size box = ancestor is TopLevel top ? top.ClientSize : ancestor.Bounds.Size;
+        Assert.InRange(origin.X, -0.1, box.Width);
+        Assert.InRange(origin.X + child.Bounds.Width, 0, box.Width + 0.1);
+        if (ReferenceEquals(child.Parent, ancestor))
+            Assert.InRange(origin.Y + child.Bounds.Height, 0, box.Height + 0.1);
     }
 
     private static void AssertNoOverlap(IReadOnlyList<Control> controls)

--- a/src/OpenXLR.UI/App.axaml.cs
+++ b/src/OpenXLR.UI/App.axaml.cs
@@ -21,8 +21,10 @@ public partial class App : Application
             if (UiSettings.Load().StartDaemonAtLogin)
                 StartupIntegration.RepairDaemonUnit();
 
-            // A moved installation or deleted desktop entry must not leave
-            // an enabled mixer-at-login preference pointing nowhere.
+            // A moved installation must not leave an enabled mixer-at-login
+            // preference pointing at a binary that is gone. An entry removed
+            // with a desktop tool stays removed. Either way the outcome is
+            // kept, and Options reports anything the user should know.
             StartupIntegration.RepairWindowAutostart();
 
             var window = new MainWindow();

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -3,7 +3,7 @@
         xmlns:vm="using:OpenXLR.UI"
         x:Class="OpenXLR.UI.MainWindow"
         x:DataType="vm:MainViewModel"
-        Title="OpenXLR" Width="1040" Height="900" MinWidth="760" MinHeight="480"
+        Title="OpenXLR" Width="1040" Height="900" MinHeight="480"
         Icon="avares://OpenXLR.UI/Assets/icon.png"
         Background="#16181d">
 
@@ -143,9 +143,12 @@
     </Style>
   </Window.Styles>
 
-  <!-- Cards follow the available width. The page scrolls when it is shorter. -->
+  <!-- MaxWidth keeps sliders and dropdowns a sane length on an ultrawide or when
+       maximized; without it a fader stretches across the whole screen. Below it
+       the cards follow the available width. Every card sizes to its content;
+       the page scrolls when the window is shorter. -->
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-  <StackPanel Name="MixerContent" Margin="16" HorizontalAlignment="Stretch">
+  <StackPanel Name="MixerContent" Margin="16" MaxWidth="1300" HorizontalAlignment="Center">
 
     <!-- header -->
     <Border Classes="card" Margin="0,0,0,8">
@@ -613,8 +616,9 @@
                         <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,2,0,0">
                           <Ellipse Width="8" Height="8" VerticalAlignment="Center" Margin="0,0,6,0"
                                    Fill="{Binding IsActive, Converter={x:Static vm:Converters.ActiveLed}}"/>
-                          <TextBlock Grid.Column="1" Text="{Binding Label}" Foreground="#e6e9f0" FontSize="11"
-                                     VerticalAlignment="Center" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
+                          <TextBlock Grid.Column="1" Text="{Binding Label}" Classes="insertName"
+                                     Foreground="#e6e9f0" FontSize="11" VerticalAlignment="Center"
+                                     TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Label}"/>
                           <ToggleButton Grid.Column="2" Content="N" Classes="insertmini"
                                         IsChecked="{Binding NativeHost, Mode=TwoWay}"
                                         IsVisible="{Binding CanChooseNativeHost}"

--- a/src/OpenXLR.UI/MainWindow.axaml.cs
+++ b/src/OpenXLR.UI/MainWindow.axaml.cs
@@ -13,7 +13,7 @@ namespace OpenXLR.UI;
 
 public partial class MainWindow : Window
 {
-    private readonly DaemonClient _client = new();
+    private readonly DaemonClient _client;
     private readonly MainViewModel _vm;
     private TrayIcon? _tray;
     private bool _reallyExit;
@@ -21,8 +21,15 @@ public partial class MainWindow : Window
     private readonly CancellationTokenSource _lifetime = new();
     private bool _automaticUpdateCheckStarted;
 
-    public MainWindow()
+    public MainWindow() : this(new DaemonClient()) { }
+
+    /// <summary>
+    /// For the window tests, which point the client at a port nothing serves
+    /// so a developer's running daemon is not part of the test.
+    /// </summary>
+    internal MainWindow(DaemonClient client)
     {
+        _client = client;
         InitializeComponent();
         _vm = new MainViewModel(_client);
         DataContext = _vm;
@@ -37,11 +44,19 @@ public partial class MainWindow : Window
             await _vm.Updates.CheckAsync(manual: false, cancellation: _lifetime.Token);
         };
 
-        // Start hidden in the tray when configured (and a tray actually
-        // exists; otherwise the window must show or nothing is reachable).
-        // App reads this and leaves the window unshown; it is never mapped
-        // and unmapped, which is what produced a hollow frame at login.
-        StartsHidden = UiSettings.Load().StartMinimized && _tray is not null;
+        // Start hidden in the tray when configured. App reads this and leaves
+        // the window unshown; it is never mapped and unmapped, which is what
+        // produced a hollow frame at login.
+        //
+        // There is no check for a usable tray here because Avalonia 12.1.2
+        // offers none on Linux: constructing a TrayIcon always succeeds, and
+        // the implementation behind it either talks to a StatusNotifier host
+        // over D-Bus or, with no session bus, is a stub that swallows every
+        // call. Neither is reachable from public API, and the D-Bus one only
+        // learns whether a host exists after the constructor returns. So the
+        // option does what it says and the manual says what happens on a
+        // desktop with no tray.
+        StartsHidden = UiSettings.Load().StartMinimized;
 
         Closing += (_, e) =>
         {
@@ -50,7 +65,7 @@ public partial class MainWindow : Window
             // user-initiated window close is intercepted: cancelling an
             // OS/application shutdown request here blocks the whole system
             // from logging out or rebooting.
-            if (_vm.MinimizeToTray && _tray is not null && !_reallyExit &&
+            if (_vm.MinimizeToTray && !_reallyExit &&
                 e.CloseReason == WindowCloseReason.WindowClosing)
             {
                 e.Cancel = true;
@@ -124,7 +139,8 @@ public partial class MainWindow : Window
         }
         catch (Exception)
         {
-            // No tray host available: the option simply has no effect.
+            // Only the icon asset or the menu can fail here; the tray
+            // implementation itself never reports a missing host.
             _tray = null;
         }
     }

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -36,6 +36,7 @@ public sealed class OptionsViewModel : ViewModelBase
         _minimizeToTray = s.MinimizeToTray;
         _startMinimized = s.StartMinimized;
         _checkForUpdates = s.CheckForUpdates;
+        _startupError = RepairNote(StartupIntegration.LastRepair);
         // No saved choice means the daemon runs whatever its unit asked for,
         // which for every shipped unit is the submixer on.
         _submixer = DaemonPrefs.Load().Submixer ?? true;
@@ -147,8 +148,18 @@ public sealed class OptionsViewModel : ViewModelBase
         get => _startDaemonAtLogin;
         set
         {
-            if (!Set(ref _startDaemonAtLogin, value)) return;
-            StartupIntegration.SetDaemonAtLogin(value);
+            if (_startDaemonAtLogin == value) return;
+            if (!StartupIntegration.SetDaemonAtLogin(value))
+            {
+                StartupError = value
+                    ? "Could not start the audio service at login. Check that OpenXLR is installed and that systemd user services work here (systemctl --user status)."
+                    : "Could not stop the audio service from starting at login. Check that systemd user services work here (systemctl --user status).";
+                Reject(ref _startDaemonAtLogin, value, nameof(StartDaemonAtLogin));
+                return;
+            }
+            StartupError = null;
+            _startDaemonAtLogin = value;
+            Raise();
             Persist();
         }
     }
@@ -162,19 +173,45 @@ public sealed class OptionsViewModel : ViewModelBase
             if (_openWindowAtLogin == value) return;
             if (!StartupIntegration.SetWindowAtLogin(value))
             {
-                StartupError = "Could not update mixer autostart. Check that OpenXLR is installed and the autostart folder is writable.";
-                Raise(nameof(OpenWindowAtLogin));
+                StartupError = "Could not update mixer autostart. Check that OpenXLR is installed, the autostart folder is writable, and the entry there is not a symbolic link.";
+                Reject(ref _openWindowAtLogin, value, nameof(OpenWindowAtLogin));
                 return;
             }
             StartupError = null;
-            Set(ref _openWindowAtLogin, value);
+            _openWindowAtLogin = value;
+            Raise();
             Raise(nameof(StartupHint));
             Persist();
         }
     }
 
+    /// <summary>
+    /// Put a rejected toggle back where it was. The check box has already
+    /// drawn itself in the new state, and a notification carrying the value
+    /// the property already had does not move it: the binding compares
+    /// against what it last wrote and pushes nothing. Publishing the rejected
+    /// value and then the real one does move it.
+    /// </summary>
+    private void Reject(ref bool field, bool rejected, string name)
+    {
+        field = rejected;
+        Raise(name);
+        field = !rejected;
+        Raise(name);
+    }
+
     private string? _startupError;
     public string? StartupError { get => _startupError; private set => Set(ref _startupError, value); }
+
+    /// <summary>What the startup repair did, in words, or null when it did nothing worth saying.</summary>
+    internal static string? RepairNote(StartupIntegration.AutostartRepair repair) => repair switch
+    {
+        StartupIntegration.AutostartRepair.RemovedOutside =>
+            "The mixer autostart entry was removed outside OpenXLR, so it was left removed. Turn this option off and on again to create it.",
+        StartupIntegration.AutostartRepair.Failed =>
+            "Could not repair the mixer autostart entry. Check that OpenXLR is installed, the autostart folder is writable, and the entry there is not a symbolic link.",
+        _ => null,
+    };
 
     public string StartupHint => OpenWindowAtLogin
         ? "The mixer and tray icon will start when you sign in."

--- a/src/OpenXLR.UI/UiSettings.cs
+++ b/src/OpenXLR.UI/UiSettings.cs
@@ -24,6 +24,13 @@ public sealed record UiSettings
     public DateTimeOffset? LastUpdateCheckUtc { get; init; }
     /// <summary>Release tag whose banner the user dismissed.</summary>
     public string? DismissedUpdate { get; init; }
+    /// <summary>
+    /// The launch path the autostart entry was last written for. The startup
+    /// repair recreates a missing entry only when this differs from the path
+    /// the running copy resolves to, so an entry removed with a desktop tool
+    /// stays removed while a moved installation is still fixed.
+    /// </summary>
+    public string? AutostartExecutable { get; init; }
     /// <summary>Names of the main window's tiles the user collapsed (INPUTS, HEADPHONES, ...).</summary>
     public IReadOnlyList<string> CollapsedSections { get; init; } = [];
 
@@ -261,21 +268,143 @@ public static class StartupIntegration
         return "\"" + inner.Replace("\\", "\\\\") + "\"";   // and once more for the string layer
     }
 
-    public static void SetDaemonAtLogin(bool enabled)
+    /// <summary>
+    /// The program an Exec value runs, as a path: the inverse of
+    /// <see cref="DesktopExec"/> for entries this window wrote, and a best
+    /// effort for entries a desktop or a user wrote by hand. Null when the
+    /// value carries no program at all.
+    /// </summary>
+    internal static string? DesktopExecBinary(string value)
+    {
+        // The desktop entry file itself escapes the value (\\ for a
+        // backslash, \s \n \t \r for whitespace); undo that first, then read
+        // the first argument under the Exec quoting rules.
+        var unescaped = new System.Text.StringBuilder();
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] != '\\' || i + 1 >= value.Length) { unescaped.Append(value[i]); continue; }
+            char next = value[++i];
+            unescaped.Append(next switch { '\\' => '\\', 's' => ' ', 'n' => '\n', 't' => '\t', 'r' => '\r', _ => next });
+            // An unknown sequence keeps the escaped character, not the backslash.
+        }
+
+        string argument = unescaped.ToString().TrimStart();
+        if (argument.Length == 0) return null;
+        var program = new System.Text.StringBuilder();
+        if (argument[0] == '"')
+        {
+            for (int i = 1; i < argument.Length; i++)
+            {
+                char c = argument[i];
+                if (c == '"') break;
+                // Inside quotes the spec reserves " ` $ \, each escaped with a backslash.
+                if (c == '\\' && i + 1 < argument.Length) { program.Append(argument[++i]); continue; }
+                program.Append(c);
+            }
+        }
+        else
+        {
+            foreach (char c in argument)
+            {
+                if (char.IsWhiteSpace(c)) break;
+                program.Append(c);
+            }
+        }
+        string result = program.ToString().Replace("%%", "%");
+        return result.Length == 0 ? null : result;
+    }
+
+    /// <summary>
+    /// True when the program an Exec value names can still be launched: an
+    /// absolute or relative path that exists, or a bare command found on PATH.
+    /// </summary>
+    internal static bool DesktopExecTargetExists(string? program)
+    {
+        if (program is not { Length: > 0 }) return false;
+        if (program.Contains(Path.DirectorySeparatorChar)) return File.Exists(program);
+        string path = Environment.GetEnvironmentVariable("PATH") ?? "";
+        return path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Any(d => File.Exists(Path.Combine(d, program)));
+    }
+
+    /// <summary>
+    /// Write one of the two startup files, both of which live in directories
+    /// the desktop and systemd own rather than in OpenXLR's own tree:
+    /// ~/.config/autostart and ~/.config/systemd/user.
+    ///
+    /// AGENTS.md requires <c>OpenXlrPaths.WriteAtomic</c> for files under
+    /// ~/.config/openxlr. These two are outside that tree and that helper is
+    /// wrong for them: it forces the directory to 0700 and the file to 0600,
+    /// which is not OpenXLR's call to make for a shared directory, and its
+    /// rename would turn an entry the user symlinked into a regular file.
+    /// So the write is still a temporary file and a rename in the same
+    /// directory, but the directory keeps its mode and the process umask
+    /// decides the file's (0644 on a default umask).
+    ///
+    /// False when the target is a symbolic link: whatever it points at
+    /// belongs to whoever made the link, so it is left untouched and the
+    /// caller reports the refusal.
+    /// </summary>
+    private static bool WriteStartupFile(string path, string text)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        if (IsSymbolicLink(path)) return false;
+        string tmp = path + ".openxlr-tmp";
+        File.WriteAllText(tmp, text);
+        File.Move(tmp, path, overwrite: true);
+        return true;
+    }
+
+    /// <summary>Remove a startup file, treating one that is already gone as done.</summary>
+    private static void RemoveStartupFile(string path)
+    {
+        // File.Delete is silent about a missing file but throws
+        // DirectoryNotFoundException when the directory itself is absent,
+        // which is the same "nothing to remove" state.
+        try { File.Delete(path); }
+        catch (DirectoryNotFoundException) { }
+    }
+
+    private static bool IsSymbolicLink(string path) => new FileInfo(path).LinkTarget is not null;
+
+    /// <summary>The autostart entry this window writes for a given executable.</summary>
+    private static string AutostartEntry(string executable) => $"""
+        [Desktop Entry]
+        Type=Application
+        Name=OpenXLR
+        Comment=OpenXLR mixer window
+        Exec={DesktopExec(executable)}
+        Icon=openxlr
+        Terminal=false
+        X-GNOME-Autostart-enabled=true
+
+        """;
+
+    /// <summary>
+    /// Apply the daemon-at-login preference. False when nothing could be
+    /// applied, so Options reports it instead of saving a preference the
+    /// system does not have.
+    /// </summary>
+    public static bool SetDaemonAtLogin(bool enabled)
+    {
+        try { return ApplyDaemonAtLogin(enabled); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return false; }
+    }
+
+    private static bool ApplyDaemonAtLogin(bool enabled)
     {
         if (enabled)
         {
             if (PackagedUnit is not null)
             {
                 // Any copy in ~/.config would shadow the packaged unit.
-                try { File.Delete(UnitPath); } catch (IOException) { }
+                try { RemoveStartupFile(UnitPath); } catch (IOException) { }
             }
             else
             {
                 // No binary anywhere we know of: a unit would only loop on 203/EXEC.
-                if (DaemonBinary is not { } daemon) return;
-                Directory.CreateDirectory(Path.GetDirectoryName(UnitPath)!);
-                File.WriteAllText(UnitPath, $"""
+                if (DaemonBinary is not { } daemon) return false;
+                if (!WriteStartupFile(UnitPath, $"""
                     # Written by the OpenXLR window for a source build (Options, Start at login).
                     [Unit]
                     Description=OpenXLR audio daemon
@@ -312,79 +441,156 @@ public static class StartupIntegration
 
                     [Install]
                     WantedBy=default.target
-                    """);
+                    """)) return false;
             }
             Systemctl("daemon-reload");
-            Systemctl("enable", UnitName);
+            return Systemctl("enable", UnitName);
         }
-        else
-        {
-            Systemctl("disable", UnitName);
-            try { File.Delete(UnitPath); } catch (IOException) { }
-            Systemctl("daemon-reload");
-        }
+        bool disabled = Systemctl("disable", UnitName);
+        try { RemoveStartupFile(UnitPath); } catch (IOException) { }
+        Systemctl("daemon-reload");
+        // systemctl refuses to disable a unit that does not exist, but an
+        // install with no unit at all already starts no daemon at login, so
+        // turning the option off there has nothing to report.
+        return disabled || (PackagedUnit is null && !File.Exists(UnitPath));
     }
 
-    public static bool SetWindowAtLogin(bool enabled) => SetWindowAtLogin(enabled, UiBinary);
+    /// <summary>
+    /// Apply the window-at-login preference and record which executable the
+    /// entry now names, so a later repair can tell a moved installation from
+    /// an entry the user removed. False when nothing was applied.
+    /// </summary>
+    public static bool SetWindowAtLogin(bool enabled)
+    {
+        if (!SetWindowAtLogin(enabled, UiBinary)) return false;
+        RememberAutostartExecutable(enabled ? UiBinary : null);
+        return true;
+    }
 
     internal static bool SetWindowAtLogin(bool enabled, string executable)
     {
         try
         {
-            if (!enabled) File.Delete(AutostartPath);
-            else
-            {
-                if (!File.Exists(executable)) return false;
-                OpenXlrPaths.WriteAtomic(AutostartPath, $"""
-                    [Desktop Entry]
-                    Type=Application
-                    Name=OpenXLR
-                    Comment=OpenXLR mixer window
-                    Exec={DesktopExec(executable)}
-                    Icon=openxlr
-                    Terminal=false
-                    X-GNOME-Autostart-enabled=true
-
-                    """);
-            }
-            return true;
+            if (!enabled) { RemoveStartupFile(AutostartPath); return true; }
+            if (!File.Exists(executable)) return false;
+            return WriteStartupFile(AutostartPath, AutostartEntry(executable));
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return false; }
     }
 
+    private static void RememberAutostartExecutable(string? executable)
+    {
+        UiSettings saved = UiSettings.Load();
+        if (saved.AutostartExecutable == executable) return;
+        (saved with { AutostartExecutable = executable }).Save();
+    }
+
+    /// <summary>What a startup repair did, so Options can report it.</summary>
+    public enum AutostartRepair
+    {
+        /// <summary>The preference is off, or the entry is already right.</summary>
+        NotNeeded,
+        /// <summary>The entry was created, or its launch path was corrected.</summary>
+        Repaired,
+        /// <summary>The entry is gone and was left gone: it was removed outside OpenXLR.</summary>
+        RemovedOutside,
+        /// <summary>The entry could not be written.</summary>
+        Failed,
+    }
+
+    /// <summary>The outcome of the repair this launch ran, for Options to show.</summary>
+    public static AutostartRepair LastRepair { get; private set; } = AutostartRepair.NotNeeded;
+
     /// <summary>
-    /// Recreate a missing entry or update its launch path after an installation
-    /// moves. Keep desktop-specific settings, including an external disable.
+    /// Bring the autostart entry back in line with the installation, once per
+    /// installation path change rather than on every launch:
+    ///
+    /// - an entry whose Exec names a program that still exists is never
+    ///   rewritten, so a user who edited the command keeps it;
+    /// - an entry whose Exec names a program that is gone gets this
+    ///   installation's path, keeping every other key, including an external
+    ///   Hidden=true disable;
+    /// - a missing entry is recreated only when the recorded launch path
+    ///   differs from this one. An entry removed with a desktop tool while the
+    ///   path is unchanged stays removed, and Options says so.
+    ///
     /// A saved choice to start only the daemon never enables the window.
     /// </summary>
-    public static bool RepairWindowAutostart()
-        => RepairWindowAutostart(UiSettings.Load(), UiBinary);
-
-    internal static bool RepairWindowAutostart(UiSettings settings, string executable)
+    public static AutostartRepair RepairWindowAutostart()
     {
-        if (!settings.OpenWindowAtLogin) return true;
+        string executable = UiBinary;
+        AutostartRepair result = RepairWindowAutostart(UiSettings.Load(), executable);
+        if (result == AutostartRepair.Repaired) RememberAutostartExecutable(executable);
+        LastRepair = result;
+        return result;
+    }
+
+    internal static AutostartRepair RepairWindowAutostart(UiSettings settings, string executable)
+    {
+        if (!settings.OpenWindowAtLogin) return AutostartRepair.NotNeeded;
         try
         {
-            if (!File.Exists(executable)) return false;
-            if (!File.Exists(AutostartPath)) return SetWindowAtLogin(true, executable);
+            if (!File.Exists(executable)) return AutostartRepair.Failed;
+            if (!EntryExists(AutostartPath))
+                return settings.AutostartExecutable == executable
+                    ? AutostartRepair.RemovedOutside
+                    : Written(SetWindowAtLogin(true, executable));
+
             var lines = File.ReadAllLines(AutostartPath).ToList();
             int start = lines.FindIndex(l => l.Trim() == "[Desktop Entry]");
-            if (start < 0) return SetWindowAtLogin(true, executable);
+            if (start < 0) return Written(SetWindowAtLogin(true, executable));
             int end = lines.FindIndex(start + 1, l => l.TrimStart().StartsWith("[", StringComparison.Ordinal));
             if (end < 0) end = lines.Count;
+
+            // The spec allows space around the separator, so "Exec = x" is the
+            // same key as "Exec=x". Matching on the literal "Exec=" missed it
+            // and appended a second Exec, which desktop-file-validate rejects.
+            var execLines = Enumerable.Range(start + 1, end - start - 1)
+                .Where(i => DesktopKey(lines[i]) == "Exec").ToList();
             string expected = "Exec=" + DesktopExec(executable);
-            int exec = lines.FindIndex(start + 1, end - start - 1,
-                l => l.TrimStart().StartsWith("Exec=", StringComparison.Ordinal));
-            if (exec >= 0)
+
+            if (execLines.Count == 1)
             {
-                if (lines[exec] == expected) return true;
-                lines[exec] = expected;
+                string? program = DesktopExecBinary(DesktopValue(lines[execLines[0]]));
+                if (DesktopExecTargetExists(program)) return AutostartRepair.NotNeeded;
+                lines[execLines[0]] = expected;
             }
-            else lines.Insert(end, expected);
-            OpenXlrPaths.WriteAtomic(AutostartPath, string.Join("\n", lines) + "\n");
-            return true;
+            else if (execLines.Count == 0) lines.Insert(end, expected);
+            else
+            {
+                // More than one Exec in the group is already invalid. Keep the
+                // first, pointing at this installation, and drop the rest.
+                lines[execLines[0]] = expected;
+                foreach (int i in execLines.Skip(1).OrderDescending()) lines.RemoveAt(i);
+            }
+            return Written(WriteStartupFile(AutostartPath, string.Join("\n", lines) + "\n"));
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return false; }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return AutostartRepair.Failed; }
+
+        static AutostartRepair Written(bool ok) => ok ? AutostartRepair.Repaired : AutostartRepair.Failed;
+    }
+
+    /// <summary>An entry is there when the file exists, or when a symlink stands in its place.</summary>
+    private static bool EntryExists(string path) => File.Exists(path) || IsSymbolicLink(path);
+
+    /// <summary>
+    /// The key a desktop entry line declares, per the Desktop Entry
+    /// specification: everything before the first '=', trimmed. Null for a
+    /// comment, a blank line, a group header or a line with no separator.
+    /// </summary>
+    internal static string? DesktopKey(string line)
+    {
+        string trimmed = line.TrimStart();
+        if (trimmed.Length == 0 || trimmed[0] is '#' or '[') return null;
+        int separator = trimmed.IndexOf('=');
+        return separator < 0 ? null : trimmed[..separator].TrimEnd();
+    }
+
+    /// <summary>The value of a desktop entry line: everything after the first '=', leading space dropped.</summary>
+    internal static string DesktopValue(string line)
+    {
+        int separator = line.IndexOf('=');
+        return separator < 0 ? "" : line[(separator + 1)..].TrimStart();
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #80, #81 and #82. @CarinaSchoppe, this touches your three merges; the notes below say what changed in each and why, so nothing here should be a surprise.

## Fixes

**Turning mixer autostart off could fail forever.** `File.Delete` throws `DirectoryNotFoundException` when `~/.config/autostart` is absent, so `SetWindowAtLogin(false)` reported failure and the preference stayed on. Removing an entry that is already gone now counts as done.

**The autostart entry was written with OpenXLR's private-file rules.** `OpenXlrPaths.WriteAtomic` is right for `~/.config/openxlr`, where the AGENTS.md rule applies, and wrong for a shared directory: it set `~/.config/autostart` to 0700 and the entry to 0600, and its rename turned a symlinked entry into a regular file. Both startup writers (the desktop entry and the systemd user unit) now share one helper: temp file plus rename in the same directory, directory mode untouched, file mode from the umask, and a symlinked entry refused and reported rather than replaced.

**The startup repair rewrote too much.** It ran on every launch, replaced any `Exec` that differed from the running copy (reverting user edits and switching a packaged entry to a source build after one manual launch), recreated entries removed with a desktop tool, and missed the spec-legal `Exec = value` form, appending a duplicate key. The rules are now: an `Exec` whose program still exists is never touched; one whose program is gone gets this installation's path with every other line kept; a missing entry is recreated only when the installation path changed since OpenXLR last wrote one (recorded in `ui.json` as `autostartExecutable`). Keys are matched per the Desktop Entry spec and duplicate `Exec` keys collapse to one. The outcome is reported in Options instead of discarded.

**The tray gate was dead.** Avalonia 12.1.2 never throws from `new TrayIcon` on Linux: without a session bus the implementation is a stub that swallows every call, and with one it is an internal type whose `IsActive` only becomes true after the constructor returns. There is no reliable synchronous way to know whether a tray exists, so the `_tray is not null` gate is removed from both `Closing` and `StartsHidden`, and the manual now says what actually happens: with close-to-tray on, the close button always hides the window, and on a desktop without a tray the option should stay off.

**Rejected toggles left the checkbox wrong.** Raising the property with an unchanged value does not push anything back through the binding, so after a failed change the box showed the rejected state while the preference, `ui.json` and the hint said the opposite. Both login checkboxes now snap back through a set-and-revert, and `StartDaemonAtLogin` handles failure the same way as the window option instead of persisting `true` when `systemctl` fails or there is no daemon binary.

## Reverted sizing decisions

Two of #81's choices are reverted on purpose:

- `MinWidth="760"` is dropped. The window had no floor before, and below 760 the content was laid out at 760 inside a narrower surface, cutting off the right edge on a half-screen snap of a 1366 px laptop. The widest row, the seven input toggles, measures 584 px at a 640 px window, so no replacement floor is needed.
- `MaxWidth="1300"` is restored on the content panel. Without it every star-column fader and dropdown stretched across a maximized ultrawide, which the cap was added to prevent. Measured: 1224 px content at 1800 and 2400 px windows, against 1768 and 2368 without the cap.

The rest of #81 stays: ellipsis and tooltips on insert names, error rows, wrapping mix cards, plugin action rows.

## Tests

The new Xvfb tests now pin the behaviour they describe, each verified by reverting the fix on a scratch copy and watching the test go red:

- `TrayWindowTests` drives a real `WM_DELETE_WINDOW` ClientMessage through the X11 event loop (libX11 P/Invoke, already a dependency of Avalonia.X11), records visibility at the moment the window's own `Closing` handler returns so the deferral can fail, asserts visibility after `Close()` in the pending-hide-then-show and then-quit cases, and points the daemon client at an unused port through an internal `MainWindow(DaemonClient)` constructor so it no longer talks to a real daemon on a developer machine. The minimized-restore assertion, which cannot fail under Xvfb without a window manager, is dropped with a comment.
- `WindowLayoutTests` adds 640 px, asserts the 1300 cap above it and window-following below, requires exactly ten `insertName` labels including one inside each mix master card (the per-mix chain label gained that class), checks contents inside each card, and checks every plugin action button inside a 420 px window. `AssertInside` now translates coordinates so it can fail against a non-immediate ancestor.
- `WindowAutostartTests` goes from 17 to 29 cases: missing directory on disable, unchanged directory and file modes, symlinked entry refused, spaces around `=`, duplicate keys collapsed, existing `Exec` targets not rewritten (path, relative path, bare command on `PATH`), user-removed entry not recreated, `Exec` landing inside `[Desktop Entry]` with the old one gone, and the checkbox snap-back with a real bound `CheckBox`.

## Checks

- Locked restore; Release build with warnings as errors and the native host enabled: 0 warnings, 0 errors.
- `dotnet test`: 362 passed, 0 failed, 2 skipped (the Xvfb-gated pair, run separately below).
- `OPENXLR_TEST_DESKTOP=1 xvfb-run` tray test: passed. `OPENXLR_TEST_LAYOUT=1 xvfb-run` layout test at 2560x1440: passed.

## Not verified

- `SetDaemonAtLogin` has no test: exercising it runs `systemctl --user enable/disable` against the live session. Its failure reporting follows the code and `systemctl` exit codes.
- No desktop acceptance run: no real tray icon, no real `~/.config/autostart` write, no daemon contact. The D-Bus tray implementation was inspected by reflection, not exercised.
- No hardware involved; nothing here touches device code.
