### PR TITLE
Plugins: report failed scans and retain diagnostic output

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,7 +57,7 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls, within the message size limit above and always including the plugins the saved chains use; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, `windowsDirectories` (the folders yabridge bridges) and `wineFolders` (Wine's own plugin folders that hold a plugin and are not bridged yet, offered as one press since a file dialog hides them) |
 | `pluginDiagnostics` | in answer to `getPluginDiagnostics` | `discovery`: daemon host/controller paths, Wine prefix, architecture, effective search paths, bounded `yabridgectl status` output and latest completed CLAP/VST3 scan reports |
-| `pluginInstall` | in answer to `installPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
+| `pluginInstall` | in answer to `installPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user, ending with the bundles the scan that followed could not read, up to three by name and the rest as a count), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
 | `error` | when a command without a `requestId` is rejected | `message` |
 | `commandResult` | in answer to a command that carried a `requestId` | `requestId`, `error` (null on success); preceded by the state the result refers to |
 
@@ -193,8 +193,20 @@ means no native scan has completed yet. Entries carry `path`, `outcome`,
 while the native helper that wrote it is the one asking, so `cached` is
 false everywhere in the first scan after the helper changes. Reports retain
 at most 128 entries per format, preferring failures over successful entries
-when full. Paths are limited to 4096 characters and details to 2048, with
-truncation marked.
+when full. Paths keep the first 4096 characters plus a truncation marker.
+Details use at most 2048 characters including the marker, with a quarter of
+the remaining space for the start and three quarters for the end. This
+keeps later errors from being hidden by a bridge's startup banner.
+
+After startup discovery and each install, sync or rescan, the daemon logs
+retained scan failures with their format, path, outcome and exit code when
+known. `pluginInstall.message` appends a summary of these failures without
+changing `ok`, `installed`, `added` or `total`. `ok` still describes the
+install or sync step, not whether every bundle could be scanned. Missing
+optional directories, an absent native helper and bundles reporting no
+plugins are not counted as scan failures. The summary uses the retained
+entries, so check `omitted` for larger scans. A timed-out scan is not cached
+and will be retried on the next rescan.
 
 These reports describe scanner output before the `plugins` message's size
 budget and the picker's channel-width/format filters. Compare them with

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -396,6 +396,54 @@ picked straight out of Downloads would hand yabridge your whole Downloads
 folder. VST2 `.dll` files are left out either way, since OpenXLR cannot
 load VST2.
 
