### PR TITLE
Daemon: end the Wine session a bridged plugin leaves behind

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -459,6 +459,22 @@ grep 'Max locked memory' /proc/$(systemctl --user show openxlr-daemon -p MainPID
 
 "unlimited" there means the plugins the daemon starts inherit it too.
 
+<a name="wine-ends"></a>
+**Wine ends with the last bridged plugin.** A Windows plugin runs in Wine,
+and Wine keeps service processes of its own behind it that stay after the
+plugin is gone. OpenXLR ends that Wine session with `wineserver -k` once
+the last bridged insert has stopped, and again when the daemon stops, so
+`systemctl --user stop openxlr-daemon` and the window's Restart finish in
+a few seconds instead of waiting out the unit's stop timeout. Only the
+session OpenXLR started is ended: a plugin installer you are running, or
+another DAW with its own bridged plugins, keeps its Wine whatever OpenXLR
+does. Without `wineserver` on PATH nothing is ended, and the daemon says
+so once in its log. The unit sends SIGTERM to the daemon alone
+(`KillMode=mixed`, in the packaged unit and in the one the window writes
+for a source build), which is what gives it the chance: sent to the whole
+group, the signal would take `wineserver` down first and leave the rest of
+Wine to the timeout.
+
 The picker marks each plugin with its format, since the same plugin often
 ships in more than one, and its LV2, CLAP and VST3 buttons narrow the list
 to one of them. When the catalogue grows past what the window can be sent,

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -88,6 +88,7 @@ in
         TimeoutStartSec = 120;
         ExecStart = "${cfg.package}/bin/openxlr-daemon";
         TimeoutStopSec = 45;
+        KillMode = "mixed";
         Restart = "on-failure";
         RestartSec = 3;
         NoNewPrivileges = true;

--- a/packaging/openxlr-daemon.service
+++ b/packaging/openxlr-daemon.service
@@ -14,6 +14,11 @@ TimeoutStartSec=120
 ExecStart=%h/openxlr/src/OpenXLR.Daemon/bin/Release/net10.0/OpenXLR.Daemon
 Environment=OPENXLR_BUILD_MIXER=1
 TimeoutStopSec=45
+# SIGTERM goes to the daemon alone, so it can end the Wine session a bridged
+# plugin leaves behind before the rest of the group is killed. Sending it to
+# the whole group would take wineserver down first and leave winedevice.exe
+# to the timeout above.
+KillMode=mixed
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -423,6 +423,16 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
             bool inputBroken = _chains.Where(e => !e.Key.StartsWith("mix:", StringComparison.Ordinal)).Any(e => !e.Value.IsAlive)
                 || _chainOuts.Values.Any(l => _pw.EnsureLinks(l) == LinkHealth.Broken);
             if (inputBroken) { WireInputFeedsLocked(); changed = true; }
+            // A heal can retire the last bridged plugin without any command
+            // being given: a chain the restart policy has given up on is left
+            // off, and the helper that held Wine up goes with it. No rewire
+            // follows to notice, so the same decision is taken here, against
+            // the chains that now run, and carried out off this thread.
+            if (changed)
+            {
+                IReadOnlyList<WineSession.Ending> endings = _pw.WineEndings();
+                if (endings.Count > 0) Task.Run(() => _pw.EndWine(endings));
+            }
             return changed;
         }
     }
@@ -751,6 +761,13 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         _restarts.Forget(key);
         if (MixForKey(key) is MixDefinition mix) WireMixChainLocked(mix);
         else if (IsInsertChannel(key)) WireInputFeedsLocked();
+        // The new chain is up: if it holds no bridged plugin any more, Wine is
+        // resident for nothing, and it would still be resident hours later
+        // when the daemon stops. The decision is taken here, under the lock,
+        // against the chain that now runs; the helper runs off this thread so
+        // the command that caused the rewire answers straight away.
+        IReadOnlyList<WineSession.Ending> endings = _pw.WineEndings();
+        if (endings.Count > 0) Task.Run(() => _pw.EndWine(endings));
     }
 
     /// <summary>Capture the host under the mixer lock, then open its UI outside it.</summary>

