### PR TITLE
Window: keep tooltips clear of their controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            g++ libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev xvfb xauth
+            g++ libpipewire-0.3-dev liblilv-dev lv2-dev libx11-dev libxtst6 xvfb xauth
           make -C native
           test -x native/openxlr-lv2-host
           make -C native test-audio test-clap
@@ -57,6 +57,9 @@ jobs:
 
       - name: Window layout at narrow and wide sizes
         run: OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~WindowLayoutTests
+
+      - name: A tooltip at a screen edge does not take the click
+        run: OPENXLR_TEST_TOOLTIP=1 xvfb-run -a -s '-screen 0 1600x1000x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~ToolTipInputTests
 
       - name: Locked restore enforced on every packaging path
         run: tools/check-locked-restore.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ make -C native test-audio test-clap  # audio bounds, stall detection and CLAP bu
 xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
 OPENXLR_TEST_DESKTOP=1 xvfb-run -a dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~TrayWindowTests
 OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~WindowLayoutTests
+OPENXLR_TEST_TOOLTIP=1 xvfb-run -a -s '-screen 0 1600x1000x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~ToolTipInputTests
 ```
 
 These cover the main CI build and tests; the workflow also checks packaged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,19 @@ make -C native test-audio test-clap  # audio bounds, stall detection and CLAP bu
 xvfb-run -a make -C native test-editor  # also needs Xvfb and xauth
 OPENXLR_TEST_DESKTOP=1 xvfb-run -a dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~TrayWindowTests
 OPENXLR_TEST_LAYOUT=1 xvfb-run -a -s '-screen 0 2560x1440x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~WindowLayoutTests
+OPENXLR_TEST_TOOLTIP=1 xvfb-run -a -s '-screen 0 1600x1000x24' dotnet test src/OpenXLR.Tests/OpenXLR.Tests.csproj -c Release --no-build --filter FullyQualifiedName~ToolTipInputTests
 ```
 
 The window layout test runs in its own process using X11 and isolated
 configuration, runtime and session-bus settings. It checks narrow plugin
 windows and mixer widths from 640 to 2400 logical pixels. Set
 `OPENXLR_LAYOUT_ARTIFACTS` to a directory to save rendered previews.
