### PR TITLE
Window: clarify login and tray options

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -46,8 +46,8 @@ The window's header shows the connected interface with a green dot.
 "No device" means the daemon cannot open the interface: replug it once
 after installing so the udev rule applies ([section 5.1](#no-device)).
 
-If you only want hardware control and no mixer, turn the submixer off
-in Options ([section 3.8](#hardware-only)). The daemon restarts in hardware-control mode
+If you only want hardware control and no mixer, turn off "Enable software
+mixer" in Options, AUDIO ([section 3.8](#hardware-only)). The daemon restarts in hardware-control mode
 and the `OpenXLR …` devices disappear.
 
 Update checks are also controlled in Options. They are off by default. You can
@@ -598,23 +598,27 @@ hold; it re-asserts them once a second and reverts any outside change.
 <a name="hardware-only"></a>
 ### 3.8 Hardware control only
 
-Options, Submixer: off. The daemon restarts in hardware-control mode:
-the sound card keeps its stock PipeWire layout (on the Pro, its UCM
-profile where one is installed), and the `OpenXLR …` devices, mixes,
+In Options, AUDIO, turn off "Enable software mixer". This controls the
+application channels, mixes, virtual microphones and plugin inserts. The
+daemon restarts when you change it, briefly interrupting audio. With it
+off, the sound card keeps its stock PipeWire layout, including the Pro's
+UCM profile where one is installed, and the `OpenXLR …` devices, mixes,
 virtual microphones and inserts go away. The INPUTS and HEADPHONES
 cards keep working. Turn it on again the same way.
 
 <a name="autostart"></a>
 ### 3.9 Start at login, tray
 
-Options, STARTUP:
+Options separates login startup from window behaviour.
 
-- "Start audio service at login (background only)" enables the daemon's
+Under AT LOGIN:
+
+- "Start audio in the background" enables the daemon's
   systemd user service. On a packaged install this is the package's own
   unit. This does not start the mixer window or create a tray icon. If
   the service cannot be enabled or disabled, Options says so and keeps
   the previous preference rather than saving one the system does not have.
-- "Start mixer window and tray icon at login" writes a desktop autostart
+- "Start the OpenXLR app" writes a desktop autostart
   entry for the window in `~/.config/autostart/openxlr.desktop`,
   including on KDE Plasma and CachyOS. The file is written the way any
   desktop application writes there: the folder keeps its own permissions,
@@ -632,21 +636,35 @@ Options, STARTUP:
     moved since it last wrote one. If you removed the entry yourself
     with a desktop tool, it stays removed and Options says so; turn the
     option off and on again to get it back.
-- With "Close button minimizes to tray", the window hides instead of
-  quitting; the tray icon's "Show mixer" menu item restores it, including
-  when the window was minimized. "Quit OpenXLR" exits even with
-  close-to-tray enabled. The close button always hides the window when
-  this option is on: a Linux desktop gives an application no way to find
-  out whether a system tray is there, so OpenXLR cannot fall back to
-  quitting when there is none. On a desktop with no tray, leave this
-  option off. "Start minimized to tray" starts with no window at all; the
-  tray icon shows it the first time you click it, and with no tray there
-  is nothing to click, so leave that off too. It changes how the window
-  opens; it does not enable autostart. For a tray icon at login, enable
-  both the mixer-at-login option and "Start minimized to tray".
-- Only one window runs per user. Starting OpenXLR again, from the menu
-  or a shell, brings the running window to the front (out of the tray
-  if it is hidden there) instead of opening a second one.
+
+The two login switches are independent. Enable both for audio and the app
+at login. Audio alone starts without a window or tray icon. The app alone
+starts without the audio service, which you must start separately to use
+it. With both off, neither starts at login. The hint below the switches
+describes the combination you chose.
+
+Under WINDOW:
+
+- "On launch" chooses "Show mixer" or "Tray only". It applies the next
+  time the app starts, whether at login or by hand; changing it does not
+  hide the current window or enable autostart. "Tray only" starts with no
+  window at all; the tray icon shows it the first time you click it. For
+  a tray icon at login, enable "Start the OpenXLR app" and choose "Tray
+  only".
+- "When closing" chooses "Keep running in tray" or "Quit app" and takes
+  effect immediately. Keeping the app in the tray hides the window
+  instead of quitting; the tray icon's "Show mixer" menu item restores it,
+  including when the window was minimized. "Quit OpenXLR" in the tray
+  menu always exits. Neither choice stops the background audio service.
+
+A Linux desktop gives an application no way to find out whether a system
+tray is there, so OpenXLR cannot fall back to quitting when there is none.
+On a desktop with no tray, choose "Show mixer" on launch and "Quit app"
+when closing. These window choices do not change either login switch.
+
+Only one window runs per user. Starting OpenXLR again, from the menu or a
+shell, brings the running window to the front, out of the tray if it is
+hidden there, instead of opening a second one.
 
 To land on a known scene at every login, mark a profile to recall on
 connect ([section 3.6](#profiles)). An interface using connect-time restoration comes back
@@ -668,7 +686,7 @@ systemctl --user restart openxlr-daemon
 ```
 
 Until then the window offers only the controls the old daemon reports.
-Toggling the submixer in Options also restarts the daemon.
+Changing "Enable software mixer" in Options, AUDIO also restarts the daemon.
 
 Since 0.1.23 every client presents a token the daemon writes at start
 ([section 6](#files)). A window or OpenDeck plugin older than the daemon is

--- a/src/OpenXLR.Tests/WindowAutostartTests.cs
+++ b/src/OpenXLR.Tests/WindowAutostartTests.cs
@@ -153,7 +153,168 @@ public sealed class WindowAutostartTests : IDisposable
         Assert.True(options.StartDaemonAtLogin);
         Assert.True(options.StartMinimized);
         Assert.False(options.OpenWindowAtLogin);
-        Assert.Contains("does not enable autostart", options.StartupHint);
+        Assert.Equal("Audio will start at login without the app or tray icon.", options.StartupHint);
+    }
+
+    [Theory]
+    [InlineData(true, true, "Audio and the app will start when you sign in.")]
+    [InlineData(false, true, "The app will start at login. Start the audio service separately to use it.")]
+    [InlineData(true, false, "Audio will start at login without the app or tray icon.")]
+    [InlineData(false, false, "Neither audio nor the app will start at login.")]
+    public void StartupHintDescribesBothSavedLoginFlags(bool audio, bool app, string expected)
+    {
+        // Load saved flags rather than calling setters that change systemd services.
+        new UiSettings { StartDaemonAtLogin = audio, OpenWindowAtLogin = app }.Save();
+        var client = new DaemonClient();
+        var options = new OptionsViewModel(client, new MainViewModel(client));
+
+        Assert.Equal(audio, options.StartDaemonAtLogin);
+        Assert.Equal(app, options.OpenWindowAtLogin);
+        Assert.Equal(expected, options.StartupHint);
+        Assert.False(Directory.Exists(AutostartDir));
+    }
+
+    private static ComboBox BindSelector(OptionsViewModel options, string property, params string[] items)
+    {
+        var box = new ComboBox { DataContext = options, ItemsSource = items };
+        box.Bind(ComboBox.SelectedIndexProperty,
+            new Binding { Path = property, Mode = BindingMode.TwoWay });
+        return box;
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void WindowSelectorsLoadAndPersistIndependently(bool startMinimized, bool minimizeToTray)
+    {
+        var saved = new UiSettings
+        {
+            StartMinimized = startMinimized,
+            MinimizeToTray = minimizeToTray,
+            StartDaemonAtLogin = startMinimized,
+            OpenWindowAtLogin = minimizeToTray,
+            AutostartExecutable = Executable,
+            CheckForUpdates = true,
+            LastUpdateCheckUtc = new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero),
+            DismissedUpdate = "v0.1.32",
+            CollapsedSections = ["INPUTS", "MONITOR"],
+        };
+        saved.Save();
+        if (saved.OpenWindowAtLogin)
+            Assert.True(StartupIntegration.SetWindowAtLogin(true, Executable));
+        string? entryBefore = File.Exists(Entry) ? File.ReadAllText(Entry) : null;
+        var marker = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        if (entryBefore is not null) File.SetLastWriteTimeUtc(Entry, marker);
+
+        var client = new DaemonClient();
+        var main = new MainViewModel(client);
+        var options = new OptionsViewModel(client, main);
+        var launch = BindSelector(options, nameof(OptionsViewModel.LaunchBehavior), "Show mixer", "Tray only");
+        var close = BindSelector(options, nameof(OptionsViewModel.CloseBehavior), "Keep running in tray", "Quit app");
+        AssertState(startMinimized, minimizeToTray);
+
+        launch.SelectedIndex = startMinimized ? 0 : 1;
+        AssertState(!startMinimized, minimizeToTray);
+        close.SelectedIndex = minimizeToTray ? 1 : 0;
+        AssertState(!startMinimized, !minimizeToTray);
+        launch.SelectedIndex = startMinimized ? 1 : 0;
+        AssertState(startMinimized, !minimizeToTray);
+        close.SelectedIndex = minimizeToTray ? 0 : 1;
+        AssertState(startMinimized, minimizeToTray);
+
+        void AssertState(bool minimized, bool tray)
+        {
+            Assert.Equal(minimized, options.StartMinimized);
+            Assert.Equal(tray, options.MinimizeToTray);
+            Assert.Equal(tray, main.MinimizeToTray);
+            Assert.Equal(minimized ? 1 : 0, options.LaunchBehavior);
+            Assert.Equal(tray ? 0 : 1, options.CloseBehavior);
+            Assert.Equal(options.LaunchBehavior, launch.SelectedIndex);
+            Assert.Equal(options.CloseBehavior, close.SelectedIndex);
+
+            UiSettings persisted = UiSettings.Load();
+            Assert.Equal(minimized, persisted.StartMinimized);
+            Assert.Equal(tray, persisted.MinimizeToTray);
+            Assert.Equal(saved.StartDaemonAtLogin, persisted.StartDaemonAtLogin);
+            Assert.Equal(saved.OpenWindowAtLogin, persisted.OpenWindowAtLogin);
+            Assert.Equal(saved.AutostartExecutable, persisted.AutostartExecutable);
+            Assert.Equal(saved.CheckForUpdates, persisted.CheckForUpdates);
+            Assert.Equal(saved.LastUpdateCheckUtc, persisted.LastUpdateCheckUtc);
+            Assert.Equal(saved.DismissedUpdate, persisted.DismissedUpdate);
+            Assert.Equal(saved.CollapsedSections, persisted.CollapsedSections);
+            Assert.Equal(saved.StartDaemonAtLogin, options.StartDaemonAtLogin);
+            Assert.Equal(saved.OpenWindowAtLogin, options.OpenWindowAtLogin);
+            if (entryBefore is null)
+                Assert.False(Directory.Exists(AutostartDir));
+            else
+            {
+                Assert.Equal(entryBefore, File.ReadAllText(Entry));
+                Assert.Equal(marker, File.GetLastWriteTimeUtc(Entry));
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BooleanChangesNotifyAndUpdateBoundWindowSelectors(bool initial)
+    {
+        new UiSettings { StartMinimized = initial, MinimizeToTray = initial }.Save();
+        var client = new DaemonClient();
+        var main = new MainViewModel(client);
+        var options = new OptionsViewModel(client, main);
+        var launch = BindSelector(options, nameof(OptionsViewModel.LaunchBehavior), "Show mixer", "Tray only");
+        var close = BindSelector(options, nameof(OptionsViewModel.CloseBehavior), "Keep running in tray", "Quit app");
+        var changes = new List<string?>();
+        options.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
+
+        foreach (bool value in new[] { !initial, initial })
+        {
+            changes.Clear();
+            options.StartMinimized = value;
+            Assert.Contains(nameof(OptionsViewModel.LaunchBehavior), changes);
+            Assert.Equal(value ? 1 : 0, launch.SelectedIndex);
+            Assert.Equal(value, UiSettings.Load().StartMinimized);
+
+            changes.Clear();
+            options.MinimizeToTray = value;
+            Assert.Contains(nameof(OptionsViewModel.CloseBehavior), changes);
+            Assert.Equal(value ? 0 : 1, close.SelectedIndex);
+            Assert.Equal(value, main.MinimizeToTray);
+            Assert.Equal(value, UiSettings.Load().MinimizeToTray);
+        }
+        Assert.False(Directory.Exists(AutostartDir));
+    }
+
+    [Theory]
+    [InlineData(false, -1)]
+    [InlineData(true, -1)]
+    [InlineData(false, 2)]
+    [InlineData(true, 2)]
+    public void WindowSelectorsIgnoreInvalidIndexes(bool initial, int index)
+    {
+        new UiSettings { StartMinimized = initial, MinimizeToTray = initial }.Save();
+        string settingsPath = Path.Combine(UiSettings.ConfigDir, "ui.json");
+        string before = File.ReadAllText(settingsPath);
+        var marker = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(settingsPath, marker);
+        var client = new DaemonClient();
+        var main = new MainViewModel(client);
+        var options = new OptionsViewModel(client, main);
+
+        options.LaunchBehavior = index;
+        options.CloseBehavior = index;
+
+        Assert.Equal(initial ? 1 : 0, options.LaunchBehavior);
+        Assert.Equal(initial ? 0 : 1, options.CloseBehavior);
+        Assert.Equal(initial, options.StartMinimized);
+        Assert.Equal(initial, options.MinimizeToTray);
+        Assert.Equal(initial, main.MinimizeToTray);
+        Assert.Equal(before, File.ReadAllText(settingsPath));
+        Assert.Equal(marker, File.GetLastWriteTimeUtc(settingsPath));
+        Assert.False(Directory.Exists(AutostartDir));
     }
 
     /// <summary>
@@ -272,10 +433,14 @@ public sealed class WindowAutostartTests : IDisposable
         Assert.NotNull(options.StartupError);
 
         Directory.Delete(Entry);
+        var changes = new List<string?>();
+        options.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
         options.OpenWindowAtLogin = false;
         Assert.False(options.OpenWindowAtLogin);
         Assert.False(UiSettings.Load().OpenWindowAtLogin);
         Assert.Null(options.StartupError);
+        Assert.Contains(nameof(OptionsViewModel.StartupHint), changes);
+        Assert.Equal("Neither audio nor the app will start at login.", options.StartupHint);
     }
 
     /// <summary>

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -169,6 +169,45 @@ public sealed class WindowLayoutTests
                     }
                 }
                 Capture(chain, "chain-440");
+
+                new UiSettings { StartMinimized = true, MinimizeToTray = true }.Save();
+                var optionsVm = new OptionsViewModel(new DaemonClient(), vm);
+                var options = new OptionsWindow { DataContext = optionsVm };
+                windows.Add(options);
+                options.Show();
+                Layout(options, 980, 800);
+                var launch = options.FindControl<ComboBox>("LaunchBehavior")!;
+                var close = options.FindControl<ComboBox>("CloseBehavior")!;
+                Assert.Equal(1, launch.SelectedIndex);
+                Assert.Equal(0, close.SelectedIndex);
+                Assert.Equal("Tray only", ((ComboBoxItem)launch.SelectedItem!).Content);
+                Assert.Equal("Keep running in tray", ((ComboBoxItem)close.SelectedItem!).Content);
+                foreach (var picker in new[] { launch, close })
+                {
+                    AssertInside(picker, options);
+                    AssertNoOverlap(((Grid)picker.Parent!).Children.Where(c => c.IsVisible).ToArray());
+                }
+                foreach (string heading in new[] { "AT LOGIN", "WINDOW", "AUDIO" })
+                    Assert.Single(options.GetVisualDescendants().OfType<TextBlock>(), t => t.Text == heading);
+                var notes = options.FindControl<StackPanel>("SoftwareMixerNotes")!;
+                var audioHeading = options.GetVisualDescendants().OfType<TextBlock>()
+                    .Single(t => t.Text == "AUDIO");
+                Assert.Equal(audioHeading.TranslatePoint(default, options)!.Value.X,
+                    notes.TranslatePoint(default, options)!.Value.X);
+                var noteLines = notes.Children.OfType<TextBlock>().Where(t => t.IsVisible).ToArray();
+                Assert.Equal(2, noteLines.Length);
+                foreach (var line in noteLines)
+                {
+                    Assert.Equal(notes.TranslatePoint(default, options)!.Value.X,
+                        line.TranslatePoint(default, options)!.Value.X);
+                    AssertInside(line, notes);
+                }
+                launch.SelectedIndex = 0;
+                close.SelectedIndex = 1;
+                Assert.False(UiSettings.Load().StartMinimized);
+                Assert.False(UiSettings.Load().MinimizeToTray);
+                Assert.False(vm.MinimizeToTray);
+                Capture(options, "options-startup");
             }
             catch (Exception ex) { failure = ex; }
             finally

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -160,6 +160,7 @@ public sealed class OptionsViewModel : ViewModelBase
             StartupError = null;
             _startDaemonAtLogin = value;
             Raise();
+            Raise(nameof(StartupHint));
             Persist();
         }
     }
@@ -213,9 +214,26 @@ public sealed class OptionsViewModel : ViewModelBase
         _ => null,
     };
 
-    public string StartupHint => OpenWindowAtLogin
-        ? "The mixer and tray icon will start when you sign in."
-        : "The mixer and tray icon will not start at login. Starting minimized does not enable autostart.";
+    public string StartupHint => (StartDaemonAtLogin, OpenWindowAtLogin) switch
+    {
+        (true, true) => "Audio and the app will start when you sign in.",
+        (false, true) => "The app will start at login. Start the audio service separately to use it.",
+        (true, false) => "Audio will start at login without the app or tray icon.",
+        _ => "Neither audio nor the app will start at login.",
+    };
+
+    // The selectors keep the existing saved booleans, including their defaults.
+    public int LaunchBehavior
+    {
+        get => StartMinimized ? 1 : 0;
+        set { if (value is 0 or 1) StartMinimized = value == 1; }
+    }
+
+    public int CloseBehavior
+    {
+        get => MinimizeToTray ? 0 : 1;
+        set { if (value is 0 or 1) MinimizeToTray = value == 0; }
+    }
 
     private bool _minimizeToTray;
     public bool MinimizeToTray
@@ -224,6 +242,7 @@ public sealed class OptionsViewModel : ViewModelBase
         set
         {
             if (!Set(ref _minimizeToTray, value)) return;
+            Raise(nameof(CloseBehavior));
             Persist();
             _main.MinimizeToTray = value;
         }
@@ -236,6 +255,7 @@ public sealed class OptionsViewModel : ViewModelBase
         set
         {
             if (!Set(ref _startMinimized, value)) return;
+            Raise(nameof(LaunchBehavior));
             Persist();
         }
     }

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -36,23 +36,55 @@
 
     <Border Classes="card">
       <StackPanel Spacing="6">
-        <TextBlock Text="STARTUP" Classes="h"/>
-        <CheckBox Content="Start audio service at login (background only)"
+        <TextBlock Text="AT LOGIN" Classes="h"/>
+        <CheckBox Content="Start audio in the background"
                   IsChecked="{Binding StartDaemonAtLogin, Mode=TwoWay}"/>
-        <CheckBox Content="Start mixer window and tray icon at login"
+        <CheckBox Content="Start the OpenXLR app"
                   IsChecked="{Binding OpenWindowAtLogin, Mode=TwoWay}"/>
-        <TextBlock Text="{Binding StartupHint}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="26,0,0,4"/>
+        <TextBlock Text="{Binding StartupHint}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap"/>
         <TextBlock Text="{Binding StartupError}" FontSize="11" Foreground="#e0a05a" TextWrapping="Wrap"
                    IsVisible="{Binding StartupError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-        <CheckBox Content="Close button minimizes to tray instead of quitting"
-                  IsChecked="{Binding MinimizeToTray, Mode=TwoWay}"/>
-        <CheckBox Content="Start minimized to tray"
-                  IsChecked="{Binding StartMinimized, Mode=TwoWay}"/>
-        <CheckBox Content="Submixer (per-app channels, mixes, virtual microphones, inserts)"
+      </StackPanel>
+    </Border>
+
+    <Border Classes="card">
+      <StackPanel Spacing="6">
+        <TextBlock Text="WINDOW" Classes="h"/>
+        <Grid ColumnDefinitions="110,*" RowDefinitions="Auto,8,Auto">
+          <TextBlock Text="On launch" Classes="h" VerticalAlignment="Center"/>
+          <ComboBox Name="LaunchBehavior" Grid.Column="1" HorizontalAlignment="Stretch"
+                    SelectedIndex="{Binding LaunchBehavior, Mode=TwoWay}"
+                    AutomationProperties.Name="On launch">
+            <ComboBoxItem Content="Show mixer"/>
+            <ComboBoxItem Content="Tray only"/>
+          </ComboBox>
+          <TextBlock Grid.Row="2" Text="When closing" Classes="h" VerticalAlignment="Center"/>
+          <ComboBox Name="CloseBehavior" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch"
+                    SelectedIndex="{Binding CloseBehavior, Mode=TwoWay}"
+                    AutomationProperties.Name="When closing">
+            <ComboBoxItem Content="Keep running in tray"/>
+            <ComboBoxItem Content="Quit app"/>
+          </ComboBox>
+        </Grid>
+        <TextBlock Text="On launch applies the next time the app starts. Quitting the app leaves audio running."
+                   FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap"/>
+      </StackPanel>
+    </Border>
+
+    <Border Classes="card">
+      <StackPanel Spacing="6">
+        <TextBlock Text="AUDIO" Classes="h"/>
+        <CheckBox Content="Enable software mixer"
                   IsChecked="{Binding Submixer, Mode=TwoWay}"
-                  ToolTip.Tip="Off: OpenXLR controls the hardware only and leaves the sound card in its stock PipeWire layout (the UCM profile where one exists). Plugin inserts go with the submixer. Toggling restarts the daemon."/>
-        <TextBlock Text="{Binding SubmixerNote}" Foreground="#8b93a7" FontSize="11" TextWrapping="Wrap"
-                   Margin="26,0,0,0" IsVisible="{Binding SubmixerNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                  ToolTip.Tip="Off: OpenXLR controls the hardware only and leaves the sound card in its stock PipeWire layout (the UCM profile where one exists)."/>
+        <StackPanel Name="SoftwareMixerNotes" Spacing="6">
+          <TextBlock Text="Application channels, mixes, virtual microphones and inserts."
+                     FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap"/>
+          <TextBlock Text="Changing this restarts the audio service and briefly interrupts audio."
+                     FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap"/>
+          <TextBlock Text="{Binding SubmixerNote}" Foreground="#8b93a7" FontSize="11" TextWrapping="Wrap"
+                     IsVisible="{Binding SubmixerNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+        </StackPanel>
       </StackPanel>
     </Border>
 


### PR DESCRIPTION
## Changes

- Separate Options into At login, Window and Audio cards instead of putting all five controls under Startup.
- Replace the tray checkboxes with explicit launch and close choices, preserving the existing saved preferences.
- Explain the selected combination of audio and app startup, and make the software mixer's restart consequence visible.
- Keep the audio notes left aligned with the other card text.
- Update the manual and cover selector bindings, persistence, login hints and rendered layout.

## Verification

- Release build with native hosting enabled and warnings treated as errors: 0 warnings, 0 errors.
- .NET suite: 416 passed, 3 opt-in desktop tests skipped.
- Ran the layout and tray desktop tests separately under Xvfb: both passed. Inspected the rendered Options window and checked note alignment against its section heading.
- Rebuilt and relaunched the local desktop app with saved preferences preserved. The audio daemon was not restarted.

No version bump or release changes.