--- a/src/OpenXLR.Core/Mixing/NativePluginHost.cs
+++ b/src/OpenXLR.Core/Mixing/NativePluginHost.cs
@@ -25,6 +25,15 @@ internal sealed class NativePluginHost : IDisposable
     private long _lastUiHeartbeat = Stopwatch.GetTimestamp();
 
     public Process Process { get; }
+
+    /// <summary>
+    /// Whether this helper loads a Windows plugin through yabridge, so Wine
+    /// is running behind it. What Wine leaves in the daemon's control group
+    /// outlives the helper, so the mixer has to know which helpers put it
+    /// there. See <see cref="WineSession"/>.
+    /// </summary>
+    public bool Bridged { get; }
+
     public bool IsRunning
     {
         get
@@ -133,6 +142,7 @@ internal sealed class NativePluginHost : IDisposable
         TimeSpan? patience = null, string? bundle = null)
     {
         if (patience is { } chosen) _patience = chosen;
+        Bridged = WineSession.Bridged(bundle);
         if (!File.Exists(executable))
             throw new InvalidOperationException(
                 "The native plugin host is not installed. Build it with -p:EnableNativeLv2Host=true, or switch this insert back to the filter chain.");

--- a/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
+++ b/src/OpenXLR.Core/Mixing/PipeWireAdapter.cs
@@ -24,14 +24,26 @@ public sealed class PipeWireAdapter
     private readonly List<Process> _loopbacks = [];
     private readonly List<Process> _filters = [];
     private readonly HashSet<NativePluginHost> _nativeHosts = [];
+    private readonly WineSession _wine;
 
-    public PipeWireAdapter() { }
+    public PipeWireAdapter() => _wine = new WineSession();
 
-    /// <summary>Report completed helper operations, including failures, to the daemon's progress gate.</summary>
-    public PipeWireAdapter(Action progress) => _progress = progress;
+    /// <summary>
+    /// Report completed helper operations, including failures, to the daemon's
+    /// progress gate. <paramref name="note"/> carries the few lines the mixer
+    /// has for the journal; the core has no logger of its own.
+    /// </summary>
+    public PipeWireAdapter(Action progress, Action<string>? note = null)
+    {
+        _progress = progress;
+        _wine = new WineSession(note);
+    }
 
     internal PipeWireAdapter(Func<DspFeatureAvailability> clipGuardAvailabilityOverride)
-        => _clipGuardAvailabilityOverride = clipGuardAvailabilityOverride;
+    {
+        _clipGuardAvailabilityOverride = clipGuardAvailabilityOverride;
+        _wine = new WineSession();
+    }
 
     /// <summary>
     /// pactl joins its arguments into one module-argument string, and PipeWire's
@@ -689,6 +701,9 @@ public sealed class PipeWireAdapter
                         throw new InvalidOperationException($"{info.Name} has no editor the native host can open; select the filter chain.");
                     var host = new NativePluginHost(insert, node, channels, rate, info.Path);
                     _nativeHosts.Add(host);
+                    // Wine starts behind a bridged plugin and outlives this
+                    // helper, so from here on it is this daemon's to end.
+                    if (host.Bridged) _wine.HelperStarted();
                     stage = new(node, node, node, host.Process) { NativeHost = host };
                     stages.Add(stage);
                     if (!WaitForPorts(node, "playback", false, TimeSpan.FromSeconds(3), host.Process)
@@ -1365,11 +1380,31 @@ public sealed class PipeWireAdapter
         return false;
     }
 
+    /// <summary>
+    /// Whether Wine can be ended now, and in which prefixes. Empty unless a
+    /// bridged plugin ran here, every bridged helper has gone, and a Wine
+    /// session this daemon started is up. Deciding is separate from doing, so
+    /// a caller can decide under its lock and make the call outside it.
+    /// </summary>
+    internal IReadOnlyList<WineSession.Ending> WineEndings() => _wine.Decide(_nativeHosts.Any(host => host.Bridged));
+
+    /// <summary>Carry out decided endings. Never throws, never waits long.</summary>
+    internal void EndWine(IReadOnlyList<WineSession.Ending> endings) => _wine.Run(endings);
+
     /// <summary>Remove everything this adapter created, in reverse order.</summary>
     public void TearDown()
     {
         foreach (NativePluginHost host in _nativeHosts) host.Dispose();
         _nativeHosts.Clear();
+        // Here the call is made rather than handed out: at a daemon stop this
+        // is the last chance to end Wine, and what it leaves has to be gone
+        // before the unit's control group is counted. It takes Wine a couple
+        // of seconds and nothing below depends on it, so it goes out now and
+        // is joined at the end: the stop pays the longer of the two, not the
+        // sum. It is bounded by the runner's deadline and cannot fail the
+        // teardown.
+        IReadOnlyList<WineSession.Ending> endings = WineEndings();
+        Task wine = endings.Count == 0 ? Task.CompletedTask : Task.Run(() => EndWine(endings));
         foreach (Process p in _loopbacks.Concat(_filters))
         {
             try { if (!p.HasExited) { p.Kill(entireProcessTree: true); p.WaitForExit(2000); } }
@@ -1385,6 +1420,8 @@ public sealed class PipeWireAdapter
             catch (Exception) { /* already unloaded */ }
         }
         _modules.Clear();
+        try { wine.Wait(WineSession.Deadline + TimeSpan.FromSeconds(1)); }
+        catch (Exception) { /* EndWine swallows its own failures; this is the join */ }
     }
 
     // The sweep asks for the graph several times a second (streams, devices,

--- a/src/OpenXLR.Core/Mixing/WineSession.cs
+++ b/src/OpenXLR.Core/Mixing/WineSession.cs
@@ -1,0 +1,201 @@
+using System.Text;
+
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>
+/// Ends the Wine prefix OpenXLR's bridged plugins ran in.
+///
+/// A Windows plugin loaded through yabridge brings up Wine's per-prefix
+/// service processes: a wineserver, services.exe, winedevice.exe and the
+/// rest. None of them is a child of the helper that started them, they stay
+/// after the helper exits, and they ignore SIGTERM, so they sit in the
+/// daemon's control group until systemd kills them at the unit's stop
+/// timeout. A stop that took one second took forty-five.
+///
+/// The cure is Wine's own: "wineserver -k" against the prefix, once the last
+/// bridged helper has gone. Which prefix is not guessed. yabridge picks the
+/// prefix from where the Windows plugin lives, not from the daemon's
+/// environment, so the prefixes are read back from the wineservers that
+/// share this process's control group. A wineserver can only be in it if one
+/// of our helpers forked it, which makes the control group both the answer to
+/// "which prefix" and the proof that OpenXLR started that session.
+///
+/// Everything else in the same prefix is left alone: another application's
+/// Wine session, a DAW with its own bridged plugins, an installer the user is
+/// running, all live in their own control groups, and ending one of those
+/// would take that application's plugins with it.
+///
+/// The decision and the helper call are separate on purpose. A caller decides
+/// under whatever lock it holds and makes the call outside it, so no command
+/// or state push ever waits on Wine.
+/// </summary>
+internal sealed class WineSession
+{
+    /// <summary>
+    /// "wineserver -k" signals the server and then walks a fixed schedule of
+    /// growing waits, about two and a quarter seconds of them, before it gives
+    /// up; it returns at once when there is no server to end. So this is that
+    /// schedule with room on top, and still short enough that a stop which
+    /// Wine ignores altogether costs seconds rather than the unit's timeout.
+    /// </summary>
+    public static readonly TimeSpan Deadline = TimeSpan.FromSeconds(6);
+
+    /// <summary>A decided ending: which wineserver to run, against which prefix.</summary>
+    public sealed record Ending(string Server, string Prefix);
+
+    private readonly Func<string, IReadOnlyList<string>, IReadOnlyDictionary<string, string>, ProcessResult> _run;
+    private readonly Func<string?> _findServer;
+    private readonly Func<IReadOnlyList<string>> _ourPrefixes;
+    private readonly Action<string>? _note;
+    private readonly object _gate = new();
+    private bool _bridgedRan;
+    private bool _saidNoServer;
+
+    public WineSession(Action<string>? note = null,
+        Func<string, IReadOnlyList<string>, IReadOnlyDictionary<string, string>, ProcessResult>? run = null,
+        Func<string?>? findServer = null, Func<IReadOnlyList<string>>? ourPrefixes = null)
+    {
+        _note = note;
+        // Helpers are started through ProcessRunner and so is this: arguments
+        // as a list, a deadline, and the tree killed if it is reached.
+        _run = run ?? ((server, arguments, environment)
+            => ProcessRunner.Run(server, arguments, Deadline, environment: environment));
+        _findServer = findServer ?? (() => PluginInstaller.OnPath("wineserver"));
+        _ourPrefixes = ourPrefixes ?? (() => PrefixesStartedHere());
+    }
+
+    /// <summary>A bridged helper has been started, so Wine is now this daemon's to end.</summary>
+    public void HelperStarted()
+    {
+        lock (_gate) _bridgedRan = true;
+    }
+
+    /// <summary>
+    /// What ending Wine would take now. Empty unless a bridged helper ran
+    /// here, every one of them has gone, there is a wineserver to run, and a
+    /// Wine session of ours is actually up. Asking again after a successful
+    /// ending finds no session and answers empty, so the question can be put
+    /// at every rewire and again at the stop; an ending that failed is simply
+    /// offered again.
+    /// </summary>
+    public IReadOnlyList<Ending> Decide(bool anyBridgedHelperAlive)
+    {
+        lock (_gate)
+        {
+            if (anyBridgedHelperAlive || !_bridgedRan) return [];
+            string? server = _findServer();
+            if (server is null)
+            {
+                if (!_saidNoServer)
+                {
+                    _saidNoServer = true;
+                    _note?.Invoke("no wineserver on PATH: what a bridged plugin leaves of Wine is the system's to clean up, and stopping the daemon waits for it");
+                }
+                return [];
+            }
+            return [.. _ourPrefixes().Select(prefix => new Ending(server, prefix))];
+        }
+    }
+
+    /// <summary>
+    /// Carry out decided endings. Never throws and never waits longer than
+    /// <see cref="Deadline"/> each: a shutdown that cannot end Wine goes on and
+    /// leaves it to systemd, which is where it was before.
+    /// </summary>
+    public void Run(IReadOnlyList<Ending> endings)
+    {
+        foreach (Ending ending in endings)
+        {
+            try
+            {
+                ProcessResult result = _run(ending.Server, ["-k"], RunEnvironment(ending.Prefix));
+                _note?.Invoke(result.Ok
+                    ? $"ended the Wine prefix {ending.Prefix}"
+                    : $"could not end the Wine prefix {ending.Prefix}: wineserver exit {result.ExitCode}{(result.TimedOut ? ", timed out" : "")}");
+            }
+            catch (Exception ex)
+            {
+                _note?.Invoke($"could not end the Wine prefix {ending.Prefix}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The same environment a bridged helper gets: the bridge's own directory
+    /// first on PATH, and the prefix to act on. wineserver picks the session it
+    /// ends by WINEPREFIX, so this is what decides which one goes.
+    /// </summary>
+    internal static Dictionary<string, string> RunEnvironment(string prefix)
+    {
+        Dictionary<string, string> environment = ManagedYabridge.Discover()?.HostEnvironment() ?? new(StringComparer.Ordinal);
+        environment["WINEPREFIX"] = prefix;
+        return environment;
+    }
+
+    /// <summary>
+    /// Whether a bundle is one of yabridge's wrappers, so loading it starts
+    /// Wine. Both layouts are named after the bridge: the companion's private
+    /// home, .../openxlr/yabridge/vst3/Plugin.vst3, and the system bridge's own
+    /// directory under the format's home, ~/.vst3/yabridge/Plugin.vst3.
+    /// </summary>
+    internal static bool Bridged(string? bundle)
+        => bundle is not null && bundle.Split('/').Contains("yabridge");
+
+    /// <summary>
+    /// The prefixes of the wineservers that share this process's control
+    /// group. Only a server one of our helpers forked is in it: a wineserver
+    /// is reparented to the user manager the moment it daemonizes, but it
+    /// keeps the control group it was forked in, and for a user service that
+    /// group is the unit. Usually one prefix, more when a user keeps their
+    /// Windows plugins in several.
+    /// </summary>
+    internal static IReadOnlyList<string> PrefixesStartedHere(string? procRoot = null, string? homePrefix = null)
+    {
+        procRoot ??= "/proc";
+        homePrefix ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".wine");
+        var found = new List<string>();
+        try
+        {
+            string ours = File.ReadAllText(Path.Combine(procRoot, "self", "cgroup")).Trim();
+            if (ours.Length == 0) return found;
+            foreach (string directory in Directory.EnumerateDirectories(procRoot))
+            {
+                if (!Path.GetFileName(directory).All(char.IsAsciiDigit)) continue;
+                try
+                {
+                    // comm first: it is one short read, and it rules out
+                    // everything but the handful of Wine processes.
+                    if (File.ReadAllText(Path.Combine(directory, "comm")).Trim() != "wineserver") continue;
+                    if (File.ReadAllText(Path.Combine(directory, "cgroup")).Trim() != ours) continue;
+                    string prefix = PrefixIn(File.ReadAllBytes(Path.Combine(directory, "environ")), homePrefix);
+                    if (!found.Contains(prefix, StringComparer.Ordinal)) found.Add(prefix);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+                {
+                    // The process ended between the listing and the read, or it
+                    // belongs to somebody else. Neither is ours.
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException) { }
+        return found;
+    }
+
+    /// <summary>
+    /// WINEPREFIX out of a process's environment block, or the prefix Wine
+    /// itself falls back to when the variable is not set.
+    /// </summary>
+    internal static string PrefixIn(byte[] environment, string homePrefix)
+    {
+        foreach (string entry in Encoding.UTF8.GetString(environment).Split('\0'))
+            if (entry.StartsWith("WINEPREFIX=", StringComparison.Ordinal))
+                return Normalize(entry["WINEPREFIX=".Length..]);
+        return Normalize(homePrefix);
+    }
+
+    private static string Normalize(string path)
+    {
+        try { return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path)); }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException) { return path; }
+    }
+}

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -56,7 +56,7 @@ public sealed class MixerService : IHostedService, IDisposable
         _config = config;
         _devices = devices;
         _lifetime = lifetime;
-        _mixer = new(new PipeWireAdapter(_progress.Mark));
+        _mixer = new(new PipeWireAdapter(_progress.Mark, note => _log.LogInformation("{msg}", note)));
         _saves = new SettingsSaver(
             () => _mixer.ExportSettings().Save(),
             error =>

--- a/src/OpenXLR.Tests/WineSessionTests.cs
+++ b/src/OpenXLR.Tests/WineSessionTests.cs
@@ -1,0 +1,187 @@
+using System.Text;
+using OpenXLR.Core;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+/// <summary>
+/// The decision to end a Wine prefix, with the process runner faked. Nothing
+/// here starts wineserver or reads a real prefix: what is proved is when the
+/// call is made, which prefix it names, and that a failure is survivable.
+/// </summary>
+public sealed class WineSessionTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "openxlr-wine-" + Guid.NewGuid().ToString("N"));
+    private readonly List<(string Server, string Arguments, string Prefix)> _calls = [];
+    private readonly List<string> _notes = [];
+
+    private const string Prefix = "/home/tester/.wine";
+    private const string Server = "/usr/bin/wineserver";
+
+    private ProcessResult Fake(string server, IReadOnlyList<string> arguments, IReadOnlyDictionary<string, string> environment)
+    {
+        _calls.Add((server, string.Join(' ', arguments), environment.TryGetValue("WINEPREFIX", out string? p) ? p : ""));
+        return new ProcessResult(0, [], "", false, false);
+    }
+
+    private WineSession Session(string? server = Server, IReadOnlyList<string>? prefixes = null,
+        Func<string, IReadOnlyList<string>, IReadOnlyDictionary<string, string>, ProcessResult>? run = null)
+        => new(_notes.Add, run ?? Fake, () => server, () => prefixes ?? [Prefix]);
+
+    private void End(WineSession session, bool anyBridgedHelperAlive) => session.Run(session.Decide(anyBridgedHelperAlive));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, true);
+    }
+
+    [Fact]
+    public void WineIsNeverEndedWhenNoBridgedHelperRanHere()
+    {
+        WineSession session = Session();
+        End(session, anyBridgedHelperAlive: false);
+        Assert.Empty(_calls);
+    }
+
+    [Fact]
+    public void WineIsLeftAloneWhileABridgedHelperIsStillRunning()
+    {
+        WineSession session = Session();
+        session.HelperStarted();
+        End(session, anyBridgedHelperAlive: true);
+        Assert.Empty(_calls);
+
+        // The same session ends it once the last helper has gone: a rebuild
+        // that drops the last bridged insert must not leave Wine resident.
+        End(session, anyBridgedHelperAlive: false);
+        Assert.Equal([(Server, "-k", Prefix)], _calls);
+    }
+
+    [Fact]
+    public void AnEndedSessionIsNotEndedAgainAndAFailedOneIsRetriedAtTheStop()
+    {
+        // The ending is decided from the Wine sessions that are up, so once
+        // one is gone the same question answers empty however often it is put.
+        List<string> running = [Prefix];
+        WineSession session = new(_notes.Add, (server, arguments, environment) =>
+        {
+            running.Remove(environment["WINEPREFIX"]);
+            return Fake(server, arguments, environment);
+        }, () => Server, () => running);
+        session.HelperStarted();
+        End(session, anyBridgedHelperAlive: false);
+        End(session, anyBridgedHelperAlive: false);
+        Assert.Single(_calls);
+
+        // A kill that failed leaves the session up, and the daemon's stop
+        // gets another go at it rather than inheriting the wait.
+        _calls.Clear();
+        WineSession failing = Session(run: (server, arguments, environment) =>
+        {
+            Fake(server, arguments, environment);
+            return new ProcessResult(1, [], "cannot connect to the wineserver", false, false);
+        });
+        failing.HelperStarted();
+        End(failing, anyBridgedHelperAlive: false);
+        End(failing, anyBridgedHelperAlive: false);
+        Assert.Equal(2, _calls.Count);
+    }
+
+    [Fact]
+    public void EveryPrefixThisDaemonStartedIsEndedAndNothingElseIs()
+    {
+        WineSession session = Session(prefixes: ["/home/tester/.wine", "/srv/prefixes/plugins"]);
+        session.HelperStarted();
+        End(session, anyBridgedHelperAlive: false);
+        Assert.Equal([(Server, "-k", "/home/tester/.wine"), (Server, "-k", "/srv/prefixes/plugins")], _calls);
+    }
+
+    [Fact]
+    public void AWineSessionThisDaemonDidNotStartIsNotEnded()
+    {
+        WineSession session = Session(prefixes: []);
+        session.HelperStarted();
+        End(session, anyBridgedHelperAlive: false);
+        Assert.Empty(_calls);
+
+        // Nothing was spent either: the decision stands for when a session of
+        // ours does turn up.
+        Assert.Empty(_notes);
+    }
+
+    [Fact]
+    public void WithoutAWineserverOnPathNothingRunsAndItIsSaidOnce()
+    {
+        WineSession session = Session(server: null);
+        session.HelperStarted();
+        End(session, anyBridgedHelperAlive: false);
+        End(session, anyBridgedHelperAlive: false);
+        Assert.Empty(_calls);
+        Assert.Single(_notes);
+        Assert.Contains("wineserver", _notes[0]);
+    }
+
+    [Fact]
+    public void AFailingWineserverIsReportedAndDoesNotThrow()
+    {
+        WineSession timedOut = Session(run: (_, _, _) => new ProcessResult(-1, [], "", true, false));
+        timedOut.HelperStarted();
+        End(timedOut, anyBridgedHelperAlive: false);
+        Assert.Contains("timed out", _notes[^1]);
+
+        _notes.Clear();
+        WineSession broken = Session(run: (_, _, _) => throw new InvalidOperationException("failed to start wineserver"));
+        broken.HelperStarted();
+        End(broken, anyBridgedHelperAlive: false);
+        Assert.Contains("failed to start wineserver", _notes[^1]);
+    }
+
+    [Fact]
+    public void OnlyYabridgeWrappersCountAsBridged()
+    {
+        Assert.True(WineSession.Bridged("/home/t/.local/share/openxlr/yabridge/vst3/TDR Nova.vst3"));
+        Assert.True(WineSession.Bridged("/home/t/.vst3/yabridge/ValhallaSupermassive.vst3"));
+        Assert.True(WineSession.Bridged("/home/t/.clap/yabridge/Plugin.clap"));
+        Assert.False(WineSession.Bridged("/usr/lib/vst3/Calf.vst3"));
+        Assert.False(WineSession.Bridged("/home/t/.lv2/eq10q.lv2"));
+        Assert.False(WineSession.Bridged(null));
+    }
+
+    [Fact]
+    public void WineprefixIsReadFromAProcessEnvironmentWithWinesOwnFallback()
+    {
+        byte[] block = Encoding.UTF8.GetBytes("PATH=/usr/bin\0WINEPREFIX=/srv/prefix/\0HOME=/home/t\0");
+        Assert.Equal("/srv/prefix", WineSession.PrefixIn(block, "/home/t/.wine"));
+        Assert.Equal("/home/t/.wine", WineSession.PrefixIn(Encoding.UTF8.GetBytes("HOME=/home/t\0"), "/home/t/.wine"));
+    }
+
+    [Fact]
+    public void OnlyTheWineserversInThisProcessesControlGroupAreCollected()
+    {
+        const string ours = "0::/user.slice/user-1000.slice/user@1000.service/app.slice/openxlr-daemon.service";
+        const string theirs = "0::/user.slice/user-1000.slice/session.slice/reaper.scope";
+        Directory.CreateDirectory(Path.Combine(_root, "self"));
+        File.WriteAllText(Path.Combine(_root, "self", "cgroup"), ours + "\n");
+        Fixture("11", "pipewire", Prefix, ours);                     // not a wineserver
+        Fixture("13", "wineserver", "/home/tester/.other", theirs);  // another application's session
+
+        Assert.Empty(WineSession.PrefixesStartedHere(_root, Prefix));
+
+        Fixture("14", "wineserver", "/srv/prefixes/plugins/", ours);
+        Assert.Equal(["/srv/prefixes/plugins"], WineSession.PrefixesStartedHere(_root, Prefix));
+
+        // Wine's own default counts as the prefix when the variable is unset.
+        Fixture("15", "wineserver", null, ours);
+        Assert.Equal([Prefix, "/srv/prefixes/plugins"], WineSession.PrefixesStartedHere(_root, Prefix).Order().ToList());
+    }
+
+    private void Fixture(string pid, string comm, string? prefix, string cgroup)
+    {
+        string directory = Path.Combine(_root, pid);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "comm"), comm + "\n");
+        File.WriteAllText(Path.Combine(directory, "cgroup"), cgroup + "\n");
+        File.WriteAllBytes(Path.Combine(directory, "environ"),
+            Encoding.UTF8.GetBytes("HOME=/home/tester\0" + (prefix is null ? "" : $"WINEPREFIX={prefix}\0")));
+    }
+}