+<a name="bundle-not-read"></a>
+**A bridged plugin is not in the picker.** A successful yabridge sync means
+the wrapper exists, not that OpenXLR could read the plugin. Each CLAP or
+VST3 bundle is scanned in a separate process. If that process fails or
+takes longer than a minute, the bundle contributes no plugins to the
+catalogue. Install, bridge, sync and Rescan replies name up to three scan
+failures and count the rest, for example:
+
+```
+1 bundle could not be read: TDR Kotelnikov.vst3 (timed out); the daemon's log says more.
+```
+
+The daemon also logs scan failures after startup discovery and after these
+commands, with the format, bundle path, outcome and exit code when known:
+
+```sh
+journalctl --user -u openxlr-daemon -n 200 --no-pager | grep 'plugin scan'
+```
+
+A timeout is not cached, so the next Rescan tries that bundle again. The
+warning makes a failed scan visible; it does not fix the underlying Wine
+or plugin failure. Collect [diagnostics](#reporting) after the scan ends.
+`plugin-discovery.json` keeps both the beginning and the end of long scanner
+output, since a bridge's startup banner can otherwise hide later errors.
+Review paths and output before sharing.
+
+After a Wine upgrade, a bridged scan can be the first program to use an
+older Wine prefix. Wine then updates it and may show an optional Mono or
+Gecko installer dialog; the scan can wait behind that dialog until its
+deadline. Check for an open Wine dialog and finish or cancel it, declining
+optional components you do not need, then Rescan. If there is no visible
+dialog, close other Wine applications using the same prefix and start Wine
+interactively so any pending update can finish where its dialogs are
+visible. For the default prefix:
+
+```sh
+WINEPREFIX="$HOME/.wine" wineboot
+```
+
+Use the plugin's actual prefix if it is not the default. Wait for Wine to
+finish, then Rescan. This is a possible explanation for a timeout, not
+proof that every missing plugin is waiting on a dialog.
+
+A timeout alone does not tell us why Wine or the plugin stopped answering.
+Do not run `wineboot -u` or a prefix-wide `wineserver -k` as a routine fix:
+they change or stop other Wine applications using that prefix. Start with
+the scan evidence instead.
+
 <a name="windows-editor-input"></a>
 **A Windows plugin's own editor ignores the mouse.** The plugin plays, its
 interface is drawn and it follows anything you change from OpenXLR, but

--- a/src/OpenXLR.Core/Mixing/PluginCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/PluginCatalog.cs
@@ -75,8 +75,17 @@ public static class PluginCatalog
         => Plugins.Count(p => !known.Contains((p.Kind, p.Plugin))
             && (directories.Count == 0 || p.Path is null || directories.Any(d => p.Path.StartsWith(d, StringComparison.Ordinal))));
 
-    /// <summary>Kick both scans off without waiting for them.</summary>
-    public static void Warm() => ThreadPool.QueueUserWorkItem(_ => { try { _ = All.Value; } catch (Exception) { } });
+    /// <summary>
+    /// Kick both scans off without waiting for them. <paramref name="then"/>
+    /// runs once they are done, on the same thread: the startup scan is the
+    /// one that has no user watching it, so whatever it could not read is
+    /// reported from there.
+    /// </summary>
+    public static void Warm(Action? then = null) => ThreadPool.QueueUserWorkItem(_ =>
+    {
+        try { _ = All.Value; } catch (Exception) { }
+        try { then?.Invoke(); } catch (Exception) { }
+    });
 
     /// <summary>The plugin an insert names, by its kind and its identifier.</summary>
     public static PluginInfo? Find(string kind, string plugin) => Find(Plugins, kind, plugin);

--- a/src/OpenXLR.Core/Mixing/PluginScanDiagnostics.cs
+++ b/src/OpenXLR.Core/Mixing/PluginScanDiagnostics.cs
@@ -7,6 +7,9 @@ public sealed record PluginScanEntry(string Path, string Outcome, bool Cached = 
 public sealed record PluginScanReport(string Kind, DateTimeOffset CompletedAt,
     IReadOnlyList<PluginScanEntry> Entries, int Omitted);
 
+/// <summary>One bundle the last scan of a format found and could not read.</summary>
+public sealed record PluginScanFailure(string Kind, string Path, string Outcome, int? ExitCode);
+
 public static class PluginScanDiagnostics
 {
     private static readonly object Gate = new();
@@ -15,6 +18,55 @@ public static class PluginScanDiagnostics
     public static IReadOnlyList<PluginScanReport> Snapshot()
     {
         lock (Gate) return Reports.Values.OrderBy(r => r.Kind, StringComparer.Ordinal).ToArray();
+    }
+
+    /// <summary>
+    /// The outcomes that cost the catalogue a plugin it should have had.
+    /// A folder that is not there, a bundle that describes nothing and a
+    /// native host that was never installed are states a working system can
+    /// be in, so they are not among them.
+    /// </summary>
+    private static readonly Dictionary<string, string> Reasons = new(StringComparer.Ordinal)
+    {
+        ["timeout"] = "timed out",
+        ["scan-failed"] = "the scanner failed",
+        ["output-limit"] = "it described too much",
+        ["start-error"] = "the scanner could not start",
+        ["invalid-description"] = "its description could not be read",
+        ["directory-error"] = "the folder could not be read",
+        ["scan-error"] = "the scan failed",
+    };
+
+    /// <summary>Every bundle the last scan of each format could not read.</summary>
+    public static IReadOnlyList<PluginScanFailure> Failures() => Failures(Snapshot());
+
+    /// <summary>The same over reports a caller already holds.</summary>
+    public static IReadOnlyList<PluginScanFailure> Failures(IEnumerable<PluginScanReport> reports)
+        => [.. reports.SelectMany(r => r.Entries.Where(e => Reasons.ContainsKey(e.Outcome))
+            .Select(e => new PluginScanFailure(r.Kind, e.Path, e.Outcome, e.ExitCode)))];
+
+    /// <summary>
+    /// The failures as a sentence for the user, empty when there are none.
+    /// A scan that loses a bundle used to say nothing at all: the catalogue
+    /// simply came back the size it was, and the answer to a rescan read as
+    /// if there had been nothing to find. Bounded the way the rest of the
+    /// reply is, three names and a count, so it stays a sentence.
+    /// </summary>
+    public static string Sentence(IReadOnlyList<PluginScanFailure> failures)
+    {
+        if (failures.Count == 0) return "";
+        const int Named = 3;
+        string names = string.Join(", ", failures.Take(Named).Select(f =>
+            $"{Name(f.Path)} ({Reasons.GetValueOrDefault(f.Outcome, f.Outcome)})"));
+        if (failures.Count > Named) names += $" and {failures.Count - Named} more";
+        string count = failures.Count == 1 ? "1 bundle" : $"{failures.Count} bundles";
+        return $"{count} could not be read: {names}; the daemon's log says more.";
+    }
+
+    private static string Name(string path)
+    {
+        string name = System.IO.Path.GetFileName(path.TrimEnd('/'));
+        return name.Length == 0 ? "a plugin folder" : name;
     }
 
     internal sealed class Capture(string kind)
@@ -34,7 +86,7 @@ public static class PluginScanDiagnostics
                 if (replace < 0) return;
                 _entries.RemoveAt(replace);
             }
-            _entries.Add(new(Clip(path, 4096)!, outcome, cached, plugins, duplicates, exitCode, Clip(detail, 2048)));
+            _entries.Add(new(Clip(path, 4096)!, outcome, cached, plugins, duplicates, exitCode, ClipEnds(detail, 2048)));
         }
 
         public PluginScanReport Complete()
@@ -47,4 +99,15 @@ public static class PluginScanDiagnostics
 
     internal static string? Clip(string? text, int limit)
         => text is { Length: > 0 } && text.Length > limit ? text[..limit] + " [truncated]" : text;
+
+    /// <summary>Keep the startup context and later errors without letting a bridge banner fill the detail.</summary>
+    internal static string? ClipEnds(string? text, int limit)
+    {
+        if (text is not { Length: > 0 } || text.Length <= limit) return text;
+        const string marker = " [truncated] ";
+        if (limit <= marker.Length) return text[..limit];
+        int room = limit - marker.Length;
+        int head = room / 4;
+        return text[..head] + marker + text[^(room - head)..];
+    }
 }

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -188,7 +188,9 @@ public sealed class MixerService : IHostedService, IDisposable
             _log.LogInformation("submixer off (daemon.json, --mixer, or OPENXLR_BUILD_MIXER=1 turn it on); hardware control only");
             return Task.CompletedTask;
         }
