### PR TITLE
Plugins: resolve saved inserts against everything installed

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,12 +35,17 @@ non-finite numbers, and over-long strings or lists all come back as an
 `error` message instead of being silently ignored. A client may send
 bursts of up to 300 commands and a sustained 100 per second; beyond
 that it is disconnected with close code 1008. At most 32 clients can be
-connected at once. The plugin catalog is bounded too: a plugin with a
+connected at once. The `plugins` message is bounded too: a plugin with a
 URI over 512 characters, more than 4096 ports, or one that would push
-the catalog past 7 MiB is left out of `plugins` altogether, and at most
+the message past 7 MiB is left out of `plugins` altogether, and at most
 512 controls, 256 scale points and 64 required features are read per
 plugin; a plugin that is listed with `supported: false` is a different
-case, one the chain host cannot run.
+case, one the chain host cannot run. The limit is on the message, not on
+what the daemon knows: every plugin a saved insert names is listed
+whatever the size, and `setInserts`, chain building and insert status all
+resolve a plugin against everything installed. A plugin missing from
+`plugins` can still be named by an insert that already holds it; it
+cannot be picked from the list, which is the only place its absence shows.
 
 Messages from the daemon, each a JSON object with a `type` field:
 
@@ -49,7 +54,7 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `state` | on connect and on every change | `daemonVersion`, device state, capabilities, mixer state, the device list, the app registry, profile names, `activeProfile` (the profile last recalled or saved for the active device; not cleared by later manual changes), `recallOnConnect` (the profile recalled when the device connects, or null), `warning` (one sentence the user should see, or null: mixer settings that cannot be written to disk, which the daemon keeps retrying with backoff, or a device set aside after three hung USB transfers in one run). In the mixer state, each channel carries `hardware` (true for the fixed input channels), `renamedSinceStart` says a virtual microphone was renamed since the daemon started (its PipeWire device keeps the old name until a restart), and `layoutWarning` is a sentence for the layout editor when pipewire-pulse nears its open-file limit, or null |
 | `diagnostics` | in answer to `getDiagnostics` | `blocks`, mapping vendor block names to hex strings or read errors |
 | `meters` | 15 Hz while the mixer is built | live stereo levels per channel and mix |