+
+The tooltip test runs in its own process too. It drives a real pointer
+through the X server's XTEST extension, so it needs `libXtst`, and it
+checks that a tooltip shown at the bottom of the screen still lets the
+control underneath it be clicked. Set `AVALONIA_GLOBAL_SCALE_FACTOR` to
+run the same cases at another desktop scale.
 
 If you add or change a NuGet package, regenerate the lock files with a
 plain `dotnet restore src/OpenXLR.slnx` (the linux-x64 graph is part of

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -118,6 +118,10 @@ than its content scrolls vertically. Mix master cards wrap onto further
 rows when needed. Long plugin names are shortened with an ellipsis, with
 the full name in the tooltip. Plugin control and chain windows keep
 actions below their headings, and actions wrap when space is limited.
+A tooltip sits against the control it describes rather than against the
+pointer, and flips to whichever side of that control the screen has room
+for, so a tooltip near an edge of the screen never ends up over the
+button and never takes the click meant for it.
 
 <a name="mic-to-call"></a>
 ### 3.1 Send your microphone to a call or a recording

--- a/src/OpenXLR.Tests/ToolTipInputTests.cs
+++ b/src/OpenXLR.Tests/ToolTipInputTests.cs
@@ -1,0 +1,275 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json.Nodes;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+/// <summary>
+/// A tooltip must never take the click meant for the control it describes.
+/// A tooltip is a native popup window of its own, so the only way to see this
+/// is to let the X server deliver the pointer events: a press posted straight
+/// into the window would miss the popup and pass whatever the popup does. The
+/// test therefore moves and clicks a real pointer through XTEST and asks the
+/// production window what happened.
+///
+/// The window is walked to the bottom of the screen because that is where the
+/// popup has to be pushed back over the pointer to fit, which is what used to
+/// eat the press. Set AVALONIA_GLOBAL_SCALE_FACTOR to run the same cases at a
+/// different desktop scale.
+/// </summary>
+[Collection("xdg-config")]
+public sealed class ToolTipInputTests
+{
+    /// <summary>A port nothing serves, so a running daemon is not part of the test.</summary>
+    private const string DeadDaemon = "ws://127.0.0.1:37899/ws";
+
+    [ToolTipFact]
+    public void ATooltipAtAScreenEdgeNeverTakesTheClickFromItsControl()
+    {
+        string config = Path.Combine(Path.GetTempPath(), "openxlr-tooltip-" + Guid.NewGuid());
+        string? oldConfig = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        string? oldRuntime = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+        string? oldBus = Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS");
+
+        MainWindow? main = null;
+        Button? cog = null;
+        ToggleButton? bypass = null;
+        DropDownButton? profiles = null;
+        int cogClicks = 0, bypassClicks = 0, profileClicks = 0;
+        var ready = new TaskCompletionSource();
+        var quit = new CancellationTokenSource();
+        Exception? failure = null;
+
+        var ui = new Thread(() =>
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", config);
+                Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", config);
+                Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent");
+                AppBuilder.Configure<App>().UseSkia().UseHarfBuzz().UseX11().SetupWithoutStarting();
+                Application.Current!.RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Dark;
+
+                main = new MainWindow(new DaemonClient(DeadDaemon));
+                var vm = new MainViewModel(new DaemonClient(DeadDaemon));
+                main.DataContext = vm;
+                typeof(MainViewModel).GetMethod("ApplyMixer", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(vm, [JsonNode.Parse("""{"mixes":[],"channels":[],"inserts":{}}""")]);
+                // One plugin in the XLR 1 chain, hosted in the mixer, so its cog
+                // opens the generated controls instead of reaching for a helper.
+                vm.Inserts.Apply(JsonNode.Parse("""
+                    [{"insert":{"id":"eq","plugin":"http://lsp-plug.in/plugins/lv2/graphic_equalizer_x16_mono",
+                    "label":"LSP Graphic Equalizer x16 Mono"}}]
+                    """));
+                main.WindowStartupLocation = WindowStartupLocation.Manual;
+                main.Position = new PixelPoint(40, 40);
+                main.Width = 900;
+                main.Height = 700;
+                main.Show();
+                ready.SetResult();
+                Dispatcher.UIThread.MainLoop(quit.Token);
+            }
+            catch (Exception ex) { failure = ex; ready.TrySetResult(); }
+            finally
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", oldConfig);
+                Environment.SetEnvironmentVariable("XDG_RUNTIME_DIR", oldRuntime);
+                Environment.SetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS", oldBus);
+            }
+        }) { IsBackground = true };
+        ui.Start();
+        Assert.True(ready.Task.Wait(TimeSpan.FromSeconds(60)), "The window never opened.");
+        if (failure is not null) throw failure;
+
+        using var pointer = new XPointer();
+        try
+        {
+            Thread.Sleep(500);
+            Ui(() =>
+            {
+                cog = Named<Button>(main!, "Open this plugin's controls");
+                bypass = Named<ToggleButton>(main!, "Bypass this plugin");
+                profiles = main!.GetVisualDescendants().OfType<DropDownButton>()
+                    .First(d => d.Content as string == "Profiles");
+                cog.AddHandler(Button.ClickEvent, (_, _) => cogClicks++, handledEventsToo: true);
+                bypass.AddHandler(Button.ClickEvent, (_, _) => bypassClicks++, handledEventsToo: true);
+                profiles.AddHandler(Button.ClickEvent, (_, _) => profileClicks++, handledEventsToo: true);
+                return true;
+            });
+
+            // The cog at the bottom of the screen, where a tooltip anchored to
+            // the pointer has nowhere to go but back over the cursor.
+            Place(main!, cog!, right: false);
+            HoverAndClick(pointer, main!, cog!, "the insert cog at the bottom edge", () => cogClicks);
+            Assert.True(Ui(() => main!.OwnedWindows.OfType<InsertControlsWindow>().Any()),
+                "The cog was clicked but no controls window opened.");
+            CloseChildren(main!);
+
+            // Another control, and the tightest placement there is.
+            bool checkedBefore = Ui(() => bypass!.IsChecked == true);
+            Place(main!, bypass!, right: true);
+            HoverAndClick(pointer, main!, bypass!, "the bypass toggle in the bottom corner", () => bypassClicks);
+            Assert.NotEqual(checkedBefore, Ui(() => bypass!.IsChecked == true));
+
+            // A tooltip in front of a menu button must still let the menu open.
+            Place(main!, profiles!, right: false);
+            HoverAndClick(pointer, main!, profiles!, "the profiles menu at the bottom edge", () => profileClicks);
+            Assert.True(Wait(() => Ui(() => profiles!.Flyout!.IsOpen)), "The profiles menu did not open.");
+            Ui(() => { profiles!.Flyout!.Hide(); return true; });
+
+            // What made all of that work, so a revert says which setting went.
+            // The application's own styles decide these, not anything set here.
+            Assert.Equal(PlacementMode.Bottom, Ui(() => ToolTip.GetPlacement(cog!)));
+            Assert.Equal(0d, Ui(() => ToolTip.GetVerticalOffset(cog!)));
+        }
+        finally
+        {
+            Ui(() =>
+            {
+                foreach (Window w in main!.OwnedWindows.ToArray()) w.Close();
+                main.Close();
+                quit.Cancel();
+                return true;
+            });
+            ui.Join(TimeSpan.FromSeconds(15));
+            if (Directory.Exists(config)) Directory.Delete(config, true);
+        }
+    }
+
+    /// <summary>
+    /// Closes the windows the clicks opened and puts the mixer back in front,
+    /// so the next hover starts from the same state as the first one.
+    /// </summary>
+    private static void CloseChildren(MainWindow main)
+    {
+        Ui(() =>
+        {
+            foreach (Window w in main.OwnedWindows.ToArray()) w.Close();
+            main.Activate();
+            return true;
+        });
+        Thread.Sleep(300);
+    }
+
+    /// <summary>Moves the window until the control sits against the bottom of the screen.</summary>
+    private static void Place(MainWindow main, Control target, bool right)
+    {
+        Ui(() =>
+        {
+            PixelRect screen = Desktop(main);
+            PixelRect box = ScreenRect(main, target);
+            PixelPoint window = main.Position;
+            int y = screen.Y + screen.Height - box.Height - 2 - (box.Y - window.Y);
+            int x = right
+                ? screen.X + screen.Width - box.Width - 2 - (box.X - window.X)
+                : window.X;
+            main.Position = new PixelPoint(x, y);
+            return true;
+        });
+        Thread.Sleep(400);
+    }
+
+    private static void HoverAndClick(XPointer pointer, MainWindow main, Control target, string what, Func<int> clicks)
+    {
+        // Park the pointer clear of the window first, so entering the control
+        // is a fresh hover and the tooltip arms again.
+        PixelRect screen = Ui(() => Desktop(main));
+        pointer.MoveTo(screen.X + screen.Width - 1, screen.Y);
+        Thread.Sleep(250);
+
+        PixelRect box = Ui(() => ScreenRect(main, target));
+        pointer.MoveTo(box.X + box.Width / 2, box.Y + box.Height / 2);
+        Assert.True(Wait(() => Ui(() => ToolTip.GetIsOpen(target))),
+            $"No tooltip appeared over {what}. box={box} window={Ui(() => main.Position)} "
+            + $"over={Ui(() => target.IsPointerOver)} screen={screen}");
+
+        int before = clicks();
+        pointer.Click();
+        Assert.True(Wait(() => clicks() > before), $"The tooltip over {what} swallowed the click.");
+        Thread.Sleep(400);
+        Assert.Equal(before + 1, clicks());
+    }
+
+    /// <summary>The screen the window is on, or the first one when nothing is marked primary.</summary>
+    private static PixelRect Desktop(MainWindow main) =>
+        (main.Screens.ScreenFromWindow(main) ?? main.Screens.Primary ?? main.Screens.All[0]).Bounds;
+
+    private static PixelRect ScreenRect(MainWindow main, Control target) =>
+        new(target.PointToScreen(default), PixelSize.FromSize(target.Bounds.Size, main.RenderScaling));
+
+    private static T Named<T>(Visual root, string name) where T : Control =>
+        root.GetVisualDescendants().OfType<T>().First(c => AutomationProperties.GetName(c) == name);
+
+    private static T Ui<T>(Func<T> work) => Dispatcher.UIThread.Invoke(work);
+
+    private static bool Wait(Func<bool> done)
+    {
+        for (int i = 0; i < 80; i++)
+        {
+            if (done()) return true;
+            Thread.Sleep(50);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Pointer events from the X server through XTEST, on a connection of this
+    /// thread's own, so they reach whichever native window is in front.
+    /// </summary>
+    private sealed class XPointer : IDisposable
+    {
+        [DllImport("libX11.so.6")] private static extern IntPtr XOpenDisplay(IntPtr name);
+        [DllImport("libX11.so.6")] private static extern int XCloseDisplay(IntPtr display);
+        [DllImport("libX11.so.6")] private static extern int XFlush(IntPtr display);
+        [DllImport("libXtst.so.6")] private static extern int XTestFakeMotionEvent(
+            IntPtr display, int screen, int x, int y, ulong delay);
+        [DllImport("libXtst.so.6")] private static extern int XTestFakeButtonEvent(
+            IntPtr display, uint button, int press, ulong delay);
+
+        private IntPtr _display;
+
+        public XPointer()
+        {
+            _display = XOpenDisplay(IntPtr.Zero);
+            Assert.True(_display != IntPtr.Zero, "The test needs an X display to move a pointer on.");
+        }
+
+        public void MoveTo(int x, int y)
+        {
+            XTestFakeMotionEvent(_display, -1, x, y, 0);
+            XFlush(_display);
+        }
+
+        public void Click()
+        {
+            XTestFakeButtonEvent(_display, 1, 1, 0);
+            XFlush(_display);
+            Thread.Sleep(60);
+            XTestFakeButtonEvent(_display, 1, 0, 0);
+            XFlush(_display);
+        }
+
+        public void Dispose()
+        {
+            if (_display == IntPtr.Zero) return;
+            XCloseDisplay(_display);
+            _display = IntPtr.Zero;
+        }
+    }
+}
+
+public sealed class ToolTipFactAttribute : FactAttribute
+{
+    public ToolTipFactAttribute()
+    {
+        if (Environment.GetEnvironmentVariable("OPENXLR_TEST_TOOLTIP") != "1")
+            Skip = "Run separately with OPENXLR_TEST_TOOLTIP=1 under xvfb-run, filtered to ToolTipInputTests.";
+    }
+}

--- a/src/OpenXLR.UI/App.axaml
+++ b/src/OpenXLR.UI/App.axaml
@@ -6,5 +6,18 @@
 
     <Application.Styles>
         <FluentTheme />
+        <!-- A tooltip follows the pointer by default and sits 20 pixels below
+             it. Close to the bottom of a screen there is no room for that, so
+             the popup is pushed back up over the cursor and swallows the next
+             button press: the control under it never sees a click. Anchoring
+             every tooltip to its owner with no offset keeps the popup clear of
+             the pointer wherever the window sits. It is set for the whole
+             application because the tooltip properties do not inherit and every
+             control with a tooltip has the same problem; a control that needs
+             other values can still set them itself. -->
+        <Style Selector=":is(Control)">
+            <Setter Property="ToolTip.Placement" Value="Bottom"/>
+            <Setter Property="ToolTip.VerticalOffset" Value="0"/>
+        </Style>
     </Application.Styles>
 </Application>


### PR DESCRIPTION
## Summary

Keep tooltips from intercepting clicks near the bottom of a screen. Tooltips now anchor below their control with zero vertical offset rather than following the pointer.

## Cause and decision

Avalonia's default pointer placement uses a 20-unit vertical offset. Near the screen bottom, the tooltip is shifted upward to fit and can cover the pointer. The press then lands on the tooltip's native popup window. The tooltip disappears and the release reaches the intended button, which never received a press and therefore cannot raise Click.

This was observed on the mixer cog: a live trace recorded a press on PopupRoot/Border followed by a release on the cog, with no Click handler or editor-open message. Sending the identical editor-open request directly worked immediately, ruling out the plugin-open timeout for the captured failure.

The production change is a two-setter application style in App.axaml: ToolTip.Placement=Bottom and ToolTip.VerticalOffset=0. A tooltip can flip above its control without its offset pushing it back over the control. Placement alone was insufficient: keeping the default offset reproduced the failure. Overlay tooltips also reproduced the problem when constrained, so they are not used.

The style applies across the application because tooltip placement does not inherit and the same failure affects other controls near screen edges. Tooltips and interactive menus are retained; a control can still explicitly override placement. No click retries, pointer-down actions, timeout changes or native plugin changes are introduced.

## Regression coverage

ToolTipInputTests runs in a separate Xvfb process using real XTEST pointer events through libXtst, not events injected directly into the MainWindow. It waits for each actual tooltip to open before clicking:

- The insert cog at the bottom edge receives exactly one Click and opens its controls window.
- A bypass toggle in the bottom-right corner receives one Click and changes state.
- The Profiles menu button at the bottom edge still opens its flyout.

Removing the style, or restoring the 20-unit offset while retaining Bottom placement, makes the behavioural test fail because the tooltip swallows the click. Both scale 1 and 1.75 runs pass. CI installs libxtst6 for this gated test; the regular application has no new dependency.

## Verification

- Locked restore and warning-as-error build passed.
- On the combined main after #87: 402 default tests passed, 3 desktop tests skipped, zero failures. The tray and layout suites passed separately under Xvfb, and the tooltip suite passed at scales 1 and 1.75. All GitHub checks passed. The merged commit has the same source tree as the tested candidate.
- The live mixer window was updated without restarting the daemon or audio helpers. With the tooltip visible, the user confirmed one-click native editor opening.
- The successful live trace records press and release on MainWindow, the native-editor branch and exactly one outgoing showInsertUi message per click. The earlier trace recorded no outgoing message.

Temporary tracing is not included in this change. The manual and contributor checklists describe the tooltip behaviour and the new gated test.