-        OpenXLR.Core.Mixing.PluginCatalog.Warm();   // plugin inserts: scan the LV2 and CLAP bundles off the startup path
+        // plugin inserts: scan the LV2, CLAP and VST3 bundles off the startup
+        // path, and say in the log what the scan could not read.
+        OpenXLR.Core.Mixing.PluginCatalog.Warm(() => PluginScanLog.Write(_log));
         _progress.Mark();
         _checkingProgress = true;
 

--- a/src/OpenXLR.Daemon/PluginScanLog.cs
+++ b/src/OpenXLR.Daemon/PluginScanLog.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Daemon;
+
+/// <summary>
+/// What the last plugin scan could not read, in the daemon's log. The scan
+/// itself runs in Core, which has no logger and keeps its evidence bounded
+/// for the diagnostics archive; without this the only record of a bundle
+/// the scan lost was that archive, and a user who never collects one has
+/// nothing to go on but a picker that is missing a plugin.
+/// </summary>
+internal static class PluginScanLog
+{
+    /// <summary>Log one line per failure and hand the caller the same list.</summary>
+    internal static IReadOnlyList<PluginScanFailure> Write(ILogger log)
+    {
+        IReadOnlyList<PluginScanFailure> failures = PluginScanDiagnostics.Failures();
+        foreach (PluginScanFailure failure in failures)
+            log.LogWarning("plugin scan: {kind} bundle not read: {path}: {outcome}{exit}",
+                failure.Kind, failure.Path, failure.Outcome,
+                failure.ExitCode is int code ? $" (exit {code})" : "");
+        return failures;
+    }
+}

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -385,7 +385,15 @@ public sealed class WebSocketHub
             int total = OpenXLR.Core.Mixing.PluginCatalog.Plugins.Count;
             if (outcome.Ok) _log.LogInformation("plugins: {message} {added} new in the catalogue", outcome.Message, added);
             else _log.LogInformation("plugins: {message}", outcome.Message);