--- a/src/OpenXLR.UI/UiSettings.cs
+++ b/src/OpenXLR.UI/UiSettings.cs
@@ -421,6 +421,7 @@ public static class StartupIntegration
                     ExecStart={SystemdQuote(daemon)}
                     Environment=OPENXLR_BUILD_MIXER=1
                     TimeoutStopSec=45
+                    KillMode=mixed
                     Restart=on-failure
                     RestartSec=3
                     NoNewPrivileges=true


### PR DESCRIPTION
Fixes #85.

## Cause

After a Windows VST3 plugin has run through yabridge, Wine's per-prefix service processes (`wineserver`, `services.exe`, `winedevice.exe`, `explorer.exe`, `plugplay.exe`, `svchost.exe`, `rpcss.exe`) stay alive in the daemon's control group once the helper has exited. They are children of the user manager, not of the helper, so the helper's process-tree kill never reaches them; they ignore SIGTERM, and systemd kills them at `TimeoutStopSec=45`. Every stop and restart with a bridged plugin running paid those 45 seconds, and the unit ended marked failed with result timeout.

## Change

A `WineSession` in Core ends the Wine session the daemon started, once nothing of ours uses it.

- Which prefix: yabridge chooses the prefix from where the Windows plugin lives, not from the daemon's environment, so the prefix is read back from the `wineserver` processes whose control group equals the daemon's own (`/proc/<pid>/cgroup`), with `WINEPREFIX` from their environ and Wine's `~/.wine` default. A `wineserver` outside our control group, such as one a DAW or an installer started in the same prefix, is never touched.
- When: only after a bridged helper ran in this daemon and no bridged helper is alive. Decided under the mixer lock after a rewire, against the chain that now runs, and carried out on a pool thread, so an insert edit that keeps a bridged plugin never pays a Wine restart and no command or state push waits on Wine. At daemon stop the ending is started before the module unloads and joined after them, so a stop pays the longer of the two rather than the sum.
- How: `wineserver -k` through `ProcessRunner`, with the helpers' PATH and the prefix, a 6 s deadline (Wine's own shutdown schedule takes about 2.3 s), failures noted in the journal and never thrown. Without a `wineserver` on PATH it notes that once and leaves the cleanup to systemd as before.
- `NativePluginHost` carries a `Bridged` flag from its bundle path (the companion's private home and the system yabridge layout).

The unit gains `KillMode=mixed` in all three places that define it (`packaging/openxlr-daemon.service`, the Nix module, and the unit the window writes for a source build). With the default `control-group` mode, `systemctl stop` sends SIGTERM to every process in the group at once, `wineserver` exits on it before the daemon's teardown runs, and only `winedevice.exe`, which ignores the signal, is left; the daemon then finds no session of its own to end. With `mixed`, SIGTERM reaches the daemon alone, the ending runs while `wineserver` is still there, and systemd kills whatever remains after the daemon exits. `TimeoutStopSec=45` stays as the backstop. The manual gains a note on how Wine is ended and why the unit is set that way.

## Tests

Ten cases in `WineSessionTests` with a faked runner and a faked `/proc` tree: no ending while a bridged helper is alive or when none ran; nothing without `wineserver`, noted once; only wineservers in our control group count; `WINEPREFIX` read from environ with the `~/.wine` default; several prefixes; a failed ending offered again; a successful one leaves nothing to find. None runs `wineserver` or reads `~/.wine`.

## Checks

- Release build with warnings as errors: 0 warnings, 0 errors.
- `dotnet test`: 378 passed, 2 skipped (the Xvfb-gated window tests). Baseline 368.
- `tools/check-version.sh`, `check-spec.py`, `check-openapi.py`, `check-locked-restore.sh`: pass.
- The control-group rule emulated against the live daemon found exactly one `wineserver`, ours, in `~/.wine`. `wineserver -k` against a throwaway prefix in a scratch directory: exit 0, process gone, 2251 ms.

## Verification on the desk

Wave XLR Pro, two bridged VST3 inserts (TDR Nova and ValhallaSupermassive) running on the Stream mix, daemon built from this branch with the native host.

- Rewire path: bypassing both inserts retired the helpers, and three seconds later `wineserver` and both `winedevice.exe` were gone from the daemon's control group with "ended the Wine prefix /home/emanuele/.wine" in the journal. Un-bypassing brought the helpers and Wine back in four seconds.
- Stop path with the unit's previous `KillMode=control-group`: 46 s, `final-sigterm` timeout, `winedevice.exe` killed by systemd, unit failed with result timeout. The ending was never decided, for the reason above.
- Stop path with `KillMode=mixed`: 2 s, "ended the Wine prefix" in the journal, unit stopped with result success, no Wine process left in the session. Start afterwards: 11 s to both helpers.