-| `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
+| `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls, within the message size limit above and always including the plugins the saved chains use; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, `windowsDirectories` (the folders yabridge bridges) and `wineFolders` (Wine's own plugin folders that hold a plugin and are not bridged yet, offered as one press since a file dialog hides them) |
 | `pluginDiagnostics` | in answer to `getPluginDiagnostics` | `discovery`: daemon host/controller paths, Wine prefix, architecture, effective search paths, bounded `yabridgectl status` output and latest completed CLAP/VST3 scan reports |
 | `pluginInstall` | in answer to `installPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
@@ -188,7 +193,7 @@ means no native scan has completed yet. Entries carry `path`, `outcome`,
 format, preferring failures over successful entries when full. Paths are
 limited to 4096 characters and details to 2048, with truncation marked.
 
-These reports describe scanner output before the combined catalogue's size
+These reports describe scanner output before the `plugins` message's size
 budget and the picker's channel-width/format filters. Compare them with
 `listPlugins` to distinguish scanning from filtering. Reading diagnostics
 does not invalidate scan caches or retry plugins. The API returns paths and

--- a/docs/features.md
+++ b/docs/features.md
@@ -160,8 +160,11 @@ bridge remains supported; Options warns about known incompatible versions.
 See [Windows plugins](manual.md#windows-plugins) for availability and setup.
 
 The catalogue sent to clients is bounded. While it fits, all formats are
-offered. Beyond the limit, LV2 entries retain priority and other formats
-fill the remaining space, with duplicate names last.
+offered. Beyond the limit, the plugins the saved chains use are kept
+first, LV2 entries retain priority over the formats that follow, and
+other formats fill the remaining space, with duplicate names last. The
+daemon itself keeps every scan whole, so an insert loads and reports on a
+plugin the list had no room for.
 
 Editor borders follow each plugin's size limits. TDR Nova uses its own UI
 scale menu instead of border resizing. LSP editors default to software

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -256,10 +256,10 @@ channel, with its level and lock in the INPUTS card.
    profiles. OpenXLR does not yet save opaque plugin state, sample-file
    selections or plugin presets.
 
-The generated controls cover the parameters in the bounded catalogue. A
-plugin's own editor can be opened as well, with the native host described
-in 3.12. CLAP and VST3 plugins appear in the same picker and always run in
-that host. VST2 plugins cannot be loaded.
+The generated controls cover the parameters the daemon read from the
+plugin. A plugin's own editor can be opened as well, with the native
+host described in 3.12. CLAP and VST3 plugins appear in the same picker
+and always run in that host. VST2 plugins cannot be loaded.
 
 <a name="install-plugins"></a>
 **Installing plugins.** The quickest set comes from your distribution:
@@ -454,9 +454,11 @@ grep 'Max locked memory' /proc/$(systemctl --user show openxlr-daemon -p MainPID
 The picker marks each plugin with its format, since the same plugin often
 ships in more than one, and its LV2, CLAP and VST3 buttons narrow the list
 to one of them. When the catalogue grows past what the window can be sent,
-the LV2 list stays whole and the other formats fill the remaining room,
-with copies of a plugin already listed going last; a set installed in two
-formats shows once rather than pushing anything out.
+the plugins your chains already use come first, then the LV2 list, then
+the other formats in the room that is left, with copies of a plugin
+already listed going last; a set installed in two formats shows once
+rather than pushing anything out. Only the list is cut. A chain keeps
+loading, and keeps its controls, whether or not its plugin fits in it.
 
 <a name="profiles"></a>
 ### 3.6 Save and recall a scene

--- a/src/OpenXLR.Core/Mixing/ClientCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/ClientCatalog.cs
@@ -1,0 +1,125 @@
+using System.Runtime.CompilerServices;
+
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>
+/// The catalogue as a client is sent it, which is the only place a size
+/// limit belongs: a client reads one message and drops anything longer, while
+/// the daemon resolves an insert against everything installed. Nothing here
+/// is on the path that loads a chain, and <see cref="PluginCatalog"/> does
+/// not call into it: a lookup that went through this list is the defect the
+/// split exists to prevent.
+/// </summary>
+public static class ClientCatalog
+{
+    // What was last built, against the catalogue it was built from. A merge
+    // costs a comparison per plugin per format and a client may ask as often
+    // as its command budget allows, so the answer is kept; it is kept only as
+    // long as that catalogue is, so a rescan drops it with the plugins in it.
+    private sealed class Sent
+    {
+        public string? Key;
+        public IReadOnlyList<PluginInfo> List = [];
+    }
+
+    private static readonly ConditionalWeakTable<IReadOnlyList<PluginInfo>, Sent> Recent = [];
+    private static readonly object Gate = new();
+
+    /// <summary>
+    /// The plugins to offer, out of everything installed: within the size a
+    /// client will read, with the plugins the saved chains use kept whatever
+    /// the budget. A client names an insert and draws its controls from this
+    /// list, so a plugin the daemon loads and the list leaves out would show
+    /// a working chain as a broken one.
+    /// </summary>
+    public static IReadOnlyList<PluginInfo> ForClient(IReadOnlyList<PluginInfo> all,
+        IEnumerable<(string Kind, string Plugin)> inUse)
+    {
+        HashSet<(string Kind, string Plugin)> used = [.. inUse];
+        string key = string.Join('\n', used.Select(u => u.Kind + ' ' + u.Plugin).Order(StringComparer.Ordinal));
+        Sent sent = Recent.GetValue(all, _ => new Sent());
+        lock (Gate)
+            if (sent.Key == key) return sent.List;
+        // LV2 first, then each other format in the order it was scanned in.
+        IReadOnlyList<PluginInfo>[] others = [.. all.Where(p => p.Kind != "lv2")
+            .GroupBy(p => p.Kind, StringComparer.Ordinal)
+            .Select(g => (IReadOnlyList<PluginInfo>)g.ToList())];
+        List<PluginInfo> list = Merge(used, [.. all.Where(p => p.Kind == "lv2")], others);
+        lock (Gate)
+        {
+            sent.Key = key;
+            sent.List = list;
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// One list within the size a client is sent. The plugins the saved
+    /// chains use come first and are charged to the budget first, so a chain
+    /// the daemon can build is one a client can name and draw controls for.
+    /// LV2 comes next and whole, as it always did; the other formats take the
+    /// room that is left. When everything fits, every copy of a plugin is
+    /// offered. When it does not, a format's copies of plugins already listed
+    /// go before anything distinct, and then its largest entries, so LV2
+    /// never loses a plugin to a duplicate of itself.
+    /// </summary>
+    internal static List<PluginInfo> Merge(IReadOnlyList<PluginInfo> lv2, params IReadOnlyList<PluginInfo>[] others)
+        => Merge(new HashSet<(string Kind, string Plugin)>(), lv2, others);
+
+    internal static List<PluginInfo> Merge(IReadOnlyCollection<(string Kind, string Plugin)> inUse,
+        IReadOnlyList<PluginInfo> lv2, params IReadOnlyList<PluginInfo>[] others)
+    {
+        // The chains' own plugins, smallest first so a monster cannot take
+        // the room several ordinary ones need. There are only ever a few
+        // chains' worth of them, but the budget still ends the list: a
+        // message a client drops would leave the picker with nothing at all.
+        var pinned = new HashSet<PluginInfo>();
+        long used = 0;
+        if (inUse.Count > 0)
+            foreach (PluginInfo p in lv2.Concat(others.SelectMany(f => f))
+                .Where(p => inUse.Contains((p.Kind, p.Plugin)))
+                .OrderBy(Lv2Catalog.Footprint))
+            {
+                long size = Lv2Catalog.Footprint(p);
+                if (used + size > Lv2Catalog.CatalogBudgetBytes) break;
+                if (pinned.Add(p)) used += size;
+            }
+        List<PluginInfo> withinBudget = Lv2Catalog.WithinBudget(
+            [.. lv2.Where(p => !pinned.Contains(p))], Lv2Catalog.CatalogBudgetBytes - used);
+        used += withinBudget.Sum(p => (long)Lv2Catalog.Footprint(p));
+        var keptLv2 = new HashSet<PluginInfo>(withinBudget);
+        List<PluginInfo> kept = [.. lv2.Where(p => pinned.Contains(p) || keptLv2.Contains(p))];
+        foreach (IReadOnlyList<PluginInfo> format in others)
+        {
+            kept.AddRange(format.Where(pinned.Contains));
+            // Distinct plugins first, smallest first, then the copies with
+            // whatever room is left; the first that does not fit ends it.
+            var listed = kept.ToList();
+            foreach (PluginInfo p in format.Where(p => !pinned.Contains(p))
+                .OrderBy(p => listed.Any(k => SamePlugin(k, p))).ThenBy(Lv2Catalog.Footprint))
+            {
+                long size = Lv2Catalog.Footprint(p);
+                if (used + size > Lv2Catalog.CatalogBudgetBytes) break;
+                kept.Add(p);
+                used += size;
+            }
+        }
+        return kept;
+    }
+
+    /// <summary>
+    /// The same plugin in another format: the same width, and a name that is
+    /// the same or the same behind a vendor prefix, as "LSP Compressor Mono"
+    /// and "Compressor Mono" are.
+    /// </summary>
+    internal static bool SamePlugin(PluginInfo a, PluginInfo b)
+    {
+        if (a.AudioIns != b.AudioIns || a.AudioOuts != b.AudioOuts) return false;
+        string x = Simplified(a.Name), y = Simplified(b.Name);
+        if (x.Length == 0 || y.Length == 0) return false;
+        return x == y || x.EndsWith(" " + y, StringComparison.Ordinal) || y.EndsWith(" " + x, StringComparison.Ordinal);
+    }
+
+    private static string Simplified(string name)
+        => string.Join(' ', name.ToLowerInvariant().Split([' ', '-', '_', ':'], StringSplitOptions.RemoveEmptyEntries));
+}

--- a/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
+++ b/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
@@ -102,7 +102,10 @@ public static class Lv2Catalog
             Lilv.lilv_world_free(world);
         }
         result.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
-        return WithinBudget(result);
+        // Whole: the budget belongs to the message a client is sent, not to
+        // what an insert can name. A chain saved around a large plugin has to
+        // keep loading after another format's plugins arrive beside it.
+        return result;
     }
 
     // Limits on what a bundle can make the daemon hold. lilv reports whatever
@@ -118,10 +121,11 @@ public static class Lv2Catalog
     /// <summary>Required features beyond this count are not read; no real plugin declares more than a handful.</summary>
     internal const int MaxFeatures = 64;
     /// <summary>
-    /// Serialized size the whole catalog may reach. A client reads at most
-    /// 8 MiB in one message and drops anything longer, which would leave a
-    /// picker with nothing in it, so the catalog stops short of that with
-    /// room for the message around it.
+    /// Serialized size the catalog sent to a client may reach. A client reads
+    /// at most 8 MiB in one message and drops anything longer, which would
+    /// leave a picker with nothing in it, so the message stops short of that
+    /// with room for what is around the list. What the daemon holds and
+    /// resolves inserts against is not bounded by this.
     /// </summary>
     internal const int CatalogBudgetBytes = 7 * 1024 * 1024;
 
@@ -140,18 +144,19 @@ public static class Lv2Catalog
            + p.RequiredFeatures.Sum(f => f.Length + 4) + (p.InputSymbols.Count + p.OutputSymbols.Count) * 16;
 
     /// <summary>
-    /// Keep the catalog under the budget by dropping the largest plugins
-    /// first: a handful of monsters must not push every ordinary plugin
-    /// out of the window's picker.
+    /// Keep a list under the budget by dropping the largest plugins first: a
+    /// handful of monsters must not push every ordinary plugin out of the
+    /// window's picker. The room already spent on the chains' own plugins is
+    /// taken off the budget by the caller.
     /// </summary>
-    internal static List<PluginInfo> WithinBudget(List<PluginInfo> all)
+    internal static List<PluginInfo> WithinBudget(List<PluginInfo> all, long budget = CatalogBudgetBytes)
     {
         long total = all.Sum(p => (long)Footprint(p));
-        if (total <= CatalogBudgetBytes) return all;
+        if (total <= budget) return all;
         var keep = new HashSet<PluginInfo>(all);
         foreach (PluginInfo p in all.OrderByDescending(Footprint))
         {
-            if (total <= CatalogBudgetBytes) break;
+            if (total <= budget) break;
             keep.Remove(p);
             total -= Footprint(p);
         }

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -608,6 +608,17 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
     private List<InsertDefinition> InsertsFor(string channelId)
         => _inserts.TryGetValue(channelId, out List<InsertDefinition>? l) ? l : [];
 
+    /// <summary>
+    /// Every plugin the saved chains name, bypassed ones included: the
+    /// catalogue a client is sent has to hold these whatever its size limit,
+    /// or a chain the daemon loads looks like an unknown plugin in the window
+    /// and on the Stream Deck.
+    /// </summary>
+    public IReadOnlyCollection<(string Kind, string Plugin)> InsertPlugins()
+    {
+        lock (_gate) return [.. _inserts.Values.SelectMany(list => list).Select(i => (i.Kind, i.Plugin))];
+    }
+
     /// <summary>Software low cut frequency (0, 80, or 120 Hz; 0 = off).</summary>
     public int LowCutHz { get { lock (_gate) return _lowCutHz; } }
 

--- a/src/OpenXLR.Core/Mixing/MixerSettings.cs
+++ b/src/OpenXLR.Core/Mixing/MixerSettings.cs
@@ -66,6 +66,14 @@ public sealed record MixerSettings
     public Dictionary<string, List<InsertDefinition>> Inserts { get; init; } = [];
 
     /// <summary>
+    /// Every plugin the saved chains name. A client that reconnects while the
+    /// daemon is still starting asks for the catalogue before the chains are
+    /// restored, and this is what they will hold.
+    /// </summary>
+    public IReadOnlyCollection<(string Kind, string Plugin)> InsertPlugins()
+        => [.. Inserts.Values.SelectMany(list => list).Select(i => (i.Kind, i.Plugin))];
+
+    /// <summary>
     /// Whether the Aux mix feeds the USB Aux port. Null in files written before
     /// the Aux mix existed; migrated from the old monitor-destination choice.
     /// </summary>

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -673,8 +673,12 @@ public sealed class PipeWireAdapter
             foreach (InsertDefinition insert in inserts.Where(i => !i.Bypass))
             {
                 PluginInfo? info = PluginCatalog.Find(insert);
+                // The plugin is named because this error is reported on every
+                // insert in the chain: without the name, the one that failed
+                // cannot be told from the ones that were behind it.
                 if (info is null || !info.Supported)
-                    throw new InvalidOperationException("Plugin is unavailable or requires unsupported host features.");
+                    throw new InvalidOperationException(
+                        $"{(string.IsNullOrWhiteSpace(insert.Label) ? insert.Plugin : insert.Label)} is unavailable or requires unsupported host features.");
                 string node = $"{sinkName}_stage_{insertStages.Count}";
                 FilterHandle stage;
                 if (insert.RunsNatively)

--- a/src/OpenXLR.Core/Mixing/PluginCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/PluginCatalog.cs
@@ -2,70 +2,38 @@ namespace OpenXLR.Core.Mixing;
 
 /// <summary>
 /// Every plugin an insert can hold, whichever format it comes in. The LV2
-/// list is read through lilv in this process; the CLAP list comes from the
-/// native host, one scan per bundle. Both are read once and kept.
+/// list is read through lilv in this process; the CLAP and VST3 lists come
+/// from the native host, one scan per bundle. All of them are read once and
+/// kept, whole: an insert is resolved against everything installed, so a
+/// chain that loaded yesterday loads today.
+///
+/// Nothing here is bounded. The size a client will read bounds the message
+/// it is sent, and that lives in <see cref="ClientCatalog"/>.
 /// </summary>
 public static class PluginCatalog
 {
     private static readonly Refreshable<IReadOnlyList<PluginInfo>> All = new(Build);
 
     private static IReadOnlyList<PluginInfo> Build()
-    {
-        // Each source on its own: one that fails costs its plugins, not the
-        // catalogue. The list is read once and kept, exceptions included.
-        static IReadOnlyList<PluginInfo> read(Func<IReadOnlyList<PluginInfo>> source)
-        {
-            try { return source(); }
-            catch (Exception) { return []; }
-        }
-        return Merge(read(() => Lv2Catalog.Plugins), read(() => ClapCatalog.Plugins), read(() => Vst3Catalog.Plugins));
-    }
+        => Combine(() => Lv2Catalog.Plugins, () => ClapCatalog.Plugins, () => Vst3Catalog.Plugins);
 
     /// <summary>
-    /// One list within the size a client is sent. LV2 comes first and whole,
-    /// as it always did; the other formats take the room that is left. When
-    /// everything fits, every copy of a plugin is offered. When it does not,
-    /// a format's copies of plugins already listed go before anything
-    /// distinct, and then its largest entries, so LV2 never loses a plugin
-    /// to a duplicate of itself.
+    /// Every source's plugins as one list. Each source on its own: one that
+    /// fails costs its plugins, not the catalogue. The list is read once and
+    /// kept, exceptions included.
     /// </summary>
-    internal static List<PluginInfo> Merge(IReadOnlyList<PluginInfo> lv2, params IReadOnlyList<PluginInfo>[] others)
+    internal static IReadOnlyList<PluginInfo> Combine(params Func<IReadOnlyList<PluginInfo>>[] sources)
     {
-        List<PluginInfo> kept = Lv2Catalog.WithinBudget([.. lv2]);
-        long used = kept.Sum(p => (long)Lv2Catalog.Footprint(p));
-        foreach (IReadOnlyList<PluginInfo> format in others)
+        var all = new List<PluginInfo>();
+        foreach (Func<IReadOnlyList<PluginInfo>> source in sources)
         {
-            // Distinct plugins first, smallest first, then the copies with
-            // whatever room is left; the first that does not fit ends it.
-            var listed = kept.ToList();
-            foreach (PluginInfo p in format.OrderBy(p => listed.Any(k => SamePlugin(k, p))).ThenBy(Lv2Catalog.Footprint))
-            {
-                long size = Lv2Catalog.Footprint(p);
-                if (used + size > Lv2Catalog.CatalogBudgetBytes) break;
-                kept.Add(p);
-                used += size;
-            }
+            try { all.AddRange(source()); }
+            catch (Exception) { }
         }
-        return kept;
+        return all;
     }
 
-    /// <summary>
-    /// The same plugin in another format: the same width, and a name that is
-    /// the same or the same behind a vendor prefix, as "LSP Compressor Mono"
-    /// and "Compressor Mono" are.
-    /// </summary>
-    internal static bool SamePlugin(PluginInfo a, PluginInfo b)
-    {
-        if (a.AudioIns != b.AudioIns || a.AudioOuts != b.AudioOuts) return false;
-        string x = Simplified(a.Name), y = Simplified(b.Name);
-        if (x.Length == 0 || y.Length == 0) return false;
-        return x == y || x.EndsWith(" " + y, StringComparison.Ordinal) || y.EndsWith(" " + x, StringComparison.Ordinal);
-    }
-
-    private static string Simplified(string name)
-        => string.Join(' ', name.ToLowerInvariant().Split([' ', '-', '_', ':'], StringSplitOptions.RemoveEmptyEntries));
-
-    /// <summary>The whole catalogue, within the size a client is sent (blocks on the first call).</summary>
+    /// <summary>Every plugin installed, in every format (blocks on the first call).</summary>
     public static IReadOnlyList<PluginInfo> Plugins => All.Value;
 
     /// <summary>
@@ -110,8 +78,10 @@ public static class PluginCatalog
     public static void Warm() => ThreadPool.QueueUserWorkItem(_ => { try { _ = All.Value; } catch (Exception) { } });
 
     /// <summary>The plugin an insert names, by its kind and its identifier.</summary>
-    public static PluginInfo? Find(string kind, string plugin)
-        => Plugins.FirstOrDefault(p => p.Kind == kind && p.Plugin == plugin);
+    public static PluginInfo? Find(string kind, string plugin) => Find(Plugins, kind, plugin);
+
+    internal static PluginInfo? Find(IReadOnlyList<PluginInfo> catalogue, string kind, string plugin)
+        => catalogue.FirstOrDefault(p => p.Kind == kind && p.Plugin == plugin);
 
     public static PluginInfo? Find(InsertDefinition insert) => Find(insert.Kind, insert.Plugin);
 

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -143,6 +143,19 @@ public sealed class MixerService : IHostedService, IDisposable
     /// <summary>Live stereo levels, or null when the mixer is off.</summary>
     public IReadOnlyDictionary<string, double[]>? Meters() => _mixer.Built ? _mixer.ReadMeters() : null;
 
+    /// <summary>
+    /// Every plugin the saved chains name, for the catalogue a client is sent.
+    /// The socket accepts clients before this service has restored the chains,
+    /// and a client that reconnects in that window asks straight away, so the
+    /// saved file answers until the mixer holds them.
+    /// </summary>
+    public IReadOnlyCollection<(string Kind, string Plugin)> InsertPlugins()
+    {
+        var used = new HashSet<(string Kind, string Plugin)>(_mixer.InsertPlugins());
+        if (used.Count == 0) used.UnionWith(OpenXLR.Core.Mixing.MixerSettings.Load()?.InsertPlugins() ?? []);
+        return used;
+    }
+
     /// <summary>Raised at the meter refresh rate so the hub can push levels.</summary>
     public event Action? MetersUpdated;
 

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -194,7 +194,11 @@ public sealed class WebSocketHub
                 break;
             case "listPlugins":
                 // The first call may block on lilv's scan; keep it off the socket loop's thread.
-                IReadOnlyList<OpenXLR.Core.Mixing.PluginInfo> plugins = await Task.Run(() => OpenXLR.Core.Mixing.PluginCatalog.Plugins);
+                // The chains' own plugins go with it, so the list a client
+                // gets can name every insert the daemon loaded.
+                IReadOnlyList<OpenXLR.Core.Mixing.PluginInfo> plugins =
+                    await Task.Run(() => OpenXLR.Core.Mixing.ClientCatalog.ForClient(
+                        OpenXLR.Core.Mixing.PluginCatalog.Plugins, _mixer.InsertPlugins()));
                 await reply(new PluginsMessage(plugins));
                 break;
             case "getPluginDiagnostics":
@@ -375,9 +379,8 @@ public sealed class WebSocketHub
             catch (Exception ex) { outcome = new(false, ex.Message, []); }
             OpenXLR.Core.Mixing.PluginCatalog.Refresh();
             // What this install brought: plugins not listed before, and when
-            // the install landed somewhere, only those found there, so a
-            // catalogue trimmed to its budget shifting underneath does not
-            // count as new plugins.
+            // the install landed somewhere, only those found there, so
+            // plugins that arrived by other means are not credited to it.
             int added = OpenXLR.Core.Mixing.PluginCatalog.CountUnder(outcome.Destinations ?? [], before);
             int total = OpenXLR.Core.Mixing.PluginCatalog.Plugins.Count;
             if (outcome.Ok) _log.LogInformation("plugins: {message} {added} new in the catalogue", outcome.Message, added);

--- a/src/OpenXLR.Tests/ClapCatalogTests.cs
+++ b/src/OpenXLR.Tests/ClapCatalogTests.cs
@@ -207,20 +207,20 @@ public sealed class ClapCatalogTests
         // Under the budget, every copy is offered.
         var lv2 = new[] { plugin("lv2", "LSP Compressor Mono", 1, 30), plugin("lv2", "Dragonfly Hall Reverb", 2, 18) };
         var vst3 = new[] { plugin("vst3", "Compressor Mono", 1, 30), plugin("vst3", "Dragonfly Hall Reverb", 2, 18) };
-        Assert.Equal(4, PluginCatalog.Merge(lv2, vst3).Count);
+        Assert.Equal(4, ClientCatalog.Merge(lv2, vst3).Count);
 
         // Over it, a copy goes before anything distinct, and LV2 stays whole.
         var heavy = Enumerable.Range(0, 400).Select(i => plugin("lv2", $"Plugin {i}", 1, Lv2Catalog.MaxControls)).ToList();
         var heavyVst3 = heavy.Select(p => plugin("vst3", p.Name, 1, Lv2Catalog.MaxControls)).ToList();
-        List<PluginInfo> merged = PluginCatalog.Merge(heavy, [.. heavyVst3, plugin("vst3", "Something Else", 2, 3)]);
+        List<PluginInfo> merged = ClientCatalog.Merge(heavy, [.. heavyVst3, plugin("vst3", "Something Else", 2, 3)]);
         List<PluginInfo> keptLv2 = Lv2Catalog.WithinBudget([.. heavy]);
         Assert.Equal(keptLv2.Count, merged.Count(p => p.Kind == "lv2"));
         Assert.Contains(merged, p => p.Name == "Something Else");      // the distinct one got in
         Assert.DoesNotContain(merged, p => p.Kind == "vst3" && p.Name == "Plugin 0");
 
-        Assert.True(PluginCatalog.SamePlugin(plugin("lv2", "LSP Compressor Mono", 1, 1), plugin("vst3", "Compressor Mono", 1, 1)));
-        Assert.True(PluginCatalog.SamePlugin(plugin("lv2", "x42 - IR Convolver", 2, 1), plugin("vst3", "IR Convolver", 2, 1)));
-        Assert.False(PluginCatalog.SamePlugin(plugin("lv2", "Compressor Mono", 1, 1), plugin("vst3", "Compressor Stereo", 2, 1)));
+        Assert.True(ClientCatalog.SamePlugin(plugin("lv2", "LSP Compressor Mono", 1, 1), plugin("vst3", "Compressor Mono", 1, 1)));
+        Assert.True(ClientCatalog.SamePlugin(plugin("lv2", "x42 - IR Convolver", 2, 1), plugin("vst3", "IR Convolver", 2, 1)));
+        Assert.False(ClientCatalog.SamePlugin(plugin("lv2", "Compressor Mono", 1, 1), plugin("vst3", "Compressor Stereo", 2, 1)));
     }
 
     private sealed class Layout : ILayoutInfo

--- a/src/OpenXLR.Tests/Lv2BundleTests.cs
+++ b/src/OpenXLR.Tests/Lv2BundleTests.cs
@@ -51,4 +51,45 @@ public sealed class Lv2BundleTests
             try { Directory.Delete(dir, recursive: true); } catch (IOException) { }
         }
     }
+
+    [Fact]
+    public void AnLv2ScanBiggerThanOneMessageIsKeptWholeAndOnlyTheClientListIsCut()
+    {
+        if (!NativeLibrary.TryLoad("liblilv-0.so.0", out IntPtr lib)) return;   // no lilv here (CI): nothing to scan with
+        NativeLibrary.Free(lib);
+        string dir = Path.Combine(Path.GetTempPath(), "openxlr-lv2-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // Ninety plugins at the control limit: more than a client reads
+            // in one message, which used to end the scan short.
+            const int count = 90;
+            for (int i = 0; i < count; i++)
+            {
+                string bundle = Path.Combine(dir, $"big{i}.lv2");
+                Directory.CreateDirectory(bundle);
+                File.WriteAllText(Path.Combine(bundle, "manifest.ttl"),
+                    "@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+                    + $"<urn:openxlr:test:big{i}> a lv2:Plugin ; lv2:binary <big{i}.so> ; rdfs:seeAlso <big{i}.ttl> .\n");
+                File.WriteAllText(Path.Combine(bundle, $"big{i}.ttl"),
+                    Bundle($"big{i}", $"urn:openxlr:test:big{i}", Lv2Catalog.MaxControls));
+            }
+            IReadOnlyList<PluginInfo> found = Lv2Catalog.ScanNow(dir);
+            Assert.Equal(count, found.Count);
+            Assert.True(found.Sum(p => (long)Lv2Catalog.Footprint(p)) > Lv2Catalog.CatalogBudgetBytes);
+
+            // The message is what gets cut, and a plugin it cut is listed
+            // again as soon as a chain uses it.
+            IReadOnlyList<PluginInfo> idle = ClientCatalog.ForClient(found, []);
+            Assert.True(idle.Count < found.Count);
+            Assert.True(idle.Sum(p => (long)Lv2Catalog.Footprint(p)) <= Lv2Catalog.CatalogBudgetBytes);
+            PluginInfo dropped = found.First(p => !idle.Contains(p));
+            IReadOnlyList<PluginInfo> sent = ClientCatalog.ForClient(found, [("lv2", dropped.Plugin)]);
+            Assert.Contains(sent, p => p.Plugin == dropped.Plugin);
+            Assert.True(sent.Sum(p => (long)Lv2Catalog.Footprint(p)) <= Lv2Catalog.CatalogBudgetBytes);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch (IOException) { }
+        }
+    }
 }

--- a/src/OpenXLR.Tests/PluginCatalogTests.cs
+++ b/src/OpenXLR.Tests/PluginCatalogTests.cs
@@ -1,0 +1,107 @@
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class PluginCatalogTests
+{
+    private static PluginInfo Plugin(string kind, string name, int controls, int width = 1)
+        => new(kind, kind + ":" + name, name, "", width, width, "in", "out",
+            [.. Enumerable.Range(0, controls).Select(i => new PluginParam($"p{i}", $"Param {i}", 0, 1, 0, false, false, false, false, []))],
+            [], ["in"], ["out"]);
+
+    /// <summary>
+    /// Enough ordinary LV2 plugins to fill the message a client is sent, in
+    /// a size that leaves less room over than one large plugin needs.
+    /// </summary>
+    private static List<PluginInfo> FullOfLv2()
+        => [.. Enumerable.Range(0, 1200).Select(i => Plugin("lv2", $"Plugin {i}", 40))];
+
+    [Fact]
+    public void EverySourceIsKeptWholeAndOneThatFailsCostsOnlyItsOwnPlugins()
+    {
+        List<PluginInfo> lv2 = FullOfLv2();
+        PluginInfo vst3 = Plugin("vst3", "Nova", 76);
+        IReadOnlyList<PluginInfo> all = PluginCatalog.Combine(
+            () => lv2,
+            () => throw new InvalidOperationException("the scanner died"),
+            () => [vst3]);
+
+        // The catalogue an insert is resolved against is not bounded: the
+        // whole LV2 scan is there, and so is the plugin there was no room for.
+        Assert.Equal(lv2.Count + 1, all.Count);
+        Assert.True(all.Sum(p => (long)Lv2Catalog.Footprint(p)) > Lv2Catalog.CatalogBudgetBytes);
+        Assert.NotNull(PluginCatalog.Find(all, "vst3", vst3.Plugin));
+        Assert.NotNull(PluginCatalog.Find(all, "lv2", lv2[^1].Plugin));
+    }
+
+    [Fact]
+    public void APluginASavedChainUsesIsSentToClientsThoughTheBudgetHasNoRoomForIt()
+    {
+        List<PluginInfo> lv2 = FullOfLv2();
+        PluginInfo used = Plugin("vst3", "Nova", Lv2Catalog.MaxControls), unused = Plugin("vst3", "Supermassive", Lv2Catalog.MaxControls);
+        IReadOnlyList<PluginInfo> all = PluginCatalog.Combine(() => lv2, () => [used, unused]);
+
+        // As it was: the LV2 set fills the message and the other format gets
+        // what is left, which is nothing.
+        IReadOnlyList<PluginInfo> idle = ClientCatalog.ForClient(all, []);
+        Assert.DoesNotContain(idle, p => p.Kind == "vst3");
+
+        // With a chain on it, the plugin is listed, and paid for by the LV2
+        // entries that no longer fit.
+        IReadOnlyList<PluginInfo> sent = ClientCatalog.ForClient(all, [("vst3", used.Plugin)]);
+        Assert.Contains(sent, p => p.Plugin == used.Plugin);
+        Assert.DoesNotContain(sent, p => p.Plugin == unused.Plugin);
+        Assert.True(sent.Count(p => p.Kind == "lv2") < idle.Count(p => p.Kind == "lv2"));
+        Assert.True(sent.Sum(p => (long)Lv2Catalog.Footprint(p)) <= Lv2Catalog.CatalogBudgetBytes);
+
+        // An insert is resolved against the whole catalogue either way, so
+        // the chain loads whether or not the picker could show the plugin.
+        Assert.NotNull(PluginCatalog.Find(all, "vst3", unused.Plugin));
+    }
+
+    [Fact]
+    public void PinnedPluginsAreListedSmallestFirstAndStillStopAtTheBudget()
+    {
+        // More chain plugins than a message can hold: the list ends where a
+        // client would stop reading, and the small ones are the ones kept.
+        List<PluginInfo> monsters = [.. Enumerable.Range(0, 200).Select(i => Plugin("clap", $"Monster {i}", Lv2Catalog.MaxControls))];
+        PluginInfo small = Plugin("clap", "Small", 4);
+        List<PluginInfo> clap = [.. monsters, small];
+        List<PluginInfo> sent = ClientCatalog.Merge([.. clap.Select(p => (p.Kind, p.Plugin))], [], clap);
+
+        Assert.True(sent.Sum(p => (long)Lv2Catalog.Footprint(p)) <= Lv2Catalog.CatalogBudgetBytes);
+        Assert.True(sent.Count < clap.Count);
+        Assert.Contains(sent, p => p.Plugin == small.Plugin);
+        Assert.Equal(sent.Count, sent.Distinct().Count());
+    }
+
+    [Fact]
+    public void TheSavedFileNamesTheChainsPluginsBeforeTheMixerHasRestoredThem()
+    {
+        // What a client asking during startup is answered from.
+        var saved = new MixerSettings
+        {
+            Inserts = new Dictionary<string, List<InsertDefinition>>
+            {
+                ["xlr1"] = [new() { Id = "a", Kind = "vst3", Plugin = "ABCD", Label = "Nova" },
+                            new() { Id = "b", Kind = "lv2", Plugin = "urn:test:eq", Bypass = true }],
+                ["stream"] = [new() { Id = "c", Kind = "clap", Plugin = "com.vendor.verb" }],
+            },
+        };
+        Assert.Equal([("clap", "com.vendor.verb"), ("lv2", "urn:test:eq"), ("vst3", "ABCD")],
+            saved.InsertPlugins().Order());
+    }
+
+    [Fact]
+    public void TheLv2ListStaysWholeWhenTheChainsPluginsLeaveRoomForIt()
+    {
+        // The ordinary case: a chain plugin changes nothing about the order
+        // the rest of the catalogue is offered in.
+        List<PluginInfo> lv2 = [.. Enumerable.Range(0, 20).Select(i => Plugin("lv2", $"Plugin {i}", 30))];
+        List<PluginInfo> vst3 = [Plugin("vst3", "Nova", 76)];
+        List<PluginInfo> sent = ClientCatalog.Merge([("vst3", vst3[0].Plugin)], lv2, vst3);
+
+        Assert.Equal(lv2.Select(p => p.Plugin), sent.Where(p => p.Kind == "lv2").Select(p => p.Plugin));
+        Assert.Equal(lv2.Count + 1, sent.Count);
+    }
+}


### PR DESCRIPTION
## Summary

A saved insert could fail at every daemon start with "plugin not installed" although its bundle was installed and its scan cached. The catalogue kept one list, and that list was the one already cut to the 7 MiB message budget: `Lv2Catalog.ScanNow` returned `WithinBudget(result)` and `PluginCatalog.Build` merged the three formats through the same budget. Every lookup used it, including the chain builder and `setInserts` validation. On a desk with the LSP LV2 set (which nearly fills the budget) and the LSP CLAP set (198 plugins), the VST3 pass had room for one small plugin; TDR Nova (76 parameters) fell off the end and the Stream chain could not be built.

A second symptom came with it: the other plugin in that chain, ValhallaSupermassive, showed "unavailable or requires unsupported host features" although it was listed. The chain builder throws on the first insert it cannot resolve, the error is stored per channel, and `InsertStatusLocked` handed that one error to every active insert in the chain. The message named no plugin.

## Changes

- `PluginCatalog` holds the full catalogue. `Build` concatenates the three scans (`Combine`); a source that fails costs only its own plugins. `Plugins`, `Find`, `Identities` and `CountUnder` see everything installed. `Lv2Catalog.ScanNow` returns the whole scan.
- The message budget moves to a new `ClientCatalog.ForClient(all, inUse)`, used only by `listPlugins`. The plugins the saved chains use are pinned first, smallest first and still within the budget; then LV2 whole in the room left; then the other formats exactly as before. Output order for everything else is unchanged. The result is cached per catalogue instance and in-use set, so a rescan drops it by itself.
- `PluginCatalog` never calls `ClientCatalog`, so a lookup cannot go back through the bounded list. Both class comments say so.
- `Mixer.InsertPlugins()`, `MixerSettings.InsertPlugins()` and `MixerService.InsertPlugins()` feed the in-use set. `MixerService` falls back to `mixer.json` while the mixer has not restored its chains yet: the socket accepts clients about six seconds before settings are restored, and the OpenDeck plugin asks for the catalogue immediately on reconnect.
- The chain builder's error now names the plugin it could not resolve.
- No client change needed: the window's picker and generated controls, and the OpenDeck plugin's dial targets, all read the `plugins` message, and the used plugin is now in it. Insert labels already fell back to `insert.label`.

## Tests

Five new cases in `PluginCatalogTests` and one lilv-backed case in `Lv2BundleTests` (a real scan of 90 generated bundles, skipped where lilv is absent). Each was checked against the fix reverted:

- an over-budget LV2 scan is kept whole and only the client list is cut;
- a plugin a saved chain uses is sent to clients though the budget has no room for it;
- pinned plugins are listed smallest first and still stop at the budget;
- every source is kept whole and one that fails costs only its own plugins;
- the saved file names the chains' plugins before the mixer has restored them;
- the LV2 list stays whole when the chains' plugins leave room for it.

One mutant the tests cannot reach without spawning the native scanners in the test process: pointing `PluginCatalog.Build` back at the client merge. The guard for it is structural, above.

## Checks

- Locked restore; `tools/check-locked-restore.sh`; `tools/check-version.sh`; `tools/check-openapi.py`: pass.
- Release build with warnings as errors, with and without the native host: 0 warnings, 0 errors.
- `dotnet test`: 368 passed, 2 skipped (the Xvfb-gated window tests). Baseline 362. Run once more with the native host present: same result, scan cache index byte-identical afterwards.
- No em dashes in the diff.

## Docs

`docs/api.md`, `docs/manual.md` and `docs/features.md` now say the same thing: the limit is on the message, the chains' plugins are kept first, and the daemon resolves inserts against everything installed.

## Not verified

- Not run against a live daemon. The end-to-end check that the Stream chain loads again on the affected desk is part of the acceptance pass that follows.
- Native and Xvfb suites not run; nothing here touches the helper or the window.