-            return new PluginInstallMessage(outcome.Ok, outcome.Message, outcome.Installed, added, total);
+            // A bundle the scan could not read costs the catalogue a plugin,
+            // and used to cost it silently: the answer said how many plugins
+            // there are, which reads as "nothing to find" to someone who has
+            // just installed one. Say it in the reply and in the log.
+            IReadOnlyList<OpenXLR.Core.Mixing.PluginScanFailure> failures = PluginScanLog.Write(_log);
+            string note = OpenXLR.Core.Mixing.PluginScanDiagnostics.Sentence(failures);
+            string message = note.Length == 0 ? outcome.Message
+                : outcome.Message.Length == 0 ? note : outcome.Message + " " + note;
+            return new PluginInstallMessage(outcome.Ok, message, outcome.Installed, added, total);
         }
     }
 

--- a/src/OpenXLR.Tests/PluginScanDiagnosticsTests.cs
+++ b/src/OpenXLR.Tests/PluginScanDiagnosticsTests.cs
@@ -1,6 +1,8 @@
 using System.Text;
+using Microsoft.Extensions.Logging;
 using OpenXLR.Core;
 using OpenXLR.Core.Mixing;
+using OpenXLR.Daemon;
 
 namespace OpenXLR.Tests;
 
@@ -85,14 +87,125 @@ public sealed class PluginScanDiagnosticsTests
     {
         var capture = new PluginScanDiagnostics.Capture("bounded-test");
         for (int i = 0; i < 200; i++) capture.Add("/plugin/" + i, "ok");
-        capture.Add(new string('p', 9000), "scan-failed", detail: new string('e', 9000));
+        capture.Add(new string('p', 9000), "scan-failed", detail: "first" + new string('e', 9000) + "last");
         var report = capture.Complete();
         Assert.Equal(128, report.Entries.Count);
         Assert.Equal(73, report.Omitted);
         var failure = Assert.Single(report.Entries, e => e.Outcome == "scan-failed");
         Assert.True(failure.Path.Length < 4200);
+        Assert.EndsWith("[truncated]", failure.Path);
         Assert.True(failure.Detail!.Length < 2100);
-        Assert.EndsWith("[truncated]", failure.Detail);
+        Assert.StartsWith("first", failure.Detail);
+        Assert.EndsWith("last", failure.Detail);
+    }
+
+    // Replay the recorded timeout and exit code with synthetic long stderr.
+    // The reporter's tail was lost, so this does not identify why Wine hung.
+    [Fact]
+    public void ATimedOutBundleKeepsBothEndsOfTheScannerOutputAndIsNamedAsAFailure()
+    {
+        string dir = Directory.CreateTempSubdirectory("plugin-scan-tail-").FullName;
+        string kind = Guid.NewGuid().ToString("N");
+        try
+        {
+            string bundle = Path.Combine(dir, "TDR Kotelnikov.vst3");
+            File.WriteAllText(bundle, "fixture");
+            string banner = string.Join("\n", Enumerable.Range(0, 60)
+                .Select(i => $"11:44:07 [bridge] Initializing yabridge, start-up line {i}"));
+            string output = banner + "\nSYNTHETIC-TAIL scanner diagnostic after the startup banner";
+            Assert.True(output.Length > 2048);
+            var cache = new ScanCache(Path.Combine(dir, "cache"));
+
+            int calls = 0;
+            ProcessResult Describe(string _) { calls++; return new(137, [], output, true, false); }
+            var result = HostScan.Run(kind, "unused", [dir], Vst3Catalog.Bundles, Describe, cache);
+
+            Assert.Empty(result);
+            var report = PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind);
+            var entry = Assert.Single(report.Entries, e => e.Outcome == "timeout");
+            Assert.Equal(137, entry.ExitCode);
+            Assert.False(entry.Cached);
+            Assert.Contains("start-up line 0", entry.Detail);
+            Assert.Contains("SYNTHETIC-TAIL", entry.Detail);
+            Assert.Contains("[truncated]", entry.Detail);
+            Assert.Equal(2048, entry.Detail!.Length);
+
+            var failure = Assert.Single(PluginScanDiagnostics.Failures([report]));
+            Assert.Equal(kind, failure.Kind);
+            Assert.Equal(bundle, failure.Path);
+            Assert.Equal("timeout", failure.Outcome);
+            Assert.Equal(137, failure.ExitCode);
+            Assert.Equal("1 bundle could not be read: TDR Kotelnikov.vst3 (timed out); the daemon's log says more.",
+                PluginScanDiagnostics.Sentence([failure]));
+
+            var log = new ScanLogger();
+            PluginScanLog.Write(log);
+            var warning = Assert.Single(log.Lines, line => line.Text.Contains(kind));
+            Assert.Equal(LogLevel.Warning, warning.Level);
+            Assert.Contains(bundle, warning.Text);
+            Assert.Contains("timeout (exit 137)", warning.Text);
+
+            // Rescan retries a timeout, including through a reloaded disk cache.
+            Assert.Empty(HostScan.Run(kind, "unused", [dir], Vst3Catalog.Bundles, Describe,
+                new ScanCache(Path.Combine(dir, "cache"))));
+            Assert.Equal(2, calls);
+
+            // When the same bundle answers, the old warning disappears and
+            // the successful description can be cached without another launch.
+            ProcessResult Recovered(string _) => new(0, Encoding.UTF8.GetBytes(
+                "{\"plugins\":[{\"id\":\"recovered\",\"name\":\"Recovered\",\"audioIns\":2,\"audioOuts\":2}]}"), "", false, false);
+            Assert.Single(HostScan.Run(kind, "unused", [dir], Vst3Catalog.Bundles, Recovered, cache));
+            Assert.Single(HostScan.Run(kind, "unused", [dir], Vst3Catalog.Bundles, Describe, cache));
+            Assert.Equal(2, calls);
+            report = PluginScanDiagnostics.Snapshot().Single(r => r.Kind == kind);
+            Assert.Contains(report.Entries, e => e.Outcome == "ok" && e.Cached);
+            Assert.Empty(PluginScanDiagnostics.Failures([report]));
+            log.Lines.Clear();
+            PluginScanLog.Write(log);
+            Assert.DoesNotContain(log.Lines, line => line.Text.Contains(kind));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("short error")]
+    public void ShortDetailsAreUnchanged(string? text)
+        => Assert.Equal(text, PluginScanDiagnostics.ClipEnds(text, 2048));
+
+    private sealed class ScanLogger : ILogger
+    {
+        internal readonly List<(LogLevel Level, string Text)> Lines = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel level) => true;
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? error,
+            Func<TState, Exception?, string> format) => Lines.Add((level, format(state, error)));
+    }
+
+    [Fact]
+    public void TheFailureSentenceNamesThreeBundlesAndCountsTheRest()
+    {
+        var capture = new PluginScanDiagnostics.Capture("failure-sentence-test");
+        capture.Add("/plugins/Ok.vst3", "ok", plugins: 1);
+        capture.Add("/plugins/absent", "directory-missing");
+        capture.Add("/plugins/Empty.vst3", "no-plugins");
+        capture.Add("/usr/lib/openxlr/daemon/openxlr-lv2-host", "host-missing");
+        capture.Add("/plugins/A.vst3", "timeout", exitCode: 137);
+        capture.Add("/plugins/B.vst3", "scan-failed", exitCode: 9);
+        capture.Add("/plugins/C.vst3", "invalid-description");
+        capture.Add("/plugins/D.vst3", "output-limit");
+        capture.Add("/plugins/E.clap", "start-error");
+
+        var failures = PluginScanDiagnostics.Failures([capture.Complete()]);
+
+        // A folder that is not there, a bundle with nothing in it and a host
+        // that was never installed are states, not failures to report.
+        Assert.Equal(5, failures.Count);
+        Assert.Equal("5 bundles could not be read: A.vst3 (timed out), B.vst3 (the scanner failed), "
+            + "C.vst3 (its description could not be read) and 2 more; the daemon's log says more.",
+            PluginScanDiagnostics.Sentence(failures));
+        Assert.Equal("", PluginScanDiagnostics.Sentence([]));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Make failed plugin scans visible instead of reporting only an unchanged catalogue count.

- Install, Windows-plugin sync and rescan replies name up to three unreadable bundles and count the remainder, using the existing message field. Operation success, installed paths and catalogue counts keep their existing meaning.
- Log scan failures after startup discovery and command-driven scans, including format, path, outcome and exit code. Missing search directories and empty scans do not become warnings.
- Keep the beginning and end of long scanner details within the existing 2048-character bound, so a bridge startup banner cannot consume all retained evidence.
- Document scan warnings, retries and a conservative way to investigate Wine dialogs after a prefix update. No automatic Wine reset, component override or longer scan deadline is introduced.

## What prompted this

A TDR Kotelnikov report showed successful Windows VST3 discovery and yabridge synchronization, followed by a bundle scan timeout at the existing 60-second deadline. The plugin never reached the catalogue. The saved diagnostic detail contained only the beginning of the bridge banner, while the rescan result gave no visible explanation for the missing plugin.

This is distinct from the earlier client catalogue-budget issue. These changes improve failure visibility and evidence retention; they do not claim to fix an unknown Wine or plugin failure automatically.

## Actual plugin testing

Tested the official standard TDR Kotelnikov 1.6.7 portable x64 VST3 with Wine 11.17 and the reporter's companion build 5.1.1.54-1, using an isolated prefix and display:

| Condition | Result |
| --- | --- |
| Initialized prefix, companion bridge | Successful metadata scan in 470 ms; repeat in 464 ms |
| Initialized prefix, system yabridge 5.1.1-10 | Successful metadata scan in 428 ms |
| Simulated stale prefix, optional Wine Mono dialog left open | Timed out at 60 seconds with exit 137 and no metadata |
| Same pending update, dialog cancelled during the scan | Successful metadata scan at 14.6 seconds |

Both bridges returned Kotelnikov's stereo layout and 22 parameters. This establishes a mechanism that reproduces the reported timeout, not the reporter's actual cause: their archive does not identify a dialog or prefix-update state. The successful scans test metadata loading, not audio processing or editor interaction.

A blanket Mono/Gecko override is deliberately excluded: other plugin factories may require those components even during scanning. A timestamp mismatch alone is not proof that a dialog is blocking a scan.

## Verification

- Locked restore and Release build with warnings treated as errors: zero warnings, zero errors.
- Full .NET suite: 402 passed, 2 desktop-gated tests skipped.
- Focused scanner diagnostics suite: 9 passed.
- Isolated replay through actual daemon command dispatch and the UI formatter covers rescan, sync, failed installation, recovery, retries and successful caching. Timeout evidence in the replay is explicitly synthetic, not a real-plugin reproduction.
- Tests exercise the real HostScan path and verify retained stderr ends, bounded warnings, journal output and warning removal after recovery.
- Diff whitespace checks pass.

The first full-suite run encountered Unix-socket path limits caused by a long scratch temporary-directory path; rerunning with a short path to the same isolated directory passed. No production files or settings were changed to work around that test-environment constraint.

## Local acceptance

Deployed commit `9e90507` locally with the native host enabled. Build: zero warnings and errors. The daemon and UI are running from the same PR build.

- Wave XLR Pro connected; 5 mixes, 9 channels and all 45 combine legs present. Both existing bridged VST3 inserts on Stream are running with no insert errors.
- Levels, mutes, device settings and insert parameters match the pre-deployment baseline. A full configuration backup was taken first.
- The real TDR Nova scan detail demonstrates the new 2048-character head-and-tail retention.
- Rescan succeeded in 1.4 seconds using cached descriptions, with no failure warning because all current bundles scanned successfully.
- The actual mixer window was opened and its screenshot inspected. Failed-bundle warnings were verified by the isolated replay and regression tests, not by installing a deliberately broken plugin into the live catalogue.
- All GitHub checks pass. Awaiting the user's own testing; no merge or release yet.
