### PR TITLE
Plugins: manage folders and isolate single-plugin imports

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,7 +57,7 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls, within the message size limit above and always including the plugins the saved chains use; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, `windowsDirectories` (the folders yabridge bridges) and `wineFolders` (Wine's own plugin folders that hold a plugin and are not bridged yet, offered as one press since a file dialog hides them) |
 | `pluginDiagnostics` | in answer to `getPluginDiagnostics` | `discovery`: daemon host/controller paths, Wine prefix, architecture, effective search paths, bounded `yabridgectl status` output and latest completed CLAP/VST3 scan reports |
-| `pluginInstall` | in answer to `installPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user, ending with the bundles the scan that followed could not read, up to three by name and the rest as a count), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
+| `pluginInstall` | in answer to `installPlugin`, `addWindowsPluginFolder`, `removeWindowsPluginFolder`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user, ending with the bundles the scan that followed could not read, up to three by name and the rest as a count), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
 | `error` | when a command without a `requestId` is rejected | `message` |
 | `commandResult` | in answer to a command that carried a `requestId` | `requestId`, `error` (null on success); preceded by the state the result refers to |
 
@@ -93,7 +93,9 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `listPlugins` | none | the installed LV2, CLAP and VST3 plugins, answered with a `plugins` message |
 | `getPluginDiagnostics` | none | read bridge status and existing native scan evidence without syncing, rescanning or changing inserts; answered with `pluginDiagnostics` |
 | `getPluginSetup` | none | where plugins are installed and what bridges Windows ones, answered with a `pluginSetup` message |
-| `installPlugin` | `path` | install what is at an absolute path the user picked: a `.clap` or single-file `.vst3` is copied into `~/.clap` or `~/.vst3`, a `.vst3` or `.lv2` directory into `~/.vst3` or `~/.lv2`, a plain directory installs every plugin inside it, and a Windows VST3 or CLAP plugin has its directory added to yabridge and synced. Archives, installers and VST2 files are refused with a message that says what to do. The catalogues are read again before the `pluginInstall` answer |
+| `installPlugin` | `path` | install what is at an absolute path the user picked: a `.clap` or single-file `.vst3` is copied into `~/.clap` or `~/.vst3`, a `.vst3` or `.lv2` directory into `~/.vst3` or `~/.lv2`, a plain directory installs every plugin inside it. A single Windows VST3/CLAP file or VST3 bundle is copied into its own folder under `windowsImportDirectory`, and only that folder is registered and synced; a plugin already installed inside a Wine prefix is linked from the managed folder instead, preserving its original location and prefix. An explicit Windows plugin folder is registered in place. Archives, installers and VST2 files are refused with a message that says what to do. The catalogues are read again before the `pluginInstall` answer |
+| `addWindowsPluginFolder` | `path` | register an existing folder holding Windows VST3 or CLAP plugins and sync it, without copying source files or installing any native plugins alongside them; answered with `pluginInstall` |
+| `removeWindowsPluginFolder` | `path` | unregister a folder from `windowsDirectories`, sync retained folders and remove only its unused generated VST3/CLAP wrappers. Original files are kept. Refused while affected plugins remain in the mixer's insert chains. A missing source folder can still be removed from the list; answered with `pluginInstall` |
 | `syncWindowsPlugins` | none | run yabridge's sync over the folders it knows, then read the catalogues again; answered with `pluginInstall` |
 | `rescanPlugins` | none | read the plugin directories again, for plugins installed by other means; answered with `pluginInstall` |
 | `setInserts` | `channel`, `inserts[]` | replace a chain; `channel` is `xlr1`, `xlr2` or `mix:<id>`, each insert is `{id, kind, plugin, label?, bypass?, params?}` where `kind` is `"lv2"` with the plugin URI, `"clap"` with the plugin's id, or `"vst3"` with the class id as 32 hex digits; a CLAP or VST3 insert always runs in the native host, so its `nativeHost` reads true whatever was sent |
@@ -119,12 +121,26 @@ loading conflicting old and normalized overrides, the normalized key wins.
 
 `pluginSetup` also reports `bridgeProvider` (`openxlr` or `system`),
 `bridgeDirectory` (the selected companion directory, or null), and
-`windowsPluginDirectory` (OpenXLR's private wrapper root, or null).
+`windowsPluginDirectory` (OpenXLR's private wrapper root, or null), and
+`windowsImportDirectory` (the managed single-plugin source folders, normally
+`~/.local/share/openxlr/windows-plugins`, honoring `XDG_DATA_HOME`). Imports
+use one folder per format and plugin name; selecting the same name again
+updates that folder. These source files are separate from generated wrappers.
 `wine` is a boolean; `wineVersion` is a string or null. `windowsEditorNote`
 is a user-facing compatibility message or null. With provider `openxlr`,
 `yabridge` is the companion package version.
 The `openxlr` provider includes the pinned Wine input fix. Its directory
 registry and generated wrappers are separate from the system controller.
+
+Folder-management paths must be absolute, at most 4096 characters and contain
+no control characters. Removing a folder changes the selected provider's
+registry; with `system`, that registry is shared with other applications.
+The daemon never runs a global prune. Wrappers still covered by a retained
+folder are kept. Folder changes, installs and rescans are serialized, as are
+insert-chain replacements and profile loads against those operations. Check
+`pluginInstall.ok` and `message` for the operation's outcome: a failed cleanup
+can leave the folder unregistered with some wrappers still present. Refresh
+`getPluginSetup` after either success or failure. Profiles are not rewritten.
 
 LV2 insert definitions optionally carry `nativeHost: true` to select the native
 helper for that insert. Missing or false keeps LV2 in PipeWire filter-chain, even

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -57,6 +57,15 @@ the effective plugin host, Wine and bridge provider. `getPluginDiagnostics` read
 scan evidence without syncing or changing inserts. Both reply shapes are
 documented in [api.md](api.md); the transport does not select a bridge itself.
 
+`addWindowsPluginFolder` and `removeWindowsPluginFolder` also use
+`POST /api/v1/commands`, with an absolute `path`. They return a `pluginInstall`
+message after refreshing the catalogue. Check that message's `ok` and
+`message`, not just the HTTP status: registry or wrapper-cleanup failures are
+reported there. Removal keeps the original files and refuses folders backing
+current inserts. With the system bridge, folder registration is shared with
+other applications. The [folder-management contract](api.md) covers partial
+failures and path limits.
+
 The [OpenAPI document](openapi-v1.json) describes the HTTP endpoints. Restarting
 the daemon rotates its per-session token once the new instance listens;
 clients must reread it.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -384,8 +384,33 @@ a system bridge. OpenXLR reads its catalogues again,
 and the plugin is in the picker with a VST3 or CLAP badge. Nothing else
 has to be restarted.
 
-The first press is the one that needs explaining. Wine keeps its Windows
-drive in `~/.wine` unless `WINEPREFIX` says otherwise, and an installer
+<a name="plugin-folders"></a>
+**Managing Windows plugin folders.** Open Options, PLUGINS, then "Manage
+folders…" to see the folders registered with the selected yabridge provider.
+
+- "Add folder…" registers a folder holding Windows VST3 or CLAP plugins,
+  syncs it and refreshes the catalogue. The original files stay in that
+  folder. Use "Install file…" or "Install folder…" for native Linux plugins.
+- Select a folder and press "Remove from list" to unregister it. A
+  confirmation explains what will be removed. OpenXLR cleans up only that
+  folder's generated VST3 and CLAP wrappers; original plugin files and
+  wrappers still covered by another registered folder are kept. A folder
+  that was moved or deleted can still be removed from the list.
+- "Rescan" syncs the registered folders and reads the catalogue again.
+
+Remove affected plugins from your insert chains before removing their
+folder, including bypassed inserts. Folder removal does not edit saved
+profiles; re-add the folder before recalling a profile that needs it. It
+does not restart the audio service. If unregistering succeeds but cleanup
+fails, the result says so and the list refreshes to show the current state.
+
+With the OpenXLR companion, this manages its private registry and wrappers.
+With system yabridge, the same registry is used by other applications, so
+removing a folder affects those applications too. The window and its removal
+confirmation call this out. This manager does not change native Linux plugin
+search paths or uninstall plugins installed by your package manager.
+
+Wine keeps its Windows drive in `~/.wine` unless `WINEPREFIX` says otherwise, and an installer
 writes into `Program Files/Common Files/VST3` inside it, or the same for
 CLAP. That is a dotted folder, which file dialogs hide, so OpenXLR looks
 there itself and offers what it finds as "Bridge Wine's plugins" rather
@@ -393,12 +418,26 @@ than asking you to go and find it. Once a folder is bridged, yabridge keeps
 it on its own list, so a second plugin installed into it needs only the
 sync, and the Bridge button has nothing left to offer.
 
-A plugin that comes as a bare Windows `.vst3` or `.clap` file, with no
-installer, is picked with "Install file…". Put it in a folder of its own
-first: OpenXLR bridges the folder a Windows plugin sits in, and a file
-picked straight out of Downloads would hand yabridge your whole Downloads
-folder. VST2 `.dll` files are left out either way, since OpenXLR cannot
-load VST2.
+Picking one Windows `.vst3` or `.clap` file with "Install file…" installs
+only that plugin. OpenXLR copies it into its own folder under
+`~/.local/share/openxlr/windows-plugins`, grouped by format and plugin name,
+and registers that folder with yabridge. A single Windows `.vst3` bundle
+picked with "Install folder…" is copied whole, including its resources.
+The original download is kept and can be deleted afterwards. Other plugins
+beside the selected one, including other downloads, are not registered.
+Selecting the same plugin name again updates its managed copy.
+
+A plugin already installed inside a Wine prefix is linked from its managed
+folder instead of being copied or moved. It keeps its original location,
+Wine prefix and neighbouring files. Selecting an ordinary folder or using
+"Add folder…" in the folder manager still registers that folder in place.
+VST2 `.dll` files are left out because OpenXLR cannot load VST2.
+
+Older folder registrations are not silently removed. If an earlier
+single-file import registered Downloads, remove that entry with "Manage
+folders…" and import the plugins you want individually. Remove affected
+inserts first if the manager asks you to. Removing a folder refreshes the
+catalogue and the open plugin pickers.
 
 <a name="bundle-not-read"></a>
 **A bridged plugin is not in the picker.** A successful yabridge sync means

--- a/src/OpenXLR.Core/Mixing/PluginInstaller.cs
+++ b/src/OpenXLR.Core/Mixing/PluginInstaller.cs
@@ -44,6 +44,7 @@ public sealed record PluginSetup(
     public string BridgeProvider { get; init; } = "system";
     public string? BridgeDirectory { get; init; }
     public string? WindowsPluginDirectory { get; init; }
+    public string? WindowsImportDirectory { get; init; }
 }
 
 /// <summary>
@@ -64,7 +65,7 @@ public sealed class PluginInstaller
     /// <summary>How long yabridge gets to bridge a directory: it copies files, it does not run them.</summary>
     private static readonly TimeSpan YabridgeTimeout = TimeSpan.FromMinutes(3);
 
-    private readonly string _lv2, _clap, _vst3, _winePrefix;
+    private readonly string _lv2, _clap, _vst3, _winePrefix, _windowsImports;
     private readonly string? _yabridgectl, _wine;
     private readonly bool _hostInstalled;
     private readonly ManagedYabridge? _managed;
@@ -79,7 +80,8 @@ public sealed class PluginInstaller
     }
 
     public PluginInstaller(string lv2Directory, string clapDirectory, string vst3Directory,
-        string? yabridgectl, string? wine, bool hostInstalled = true, string? winePrefix = null)
+        string? yabridgectl, string? wine, bool hostInstalled = true, string? winePrefix = null,
+        string? windowsImportDirectory = null)
     {
         _lv2 = lv2Directory;
         _clap = clapDirectory;
@@ -88,6 +90,7 @@ public sealed class PluginInstaller
         _wine = wine;
         _hostInstalled = hostInstalled;
         _winePrefix = winePrefix ?? DefaultWinePrefix();
+        _windowsImports = windowsImportDirectory ?? Path.Combine(Path.GetDirectoryName(ManagedYabridge.PluginHome)!, "windows-plugins");
     }
 
     private static string HomeDirectory(string name)
@@ -231,9 +234,16 @@ public sealed class PluginInstaller
                 case PluginItemKind.ClapBundle: Copy(item.Path, _clap, installed, destinations, notes); break;
                 case PluginItemKind.Vst3Bundle: Copy(item.Path, _vst3, installed, destinations, notes); break;
                 case PluginItemKind.WindowsPlugin:
-                    // yabridge takes directories: a picked plugin means the
-                    // directory it is in, a picked directory means itself.
-                    windows.Add(string.Equals(item.Path, path, StringComparison.Ordinal) ? Path.GetDirectoryName(path.TrimEnd('/'))! : path);
+                    if (string.Equals(item.Path, path, StringComparison.Ordinal))
+                    {
+                        // A single selection must not register its siblings.
+                        // Missing bridge tools are reported below without copying.
+                        string? directory = _yabridgectl is null || _wine is null
+                            ? Path.GetDirectoryName(path.TrimEnd('/'))
+                            : ImportWindowsPlugin(path, notes);
+                        if (directory is not null) windows.Add(directory);
+                    }
+                    else windows.Add(path);   // an explicit folder pick stays in place
                     break;
                 case PluginItemKind.WindowsVst2: vst2++; break;
             }
@@ -259,7 +269,39 @@ public sealed class PluginInstaller
         _ => $"Nothing to install at {name}. Pick a .clap file, a .vst3 or .lv2 folder, or a folder holding plugins.",
     };
 
-    private static void Copy(string source, string directory, List<string> installed, List<string> destinations, List<string> notes)
+    private string? ImportWindowsPlugin(string source, List<string> notes)
+    {
+        string name = Path.GetFileName(source.TrimEnd('/'));
+        string stem = Path.GetFileNameWithoutExtension(name);
+        if (stem.Length == 0 || stem is "." or ".." || name.Any(char.IsControl))
+        {
+            notes.Add("The plugin needs a valid file name without control characters.");
+            return null;
+        }
+        string format = Path.GetExtension(name).TrimStart('.').ToLowerInvariant();
+        string directory = Path.Combine(_windowsImports, format, stem);
+        var imported = new List<string>();
+        // Installed plugins can depend on their Wine prefix and neighbours.
+        // One link isolates the selection without moving it out of that prefix.
+        try { Copy(source, directory, imported, [], notes, linkSource: InWinePrefix(source)); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            notes.Add($"Could not import {name}: {ex.Message}");
+        }
+        return imported.Count > 0 ? directory : null;
+    }
+
+    private static bool InWinePrefix(string source)
+    {
+        FileSystemInfo info = Directory.Exists(source) ? new DirectoryInfo(source) : new FileInfo(source);
+        string path = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? Path.GetFullPath(source);
+        for (string? parent = Path.GetDirectoryName(path); parent is not null; parent = Path.GetDirectoryName(parent))
+            if (File.Exists(Path.Combine(parent, "system.reg")) && Directory.Exists(Path.Combine(parent, "drive_c"))) return true;
+        return false;
+    }
+
+    private static void Copy(string source, string directory, List<string> installed, List<string> destinations, List<string> notes,
+        bool linkSource = false)
     {
         string name = Path.GetFileName(source.TrimEnd('/'));
         string destination = Path.Combine(directory, name);
@@ -283,9 +325,14 @@ public sealed class PluginInstaller
             Directory.CreateDirectory(directory);
             Remove(staged);
             Remove(retired);
-            if (Directory.Exists(source)) CopyTree(source, staged);
+            if (linkSource)
+            {
+                if (Directory.Exists(source)) Directory.CreateSymbolicLink(staged, Path.GetFullPath(source));
+                else File.CreateSymbolicLink(staged, Path.GetFullPath(source));
+            }
+            else if (Directory.Exists(source)) CopyTree(source, staged);
             else File.Copy(source, staged);
-            bool replacing = Directory.Exists(destination) || File.Exists(destination);
+            bool replacing = Directory.Exists(destination) || File.Exists(destination) || new FileInfo(destination).LinkTarget is not null;
             if (replacing) Move(destination, retired);
             try { Move(staged, destination); }
             catch { if (replacing) Move(retired, destination); throw; }
@@ -293,7 +340,9 @@ public sealed class PluginInstaller
             try { Remove(retired); } catch (Exception) { /* removed on the next install */ }
             installed.Add(name);
             destinations.Add(destination);
-            notes.Add($"Installed {name} in {Shorten(directory)}.");
+            notes.Add(linkSource
+                ? $"Linked {name} from its Wine prefix into {Shorten(directory)}."
+                : $"Installed {name} in {Shorten(directory)}.");
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -306,7 +355,7 @@ public sealed class PluginInstaller
     private static void Remove(string path)
     {
         if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
-        else if (File.Exists(path)) File.Delete(path);
+        else if (File.Exists(path) || new FileInfo(path).LinkTarget is not null) File.Delete(path);
     }
 
     /// <summary>Rename within one directory, for either kind of bundle.</summary>
@@ -356,7 +405,8 @@ public sealed class PluginInstaller
             return $"{what}, and {missing} not installed. Install {(missing.StartsWith("yabridge and", StringComparison.Ordinal) ? "them" : "it")}, then add {(picked is not null || directories.Count == 1 ? "it" : "them")} again.";
         }
         if (!PrepareManagedBridge()) return "The OpenXLR bridge could not select its packaged libraries.";
-        HashSet<string> known = WindowsDirectories().ToHashSet(StringComparer.Ordinal);
+        if (!TryWindowsDirectories(out IReadOnlyList<string> directoriesBefore, out string? listError)) return listError!;
+        HashSet<string> known = directoriesBefore.ToHashSet(StringComparer.Ordinal);
         foreach (string directory in directories)
         {
             if (known.Contains(Path.GetFullPath(directory).TrimEnd('/'))) continue;
@@ -372,6 +422,76 @@ public sealed class PluginInstaller
         return directories.Count == 1
             ? $"Bridged the Windows plugins in {Shorten(directories[0])} with yabridge."
             : $"Bridged the Windows plugins in {directories.Count} folders with yabridge.";
+    }
+
+    /// <summary>Register a Windows plugin folder without copying any native plugins beside it.</summary>
+    public InstallOutcome AddWindowsFolder(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Path.IsPathFullyQualified(path))
+            return new(false, "The folder path has to be absolute.", []);
+        if (!Directory.Exists(path)) return new(false, $"There is no folder at {path}.", []);
+        try
+        {
+            if (!Items(path).Any(i => i.Kind == PluginItemKind.WindowsPlugin))
+                return new(false, "This folder holds no Windows VST3 or CLAP plugins. Use Install file or Install folder for native Linux plugins.", []);
+            var installed = new List<string>();
+            var destinations = new List<string>();
+            string message = Bridge([path], null, installed, destinations);
+            return new(installed.Count > 0, message, installed, destinations);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return new(false, $"Could not add the plugin folder: {ex.Message}", []);
+        }
+    }
+
+    /// <summary>Unregister one source and remove only its unused VST3/CLAP wrappers, never its plugins.</summary>
+    public InstallOutcome RemoveWindowsFolder(string path, IReadOnlyCollection<string>? inUsePluginPaths = null)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Path.IsPathFullyQualified(path))
+            return new(false, "The folder path has to be absolute.", []);
+        if (_yabridgectl is null) return new(false, "yabridge is not installed.", []);
+        bool unregistered = false;
+        try
+        {
+            path = WindowsPluginWrappers.Normalize(path);
+            if (!TryWindowsDirectories(out IReadOnlyList<string> known, out string? listError))
+                return new(false, listError!, []);
+            string? registered = known.FirstOrDefault(d => WindowsPluginWrappers.Normalize(d) == path);
+            if (registered is null) return new(false, "This folder is not in yabridge's registered plugin folders.", []);
+            string[] retained = [.. known.Where(d => d != registered).Select(WindowsPluginWrappers.Normalize)];
+            IReadOnlyList<WindowsPluginWrappers.Wrapper> wrappers = WindowsPluginWrappers.Find(BridgedVst3Directory, BridgedClapDirectory, path, retained);
+            if (inUsePluginPaths is not null && wrappers.Any(w => inUsePluginPaths.Any(p => WindowsPluginWrappers.Under(WindowsPluginWrappers.Normalize(p), w.Path))))
+                return new(false, "Remove the inserts using this folder from the mixer before removing the folder.", []);
+            // A retained source may share a wrapper name. Sync gets the chance
+            // to retarget it before deciding which wrappers are ours to delete.
+            if (retained.Length > 0 && _wine is null)
+                return new(false, "Wine is not installed. It is needed to sync the remaining plugin folders safely.", []);
+            if (!PrepareManagedBridge()) return new(false, "The OpenXLR bridge could not select its packaged libraries.", []);
+            ProcessResult? remove = Run("rm", registered);
+            if (remove?.Ok != true) return new(false, $"yabridge could not remove the folder: {Tail(remove)}", []);
+            unregistered = true;
+            if (!TryWindowsDirectories(out IReadOnlyList<string> remaining, out listError))
+                return new(false, $"The folder was removed from the list, but wrappers were kept: {listError}", []);
+            if (remaining.Any(d => WindowsPluginWrappers.Normalize(d) == path))
+                return new(false, "yabridge still lists the folder. Its wrappers were kept.", []);
+            if (remaining.Count > 0)
+            {
+                ProcessResult? sync = Run("sync");
+                if (sync?.Ok != true)
+                    return new(false, $"The folder was removed from the list, but its wrappers were kept because syncing the remaining folders failed: {Tail(sync)}", []);
+            }
+            wrappers = WindowsPluginWrappers.Find(BridgedVst3Directory, BridgedClapDirectory, path,
+                remaining.Select(WindowsPluginWrappers.Normalize).ToArray());
+            foreach (WindowsPluginWrappers.Wrapper wrapper in wrappers) wrapper.Remove();
+            return new(true, $"Removed {Shorten(registered)} from the plugin folders and cleaned up {wrappers.Count} bridge wrappers. Original plugin files were kept.", []);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return new(false, unregistered
+                ? $"The folder was removed from the list, but wrapper cleanup did not finish: {ex.Message} Original plugin files were kept."
+                : $"Could not remove the plugin folder: {ex.Message}", []);
+        }
     }
 
     /// <summary>Bridge again whatever yabridge knows, for plugins installed into those folders since.</summary>
@@ -400,12 +520,21 @@ public sealed class PluginInstaller
 
     /// <summary>The directories yabridge watches, from `yabridgectl list`.</summary>
     public IReadOnlyList<string> WindowsDirectories()
+        => TryWindowsDirectories(out IReadOnlyList<string> directories, out _) ? directories : [];
+
+    private bool TryWindowsDirectories(out IReadOnlyList<string> directories, out string? error)
     {
-        if (_yabridgectl is null) return [];
+        directories = [];
         ProcessResult? list = Run("list");
-        if (list is null || list.ExitCode != 0) return [];
-        return Encoding.UTF8.GetString(list.Stdout).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(line => line.StartsWith('/')).Select(line => line.TrimEnd('/')).ToList();
+        if (list?.Ok != true)
+        {
+            error = $"yabridge could not list the plugin folders: {Tail(list)}";
+            return false;
+        }
+        directories = Encoding.UTF8.GetString(list.Stdout).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(line => line.StartsWith('/')).Select(Path.TrimEndingDirectorySeparator).Distinct(StringComparer.Ordinal).ToList();
+        error = null;
+        return true;
     }
 
     /// <summary>Where Wine keeps its own drive: WINEPREFIX, or ~/.wine as Wine itself does.</summary>
@@ -557,6 +686,7 @@ public sealed class PluginInstaller
             BridgeProvider = _managed is null ? "system" : "openxlr",
             BridgeDirectory = _managed is null ? null : Shorten(_managed.Directory),
             WindowsPluginDirectory = _managed is null ? null : Shorten(ManagedYabridge.PluginHome),
+            WindowsImportDirectory = Shorten(_windowsImports),
             WindowsEditorNote = _managed is null && EditorsIgnoreTheMouse(version, wineVersion)
                 ? $"A Windows plugin's own editor can ignore the mouse with yabridge {version} and {wineVersion}: since Wine 9.22 its clicks can arrive somewhere else entirely. The optional openxlr-yabridge package includes the input fix. The manual covers bridge selection."
                 : null,

--- a/src/OpenXLR.Core/Mixing/WindowsPluginWrappers.cs
+++ b/src/OpenXLR.Core/Mixing/WindowsPluginWrappers.cs
@@ -1,0 +1,128 @@
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>Only yabridge wrappers whose Windows targets belong to a removed source folder.</summary>
+internal static class WindowsPluginWrappers
+{
+    internal sealed record Wrapper(string Path, string? WindowsLink = null)
+    {
+        public void Remove()
+        {
+            if (WindowsLink is null) Directory.Delete(Path, recursive: true);
+            else
+            {
+                File.Delete(Path);
+                File.Delete(WindowsLink);
+            }
+        }
+    }
+
+    internal static string Normalize(string path) => System.IO.Path.TrimEndingDirectorySeparator(System.IO.Path.GetFullPath(path));
+
+    internal static bool Under(string path, string directory)
+        => path == directory || path.StartsWith(directory == "/" ? "/" : directory + "/", StringComparison.Ordinal);
+
+    internal static IReadOnlyList<Wrapper> Find(string vst3, string clap, string removed, IReadOnlyCollection<string> retained)
+    {
+        var wrappers = new List<Wrapper>();
+        foreach (string bundle in Entries(vst3, vst3: true))
+        {
+            string contents = System.IO.Path.Combine(bundle, "Contents");
+            EnsureNotLink(contents);
+            if (!Directory.Exists(contents)) continue;
+            var targets = new List<string>();
+            foreach (string architecture in Directory.EnumerateDirectories(contents))
+            {
+                if (!System.IO.Path.GetFileName(architecture).EndsWith("-win", StringComparison.Ordinal)) continue;
+                EnsureNotLink(architecture);
+                foreach (string module in Directory.EnumerateFileSystemEntries(architecture))
+                {
+                    if (!module.EndsWith(".vst3", StringComparison.OrdinalIgnoreCase)) continue;
+                    targets.Add(LinkTarget(module) ?? throw new IOException($"The Windows module in {bundle} is not a yabridge link."));
+                }
+            }
+            if (targets.Count > 0 && targets.All(t => Under(t, removed)) && !targets.Any(t => retained.Any(d => Under(t, d))))
+            {
+                CheckBundle(bundle);
+                wrappers.Add(new(bundle));
+            }
+        }
+        foreach (string module in Entries(clap, vst3: false))
+        {
+            string link = System.IO.Path.ChangeExtension(module, ".clap-win");
+            string? target = LinkTarget(link);
+            if (target is not null && Under(target, removed) && !retained.Any(d => Under(target, d)))
+            {
+                if (!IsElf(module)) throw new IOException($"The CLAP file {module} is not a Linux bridge wrapper.");
+                wrappers.Add(new(module, link));
+            }
+        }
+        return wrappers;
+    }
+
+    private static IEnumerable<string> Entries(string root, bool vst3)
+    {
+        root = Normalize(root);
+        // A moved ~/.vst3 or an aliased wrapper root must not turn cleanup
+        // into a traversal of an unrelated tree.
+        for (string? path = root; path is not null; path = System.IO.Path.GetDirectoryName(path)) EnsureNotLink(path);
+        if (!Directory.Exists(root)) yield break;
+        foreach (string entry in Walk(root))
+            yield return entry;
+
+        IEnumerable<string> Walk(string directory)
+        {
+            foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
+            {
+                if (!vst3 && entry.EndsWith(".clap-win", StringComparison.OrdinalIgnoreCase)) continue;
+                EnsureNotLink(entry);
+                bool isDirectory = Directory.Exists(entry);
+                if (vst3 && isDirectory && entry.EndsWith(".vst3", StringComparison.OrdinalIgnoreCase)) yield return entry;
+                else if (isDirectory)
+                    foreach (string nested in Walk(entry)) yield return nested;
+                else if (!vst3 && entry.EndsWith(".clap", StringComparison.OrdinalIgnoreCase)) yield return entry;
+            }
+        }
+    }
+
+    private static void CheckBundle(string bundle)
+    {
+        string contents = System.IO.Path.Combine(bundle, "Contents");
+        if (Directory.EnumerateFileSystemEntries(bundle).Any(p => p != contents)) throw Unexpected();
+        string name = System.IO.Path.GetFileNameWithoutExtension(bundle);
+        foreach (string entry in Directory.EnumerateFileSystemEntries(contents))
+        {
+            string part = System.IO.Path.GetFileName(entry);
+            if (part == "Resources" && new FileInfo(entry).LinkTarget is not null) continue;
+            if (part is not ("x86_64-win" or "i386-win" or "x86_64-linux" or "i386-linux")) throw Unexpected();
+            EnsureNotLink(entry);
+            if (!Directory.Exists(entry)) throw Unexpected();
+            bool windows = part.EndsWith("-win", StringComparison.Ordinal);
+            foreach (string module in Directory.EnumerateFileSystemEntries(entry))
+            {
+                if (System.IO.Path.GetFileName(module) != name + (windows ? ".vst3" : ".so")) throw Unexpected();
+                if (windows ? new FileInfo(module).LinkTarget is null : !IsElf(module)) throw Unexpected();
+            }
+        }
+        IOException Unexpected() => new($"The bundle {bundle} contains files outside the expected yabridge layout.");
+    }
+
+    private static bool IsElf(string path)
+    {
+        EnsureNotLink(path);
+        using FileStream file = File.OpenRead(path);
+        Span<byte> header = stackalloc byte[4];
+        return file.Read(header) == 4 && header.SequenceEqual(new byte[] { 0x7f, (byte)'E', (byte)'L', (byte)'F' });
+    }
+
+    private static string? LinkTarget(string path)
+    {
+        string? target = new FileInfo(path).LinkTarget;
+        return target is null ? null : Normalize(System.IO.Path.GetFullPath(target, System.IO.Path.GetDirectoryName(path)!));
+    }
+
+    private static void EnsureNotLink(string path)
+    {
+        if (new FileInfo(path).LinkTarget is not null)
+            throw new IOException($"Cannot safely clean wrappers through the symbolic link {path}.");
+    }
+}

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -24,6 +24,9 @@ public static class CommandValidation
     {
         switch (cmd.Cmd)
         {
+            case "addWindowsPluginFolder":
+            case "removeWindowsPluginFolder":
+                return CheckPluginFolderPath(cmd);
             case "createChannel":
             case "createMix":
                 return BadName(cmd.Name) ? $"{cmd.Cmd}: name must contain 1 to 60 printable characters" : null;
@@ -130,6 +133,12 @@ public static class CommandValidation
                 return null;   // the service knows the rest, or reports the command as unknown
         }
     }
+
+    internal static string? CheckPluginFolderPath(Command cmd)
+        => string.IsNullOrWhiteSpace(cmd.Path) || cmd.Path.Length > 4096
+           || cmd.Path.Any(char.IsControl) || !Path.IsPathFullyQualified(cmd.Path)
+            ? $"{cmd.Cmd}: path must be an absolute folder path of at most 4096 characters"
+            : null;
 
     private static string? Finite(Command cmd, string field)
         => cmd.Value.ValueKind == JsonValueKind.Number && cmd.Value.TryGetDouble(out double d) && double.IsFinite(d)

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -80,7 +80,7 @@ public sealed record Command
     /// <summary>"setInsertParam": the control port symbol.</summary>
     [JsonPropertyName("symbol")] public string? Symbol { get; init; }
 
-    /// <summary>"installPlugin": the file or directory the user picked, absolute.</summary>
+    /// <summary>Plugin installs and folder management: the file or directory the user picked, absolute.</summary>
     [JsonPropertyName("path")] public string? Path { get; init; }
 }
 
@@ -104,10 +104,11 @@ public sealed record PluginSetupMessage(PluginSetup Setup)
     [JsonPropertyName("bridgeProvider")] public string BridgeProvider => Setup.BridgeProvider;
     [JsonPropertyName("bridgeDirectory")] public string? BridgeDirectory => Setup.BridgeDirectory;
     [JsonPropertyName("windowsPluginDirectory")] public string? WindowsPluginDirectory => Setup.WindowsPluginDirectory;
+    [JsonPropertyName("windowsImportDirectory")] public string? WindowsImportDirectory => Setup.WindowsImportDirectory;
     [JsonIgnore] public PluginSetup Setup { get; } = Setup;
 }
 
-/// <summary>Reply to "installPlugin", "syncWindowsPlugins" and "rescanPlugins": what happened, and what the catalogue gained.</summary>
+/// <summary>Reply to plugin installation, folder management, sync and rescan: what happened, and what the catalogue gained.</summary>
 public sealed record PluginInstallMessage(bool Ok, string Message, IReadOnlyList<string> Installed, int Added, int Total)
 {
     [JsonPropertyName("type")] public string Type => "pluginInstall";

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -211,11 +211,26 @@ public sealed class WebSocketHub
                 if (string.IsNullOrWhiteSpace(cmd.Path)) { error = "installPlugin: missing 'path'"; break; }
                 await reply(await Task.Run(() => InstallPlugin(installer => installer.Install(cmd.Path))));
                 break;
+            case "addWindowsPluginFolder":
+            case "removeWindowsPluginFolder":
+                error = CommandValidation.CheckPluginFolderPath(cmd);
+                if (error is not null) break;
+                await reply(await Task.Run(() => InstallPlugin(installer =>
+                    cmd.Cmd == "addWindowsPluginFolder"
+                        ? installer.AddWindowsFolder(cmd.Path!)
+                        : installer.RemoveWindowsFolder(cmd.Path!, InsertPluginPaths()))));
+                break;
             case "syncWindowsPlugins":
                 await reply(await Task.Run(() => InstallPlugin(installer => installer.SyncWindows())));
                 break;
             case "rescanPlugins":
                 await reply(await Task.Run(() => InstallPlugin(_ => new OpenXLR.Core.Mixing.InstallOutcome(true, "", []))));
+                break;
+            case "setInserts":
+                // A folder cannot be removed between checking its users and
+                // creating an insert from it on another client.
+                lock (_installGate) error = _mixer.Apply(cmd);
+                stateOnError = true;
                 break;
             case "set":
                 error = cmd.Control is null ? "set: missing 'control'" : _devices.Apply(cmd.Control, cmd.Value);  // broadcasts on success
@@ -242,7 +257,6 @@ public sealed class WebSocketHub
             case "setAuxPortEnabled":
             case "setLowCutHz":
             case "setSoftClipGuard":
-            case "setInserts":
             case "setInsertBypass":
             case "setInsertParam":
             case "showInsertUi":
@@ -289,6 +303,11 @@ public sealed class WebSocketHub
     /// skipped when this run has no submixer. Null on success.
     /// </summary>
     private string? ApplyNamedProfile(string devId, string name, bool restoring = false)
+    {
+        lock (_installGate) return ApplyNamedProfileLocked(devId, name, restoring);
+    }
+
+    private string? ApplyNamedProfileLocked(string devId, string name, bool restoring)
     {
         OpenXLR.Core.Profile? p = OpenXLR.Core.ProfileStore.Load(devId, name);
         if (p is null) return $"no profile named '{name}'";
@@ -396,6 +415,11 @@ public sealed class WebSocketHub
             return new PluginInstallMessage(outcome.Ok, message, outcome.Installed, added, total);
         }
     }
+
+    private IReadOnlyCollection<string> InsertPluginPaths()
+        => _mixer.InsertPlugins()
+            .Select(id => OpenXLR.Core.Mixing.PluginCatalog.Find(id.Kind, id.Plugin)?.Path)
+            .OfType<string>().Distinct(StringComparer.Ordinal).ToArray();
 
     private readonly object _installGate = new();
 

--- a/src/OpenXLR.Tests/DaemonClientTests.cs
+++ b/src/OpenXLR.Tests/DaemonClientTests.cs
@@ -128,6 +128,8 @@ public sealed class DaemonClientTests
         Assert.Throws<ObjectDisposedException>(client.Start);
         await client.SetLevelAsync("music", "monitor", 0.5);
         Assert.Null(await client.RequestDiagnosticsAsync(TimeSpan.FromSeconds(30)));
+        Assert.Null(await client.AddWindowsPluginFolderAsync("/plugins", TimeSpan.FromSeconds(30)));
+        Assert.Null(await client.RemoveWindowsPluginFolderAsync("/plugins", TimeSpan.FromSeconds(30)));
     }
 
     [Fact]
@@ -149,6 +151,50 @@ public sealed class DaemonClientTests
         await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await client.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Null(await query.WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public async Task PluginFolderChangesAreSentSeparatelyInsteadOfSharingAnInstallReply()
+    {
+        var received = Completion();
+        var release = Completion();
+        var commands = new List<(string Command, string? Path)>();
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                var command = await SocketTestServer.Receive(socket, stop);
+                string name = command["cmd"]!.GetValue<string>();
+                if (name == "auth") continue;
+                commands.Add((name, command["path"]?.GetValue<string>()));
+                if (commands.Count == 1)
+                {
+                    received.SetResult();
+                    await release.Task.WaitAsync(stop);
+                }
+                await SocketTestServer.Send(socket, new { type = "pluginInstall", ok = true, message = name }, stop);
+                await SocketTestServer.Send(socket, new { type = "commandResult", requestId = command["requestId"]!.GetValue<string>() }, stop);
+            }
+        });
+        await using var client = new DaemonClient(server.Url);
+        var connected = Completion();
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var add = client.AddWindowsPluginFolderAsync("/plugins/new", TimeSpan.FromSeconds(5));
+        await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var remove = client.RemoveWindowsPluginFolderAsync("/plugins/old", TimeSpan.FromSeconds(5));
+        var sync = client.SyncWindowsPluginsAsync(TimeSpan.FromSeconds(5));
+        release.SetResult();
+        Assert.Equal("addWindowsPluginFolder", (await add)!["message"]!.GetValue<string>());
+        Assert.Equal("removeWindowsPluginFolder", (await remove)!["message"]!.GetValue<string>());
+        Assert.Equal("syncWindowsPlugins", (await sync)!["message"]!.GetValue<string>());
+        Assert.Equal(new (string, string?)[]
+        {
+            ("addWindowsPluginFolder", "/plugins/new"),
+            ("removeWindowsPluginFolder", "/plugins/old"),
+            ("syncWindowsPlugins", null),
+        }, commands);
     }
 
     private static TaskCompletionSource Completion()

--- a/src/OpenXLR.Tests/HttpApiTests.cs
+++ b/src/OpenXLR.Tests/HttpApiTests.cs
@@ -97,6 +97,14 @@ public sealed class HttpApiTests
                 new StringContent("{\"cmd\":\"getDiagnostics\"}", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.OK, valid.StatusCode);
             Assert.Contains("\"ok\":true", await valid.Content.ReadAsStringAsync());
+            foreach (string command in new[] { "addWindowsPluginFolder", "removeWindowsPluginFolder" })
+            {
+                using var folder = await http.PostAsync("/api/v1/commands",
+                    new StringContent(System.Text.Json.JsonSerializer.Serialize(new { cmd = command, path = "relative/plugins" }),
+                        Encoding.UTF8, "application/json"));
+                Assert.Equal(HttpStatusCode.BadRequest, folder.StatusCode);
+                Assert.Contains("absolute folder path", await folder.Content.ReadAsStringAsync());
+            }
             using var pluginDiagnostics = await http.PostAsync("/api/v1/commands",
                 new StringContent("{\"cmd\":\"getPluginDiagnostics\"}", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.OK, pluginDiagnostics.StatusCode);

--- a/src/OpenXLR.Tests/PluginFolderUiTests.cs
+++ b/src/OpenXLR.Tests/PluginFolderUiTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Nodes;
+using OpenXLR.Daemon;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+[Collection("xdg-config")]
+public sealed class PluginFolderUiTests : IDisposable
+{
+    private readonly string _config = Path.Combine(Path.GetTempPath(), "openxlr-folders-ui-" + Guid.NewGuid());
+    private readonly string? _oldConfig = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+
+    public PluginFolderUiTests() => Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", _config);
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", _oldConfig);
+        if (Directory.Exists(_config)) Directory.Delete(_config, recursive: true);
+    }
+
+    [Fact]
+    public void SetupRefreshReplacesFolderListAndDistinguishesSharedConfiguration()
+    {
+        var client = new DaemonClient();
+        var vm = new OptionsViewModel(client, new MainViewModel(client));
+        vm.ApplyPluginSetup(JsonNode.Parse("""
+            {"yabridge":"5.1.1","wine":true,"bridgeProvider":"system","windowsImportDirectory":"/imports",
+             "windowsDirectories":["/plugins/z","/plugins/a","/plugins/a"]}
+            """));
+        Assert.Equal(new[] { "/plugins/a", "/plugins/z" }, vm.WindowsDirectories);
+        Assert.True(vm.HasWindowsDirectories);
+        Assert.True(vm.CanManageWindows);
+        Assert.True(vm.CanSyncWindows);
+        Assert.True(vm.SystemBridge);
+        Assert.Contains("/imports", vm.WindowsImportNote);
+
+        vm.ApplyPluginSetup(JsonNode.Parse("""
+            {"yabridge":"5.1.1","wine":false,"bridgeProvider":"openxlr","windowsDirectories":[]}
+            """));
+        Assert.Empty(vm.WindowsDirectories);
+        Assert.False(vm.HasWindowsDirectories);
+        Assert.True(vm.CanManageWindows);
+        Assert.False(vm.CanSyncWindows);
+        Assert.False(vm.SystemBridge);
+
+        vm.ApplyPluginSetup(null);
+        Assert.False(vm.CanManageWindows);
+        Assert.False(vm.CanSyncWindows);
+    }
+
+    [Theory]
+    [InlineData("addWindowsPluginFolder")]
+    [InlineData("removeWindowsPluginFolder")]
+    public void FolderCommandsRequireBoundedAbsolutePaths(string command)
+    {
+        foreach (string? path in new[] { null, "", "plugins", "~/plugins", "/plugins\nother", "/" + new string('x', 4096) })
+            Assert.Contains(command, CommandValidation.CheckPluginFolderPath(new Command { Cmd = command, Path = path }));
+        Assert.Null(CommandValidation.CheckPluginFolderPath(new Command { Cmd = command, Path = "/home/user/Windows plugins" }));
+    }
+}

--- a/src/OpenXLR.Tests/PluginInstallerTests.cs
+++ b/src/OpenXLR.Tests/PluginInstallerTests.cs
@@ -60,8 +60,10 @@ public sealed class PluginInstallerTests : IDisposable
         return bundle;
     }
 
+    private string WindowsImports => Path.Combine(_root, "home", "windows-plugins");
+
     private PluginInstaller Installer(string? yabridgectl = null, string? wine = null, bool host = true)
-        => new(_lv2, _clap, _vst3, yabridgectl, wine, host);
+        => new(_lv2, _clap, _vst3, yabridgectl, wine, host, windowsImportDirectory: WindowsImports);
 
     [Fact]
     public void WhatAPathIsComesFromItsNameAndItsFirstBytes()
@@ -243,17 +245,46 @@ public sealed class PluginInstallerTests : IDisposable
     private string[] YabridgeCalls() => File.Exists(Path.Combine(_root, "yabridgectl.log"))
         ? File.ReadAllLines(Path.Combine(_root, "yabridgectl.log")) : [];
 
+    [Theory]
+    [InlineData("vst3")]
+    [InlineData("clap")]
+    public void ASingleWindowsFileImportsOnlyThatPlugin(string format)
+    {
+        string selected = File_("Chosen." + format, Windows);
+        File_("Other.vst3", Windows);
+        File_("Third.clap", Windows);
+        File_("Fourth.vst3", Windows);
+        var installer = Installer(FakeYabridgectl(), wine: "/bin/true");
+
+        InstallOutcome result = installer.Install(selected);
+
+        Assert.True(result.Ok, result.Message);
+        string directory = Path.Combine(WindowsImports, format, "Chosen");
+        Assert.Equal(["list", $"add {directory}", "sync"], YabridgeCalls());
+        string imported = Path.Combine(directory, "Chosen." + format);
+        Assert.Equal(Windows, File.ReadAllBytes(imported));
+        Assert.Null(new FileInfo(imported).LinkTarget);
+        Assert.Single(Directory.GetFileSystemEntries(directory));
+        Assert.Equal(4, Directory.GetFiles(_picked).Length);
+        File.Delete(selected);
+        Assert.Equal(Windows, File.ReadAllBytes(imported));
+    }
+
     [Fact]
-    public void AWindowsPluginIsHandedToYabridgeByItsDirectory()
+    public void ASingleWindowsBundleIsCopiedWholeButAnExplicitFolderIsRegisteredInPlace()
     {
         string bundle = WindowsVst3(Path.Combine("VST3", "Comp-win.vst3"));
+        File_(Path.Combine("VST3", "Comp-win.vst3", "Contents", "Resources", "preset.txt"), [1, 2, 3]);
         string directory = Path.GetDirectoryName(bundle)!;
         PluginInstaller installer = Installer(FakeYabridgectl(), wine: "/bin/true");
 
         InstallOutcome outcome = installer.Install(bundle);
         Assert.True(outcome.Ok, outcome.Message);
         Assert.Contains("Bridged the Windows plugins", outcome.Message);
-        Assert.Equal([$"list", $"add {directory}", "sync"], YabridgeCalls());
+        string imported = Path.Combine(WindowsImports, "vst3", "Comp-win");
+        Assert.Equal(["list", $"add {imported}", "sync"], YabridgeCalls());
+        Assert.Equal(Windows, File.ReadAllBytes(Path.Combine(imported, "Comp-win.vst3", "Contents", "x86_64-win", "Comp-win.vst3")));
+        Assert.Equal(new byte[] { 1, 2, 3 }, File.ReadAllBytes(Path.Combine(imported, "Comp-win.vst3", "Contents", "Resources", "preset.txt")));
         Assert.Equal([Path.Combine(_vst3, "yabridge"), Path.Combine(_clap, "yabridge")], outcome.Destinations);
 
         // A picked folder of Windows plugins is the folder itself, added once.
@@ -270,7 +301,7 @@ public sealed class PluginInstallerTests : IDisposable
         string bundle = WindowsVst3(Path.Combine("VST3", "Comp-win.vst3"));
         string directory = Path.GetDirectoryName(bundle)!;
         PluginInstaller installer = Installer(FakeYabridgectl(directory), wine: "/bin/true");
-        Assert.True(installer.Install(bundle).Ok);
+        Assert.True(installer.Install(directory).Ok);
         Assert.Equal(["list", "sync"], YabridgeCalls());
 
         InstallOutcome sync = installer.SyncWindows();
@@ -279,6 +310,83 @@ public sealed class PluginInstallerTests : IDisposable
         Assert.Equal("5.1.1", setup.YabridgeVersion);
         Assert.True(setup.Wine);
         Assert.Equal([directory], setup.WindowsDirectories);
+    }
+
+    [Fact]
+    public void ASingleWineInstalledPluginIsLinkedWithoutRegisteringItsSiblings()
+    {
+        string selected = File_(Path.Combine("prefix", "drive_c", "VST3", "Chosen.vst3"), Windows);
+        File_(Path.Combine("prefix", "drive_c", "VST3", "Other.vst3"), Windows);
+        File_(Path.Combine("prefix", "system.reg"), [1]);
+        var installer = Installer(FakeYabridgectl(), wine: "/bin/true");
+
+        var result = installer.Install(selected);
+
+        Assert.True(result.Ok, result.Message);
+        string imported = Path.Combine(WindowsImports, "vst3", "Chosen");
+        Assert.Equal(["list", $"add {imported}", "sync"], YabridgeCalls());
+        Assert.Equal(selected, new FileInfo(Path.Combine(imported, "Chosen.vst3")).LinkTarget);
+        Assert.Equal(Windows, File.ReadAllBytes(selected));
+        Assert.Contains("Linked Chosen.vst3 from its Wine prefix", result.Message);
+        Assert.Single(Directory.GetFileSystemEntries(imported));
+    }
+
+    [Fact]
+    public void ReimportUsesTheSameManagedFolderAndReplacesOnlyTheSelectedPlugin()
+    {
+        string source = File_("Chosen.vst3", Windows);
+        string imported = Path.Combine(WindowsImports, "vst3", "Chosen");
+        var installer = Installer(FakeYabridgectl(imported), wine: "/bin/true");
+        Assert.True(installer.Install(source).Ok);
+        byte[] updated = [.. Windows, 10, 20];
+        File.WriteAllBytes(source, updated);
+        Assert.True(installer.Install(source).Ok);
+        Assert.Equal(updated, File.ReadAllBytes(Path.Combine(imported, "Chosen.vst3")));
+        Assert.Equal(["list", "sync", "list", "sync"], YabridgeCalls());
+        Assert.Single(Directory.GetFileSystemEntries(imported));
+    }
+
+    [Fact]
+    public void FailedManagedCopyDoesNotRegisterDownloads()
+    {
+        string source = File_("Chosen.vst3", Windows);
+        Directory.CreateDirectory(Path.GetDirectoryName(WindowsImports)!);
+        File.WriteAllText(WindowsImports, "not a directory");
+        var installer = Installer(FakeYabridgectl(), wine: "/bin/true");
+        var result = installer.Install(source);
+        Assert.False(result.Ok);
+        Assert.Contains("Could not copy", result.Message);
+        Assert.Empty(YabridgeCalls());
+        Assert.Equal(Windows, File.ReadAllBytes(source));
+    }
+
+    [Theory]
+    [InlineData(".vst3")]
+    [InlineData("..vst3")]
+    [InlineData("...vst3")]
+    public void AnInvalidPluginNameCannotRegisterAnImportParent(string name)
+    {
+        string source = File_(name, Windows);
+        var result = Installer(FakeYabridgectl(), wine: "/bin/true").Install(source);
+        Assert.False(result.Ok);
+        Assert.Empty(YabridgeCalls());
+        Assert.False(Directory.Exists(WindowsImports));
+    }
+
+    [Fact]
+    public void ADownloadCanReplaceABrokenWinePluginLink()
+    {
+        string original = File_(Path.Combine("prefix", "drive_c", "VST3", "Chosen.vst3"), Windows);
+        File_(Path.Combine("prefix", "system.reg"), [1]);
+        string managed = Path.Combine(WindowsImports, "vst3", "Chosen", "Chosen.vst3");
+        var installer = Installer(FakeYabridgectl(), wine: "/bin/true");
+        Assert.True(installer.Install(original).Ok);
+        File.Delete(original);
+        string download = File_("Chosen.vst3", Windows);
+        Assert.True(installer.Install(download).Ok);
+        Assert.Null(new FileInfo(managed).LinkTarget);
+        Assert.Equal(Windows, File.ReadAllBytes(managed));
+        Assert.Single(Directory.GetFileSystemEntries(Path.GetDirectoryName(managed)!));
     }
 
     [Fact]
@@ -407,6 +515,7 @@ public sealed class PluginInstallerTests : IDisposable
         Assert.False(setup.Wine);
         Assert.Empty(setup.WindowsDirectories);
         Assert.EndsWith(".clap", setup.ClapDirectory);
+        Assert.Equal(WindowsImports, setup.WindowsImportDirectory);
         Assert.True(setup.HostInstalled);
     }
 

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -208,6 +208,28 @@ public sealed class WindowLayoutTests
                 Assert.False(UiSettings.Load().MinimizeToTray);
                 Assert.False(vm.MinimizeToTray);
                 Capture(options, "options-startup");
+
+                optionsVm.ApplyPluginSetup(JsonNode.Parse("""
+                    {"yabridge":"5.1.1","wine":true,"bridgeProvider":"system",
+                     "windowsImportDirectory":"~/.local/share/openxlr/windows-plugins",
+                     "windowsDirectories":["/home/test/.wine/drive_c/Program Files/Common Files/VST3",
+                     "/home/test/Downloads/A plugin collection with a long folder name/Windows/VST3/x64"]}
+                    """));
+                var folders = new PluginFoldersWindow { DataContext = optionsVm };
+                windows.Add(folders);
+                folders.Show();
+                foreach (double width in new[] { 480d, 720 })
+                {
+                    Layout(folders, width, 480);
+                    var list = folders.FindControl<ListBox>("FolderList")!;
+                    Assert.Equal(2, list.ItemCount);
+                    list.SelectedIndex = 0;
+                    Assert.True(folders.FindControl<Button>("RemoveFolder")!.IsEnabled);
+                    foreach (var button in folders.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible))
+                        AssertInside(button, folders);
+                    AssertInside(list, folders);
+                    Capture(folders, "plugin-folders-" + width);
+                }
             }
             catch (Exception ex) { failure = ex; }
             finally

--- a/src/OpenXLR.Tests/WindowsPluginFolderTests.cs
+++ b/src/OpenXLR.Tests/WindowsPluginFolderTests.cs
@@ -1,0 +1,347 @@
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class WindowsPluginFolderTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "openxlr-folders-" + Guid.NewGuid().ToString("N"));
+    private static readonly byte[] Elf = [0x7f, (byte)'E', (byte)'L', (byte)'F', 2, 1];
+    private static readonly byte[] Windows = [(byte)'M', (byte)'Z', 0x90, 0];
+    private string Registry => Path.Combine(_root, "folders");
+    private string Vst3 => Path.Combine(_root, "vst3", "yabridge");
+    private string Clap => Path.Combine(_root, "clap", "yabridge");
+    private string[] Calls => File.ReadAllLines(Path.Combine(_root, "calls"));
+
+    public WindowsPluginFolderTests() => Directory.CreateDirectory(_root);
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    private string Source(string relative, byte[]? bytes = null)
+    {
+        string path = Path.Combine(_root, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, bytes ?? Windows);
+        return path;
+    }
+
+    private PluginInstaller Installer(string[] folders, string? fail = null, string? sync = null, bool wine = true)
+    {
+        File.WriteAllLines(Registry, folders);
+        string controller = Path.Combine(_root, "yabridgectl");
+        File.WriteAllText(controller, $$"""
+            #!/bin/sh
+            printf '%s\n' "$*" >> '{{_root}}/calls'
+            if [ "$1" = '{{fail}}' ]; then printf 'test failure\n' >&2; exit 1; fi
+            case "$1" in
+              list) cat '{{Registry}}' ;;
+              add) printf '%s\n' "$2" >> '{{Registry}}' ;;
+              rm) grep -Fxv -- "$2" '{{Registry}}' > '{{Registry}}.new'; mv '{{Registry}}.new' '{{Registry}}' ;;
+              sync) {{sync ?? ":"}} ;;
+            esac
+            exit 0
+            """);
+        if (!OperatingSystem.IsWindows()) File.SetUnixFileMode(controller, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return new(Path.Combine(_root, "lv2"), Path.Combine(_root, "clap"), Path.Combine(_root, "vst3"), controller, wine ? "/bin/true" : null);
+    }
+
+    private string Vst3Wrapper(string name, string source)
+    {
+        string bundle = Path.Combine(Vst3, name + ".vst3");
+        string contents = Path.Combine(bundle, "Contents");
+        Directory.CreateDirectory(Path.Combine(contents, "x86_64-linux"));
+        Directory.CreateDirectory(Path.Combine(contents, "x86_64-win"));
+        File.WriteAllBytes(Path.Combine(contents, "x86_64-linux", name + ".so"), Elf);
+        File.CreateSymbolicLink(Path.Combine(contents, "x86_64-win", name + ".vst3"), source);
+        return bundle;
+    }
+
+    private string ClapWrapper(string name, string source)
+    {
+        Directory.CreateDirectory(Clap);
+        string module = Path.Combine(Clap, name + ".clap");
+        File.WriteAllBytes(module, Elf);
+        File.CreateSymbolicLink(Path.ChangeExtension(module, ".clap-win"), source);
+        return module;
+    }
+
+    [Fact]
+    public void AddingAWindowsFolderDoesNotCopyNativePluginsBesideIt()
+    {
+        string folder = Path.GetDirectoryName(Source("source/Comp.vst3"))!;
+        Source("source/Linux.clap", Elf);
+        var installer = Installer([]);
+
+        InstallOutcome result = installer.AddWindowsFolder(folder);
+
+        Assert.True(result.Ok, result.Message);
+        Assert.Equal(["list", "add " + folder, "sync"], Calls);
+        Assert.False(File.Exists(Path.Combine(_root, "clap", "Linux.clap")));
+        Assert.Equal([folder], File.ReadAllLines(Registry));
+    }
+
+    [Fact]
+    public void AddingRejectsFilesRelativeMissingAndNativeOnlyFolders()
+    {
+        string native = Source("native/Linux.clap", Elf);
+        var installer = Installer([]);
+        Assert.False(installer.AddWindowsFolder(native).Ok);
+        Assert.False(installer.AddWindowsFolder("relative").Ok);
+        Assert.False(installer.AddWindowsFolder(Path.Combine(_root, "missing")).Ok);
+        Assert.False(installer.AddWindowsFolder(Path.GetDirectoryName(native)!).Ok);
+        Assert.False(File.Exists(Path.Combine(_root, "calls")));
+    }
+
+    [Theory]
+    [InlineData("list")]
+    [InlineData("add")]
+    [InlineData("sync")]
+    public void AddingReportsControllerFailures(string command)
+    {
+        string folder = Path.GetDirectoryName(Source("source/Comp.vst3"))!;
+        InstallOutcome result = Installer([], fail: command).AddWindowsFolder(folder);
+        Assert.False(result.Ok);
+        Assert.Contains("test failure", result.Message);
+        Assert.Equal(command, Calls[^1].Split(' ')[0]);
+    }
+
+    [Fact]
+    public void RemovingDeletesOnlyMatchingWrappersAndKeepsAllSourceFiles()
+    {
+        string plugin = Source("source/Comp.vst3");
+        string clapSource = Source("source/Hall.clap");
+        string source = Path.GetDirectoryName(plugin)!;
+        string bundle = Vst3Wrapper("Comp", plugin);
+        string clap = ClapWrapper("Hall", clapSource);
+        string resource = Source("source/Resources/preset.txt", [1, 2, 3]);
+        Directory.CreateSymbolicLink(Path.Combine(bundle, "Contents", "Resources"), Path.GetDirectoryName(resource)!);
+        string unrelated = Vst3Wrapper("Other", Source("other/Other.vst3"));
+        string unrelatedClap = ClapWrapper("Other", Source("other/Other.clap"));
+        var installer = Installer([source], wine: false);
+
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+
+        Assert.True(result.Ok, result.Message);
+        Assert.Empty(File.ReadAllLines(Registry));
+        Assert.False(Directory.Exists(bundle));
+        Assert.False(File.Exists(clap));
+        Assert.Null(new FileInfo(Path.ChangeExtension(clap, ".clap-win")).LinkTarget);
+        Assert.True(Directory.Exists(unrelated));
+        Assert.True(File.Exists(unrelatedClap));
+        Assert.Equal(Windows, File.ReadAllBytes(plugin));
+        Assert.Equal(Windows, File.ReadAllBytes(clapSource));
+        Assert.Equal(new byte[] { 1, 2, 3 }, File.ReadAllBytes(resource));
+        Assert.Equal(["list", "rm " + source, "list"], Calls);
+        Assert.DoesNotContain(Calls, c => c.Contains("--prune"));
+    }
+
+    [Fact]
+    public void AMissingRegisteredSourceCanStillBeRemoved()
+    {
+        string source = Path.Combine(_root, "gone");
+        string bundle = Vst3Wrapper("Gone", Path.Combine(source, "Gone.vst3"));
+        var installer = Installer([source]);
+
+        InstallOutcome result = installer.RemoveWindowsFolder(source + "/");
+
+        Assert.True(result.Ok, result.Message);
+        Assert.False(Directory.Exists(bundle));
+    }
+
+    [Theory]
+    [InlineData("list")]
+    [InlineData("rm")]
+    public void RemovalNeverCleansWrappersWhenListingOrUnregisteringFails(string command)
+    {
+        string plugin = Source("source/Comp.vst3");
+        string source = Path.GetDirectoryName(plugin)!;
+        string bundle = Vst3Wrapper("Comp", plugin);
+        var installer = Installer([source], fail: command);
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+        Assert.False(result.Ok);
+        Assert.Contains("test failure", result.Message);
+        Assert.True(Directory.Exists(bundle));
+        Assert.Equal([source], File.ReadAllLines(Registry));
+    }
+
+    [Fact]
+    public void FailedSyncReportsPartialRemovalAndKeepsWrappers()
+    {
+        string plugin = Source("source/Comp.vst3");
+        string source = Path.GetDirectoryName(plugin)!;
+        string other = Path.GetDirectoryName(Source("other/Other.vst3"))!;
+        string bundle = Vst3Wrapper("Comp", plugin);
+        var installer = Installer([source, other], fail: "sync");
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+        Assert.False(result.Ok);
+        Assert.Contains("removed from the list", result.Message);
+        Assert.Contains("wrappers were kept", result.Message);
+        Assert.True(Directory.Exists(bundle));
+        Assert.Equal([other], File.ReadAllLines(Registry));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RemovingAnInUseWrapperIsRejectedBeforeAnyMutation(bool clap)
+    {
+        string plugin = Source(clap ? "source/Comp.clap" : "source/Comp.vst3");
+        string source = Path.GetDirectoryName(plugin)!;
+        string wrapper = clap ? ClapWrapper("Comp", plugin) : Vst3Wrapper("Comp", plugin);
+        var installer = Installer([source]);
+        InstallOutcome result = installer.RemoveWindowsFolder(source, [wrapper]);
+        Assert.False(result.Ok);
+        Assert.Contains("Remove the inserts", result.Message);
+        Assert.Equal(["list"], Calls);
+        Assert.Equal([source], File.ReadAllLines(Registry));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RetainedOverlappingRegistrationKeepsTheWrapper(bool removingParent)
+    {
+        string plugin = Source("source/child/Comp.vst3");
+        string child = Path.GetDirectoryName(plugin)!;
+        string parent = Path.GetDirectoryName(child)!;
+        string bundle = Vst3Wrapper("Comp", plugin);
+        var installer = Installer([parent, child]);
+        InstallOutcome result = installer.RemoveWindowsFolder(removingParent ? parent : child);
+        Assert.True(result.Ok, result.Message);
+        Assert.True(Directory.Exists(bundle));
+        Assert.Equal([removingParent ? child : parent], File.ReadAllLines(Registry));
+        Assert.Equal("sync", Calls[^1]);
+    }
+
+    [Fact]
+    public void SyncCanRetargetADuplicateWrapperToARetainedSource()
+    {
+        string first = Source("source/Comp.vst3");
+        string other = Source("other/Comp.vst3");
+        string bundle = Vst3Wrapper("Comp", first);
+        string link = Path.Combine(bundle, "Contents", "x86_64-win", "Comp.vst3");
+        var installer = Installer([Path.GetDirectoryName(first)!, Path.GetDirectoryName(other)!],
+            sync: $"ln -sfn '{other}' '{link}'");
+        InstallOutcome result = installer.RemoveWindowsFolder(Path.GetDirectoryName(first)!);
+        Assert.True(result.Ok, result.Message);
+        Assert.True(Directory.Exists(bundle));
+        Assert.Equal(other, new FileInfo(link).LinkTarget);
+        Assert.True(File.Exists(first));
+    }
+
+    [Fact]
+    public void SiblingNamesAreNotMistakenForTheRemovedFolder()
+    {
+        string first = Source("plugins/One.vst3");
+        string second = Source("plugins-other/Two.vst3");
+        string one = Vst3Wrapper("One", first);
+        string two = Vst3Wrapper("Two", second);
+        var installer = Installer([Path.GetDirectoryName(first)!]);
+        Assert.True(installer.RemoveWindowsFolder(Path.GetDirectoryName(first)!).Ok);
+        Assert.False(Directory.Exists(one));
+        Assert.True(Directory.Exists(two));
+    }
+
+    [Fact]
+    public void UnregisteredAndRelativePathsNeverMutateTheRegistry()
+    {
+        string source = Path.GetDirectoryName(Source("source/Comp.vst3"))!;
+        var installer = Installer([source]);
+        Assert.False(installer.RemoveWindowsFolder("relative").Ok);
+        Assert.False(installer.RemoveWindowsFolder(source + "-other").Ok);
+        Assert.Equal(["list"], Calls);
+        Assert.Equal([source], File.ReadAllLines(Registry));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SymbolicWrapperRootsAndBundlesAreRefused(bool rootLink)
+    {
+        string source = Path.GetDirectoryName(Source("source/Comp.vst3"))!;
+        string original = Source("original/keep.txt");
+        Directory.CreateDirectory(Vst3);
+        if (rootLink)
+        {
+            Directory.Delete(Vst3);
+            Directory.CreateSymbolicLink(Vst3, Path.GetDirectoryName(original)!);
+        }
+        else Directory.CreateSymbolicLink(Path.Combine(Vst3, "Comp.vst3"), Path.GetDirectoryName(original)!);
+        var installer = Installer([source]);
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+        Assert.False(result.Ok);
+        Assert.Contains("symbolic link", result.Message);
+        Assert.Equal(["list"], Calls);
+        Assert.True(File.Exists(original));
+        Assert.Equal([source], File.ReadAllLines(Registry));
+    }
+
+    [Fact]
+    public void UnexpectedFilesInABundleAreNotDeleted()
+    {
+        string plugin = Source("source/Comp.vst3");
+        string source = Path.GetDirectoryName(plugin)!;
+        string bundle = Vst3Wrapper("Comp", plugin);
+        string original = Path.Combine(bundle, "original.dll");
+        File.WriteAllBytes(original, Windows);
+        var installer = Installer([source]);
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+        Assert.False(result.Ok);
+        Assert.Equal(["list"], Calls);
+        Assert.Equal(Windows, File.ReadAllBytes(original));
+    }
+
+    [Fact]
+    public void AWindowsClapFileIsNeverDeletedAsANativeWrapper()
+    {
+        string plugin = Source("source/Comp.clap");
+        string source = Path.GetDirectoryName(plugin)!;
+        string wrapper = ClapWrapper("Comp", plugin);
+        File.WriteAllBytes(wrapper, Windows);
+        var installer = Installer([source]);
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+        Assert.False(result.Ok);
+        Assert.Equal(["list"], Calls);
+        Assert.Equal(Windows, File.ReadAllBytes(wrapper));
+    }
+
+    [Fact]
+    public void MissingYabridgeAndWineProduceUsefulAnswers()
+    {
+        string source = Path.GetDirectoryName(Source("source/Comp.vst3"))!;
+        var none = new PluginInstaller(Path.Combine(_root, "lv2"), Path.Combine(_root, "clap"), Path.Combine(_root, "vst3"), null, null);
+        Assert.Contains("yabridge and Wine are not installed", none.AddWindowsFolder(source).Message);
+        Assert.Contains("yabridge is not installed", none.RemoveWindowsFolder(source).Message);
+        Assert.False(File.Exists(Path.Combine(_root, "calls")));
+    }
+
+    [Fact]
+    public void ALinkedContentsDirectoryCannotRedirectCleanupToOriginalFiles()
+    {
+        string plugin = Source("source/Comp.vst3");
+        string source = Path.GetDirectoryName(plugin)!;
+        string bundle = Vst3Wrapper("Comp", plugin);
+        string contents = Path.Combine(bundle, "Contents");
+        string moved = Path.Combine(_root, "original-contents");
+        Directory.Move(contents, moved);
+        Directory.CreateSymbolicLink(contents, moved);
+        var installer = Installer([source]);
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+        Assert.False(result.Ok);
+        Assert.Contains("symbolic link", result.Message);
+        Assert.Equal(["list"], Calls);
+        Assert.True(File.Exists(Path.Combine(moved, "x86_64-linux", "Comp.so")));
+        Assert.True(File.Exists(plugin));
+    }
+
+    [Fact]
+    public void MissingWineOnlyBlocksRemovalWhenOtherFoldersNeedSyncing()
+    {
+        string source = Path.GetDirectoryName(Source("source/Comp.vst3"))!;
+        string other = Path.GetDirectoryName(Source("other/Other.vst3"))!;
+        var installer = Installer([source, other], wine: false);
+        InstallOutcome result = installer.RemoveWindowsFolder(source);
+        Assert.False(result.Ok);
+        Assert.Contains("Wine is not installed", result.Message);
+        Assert.Equal([source, other], File.ReadAllLines(Registry));
+        Assert.Equal(["list"], Calls);
+    }
+}

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -22,6 +22,7 @@ public sealed class DaemonClient : IAsyncDisposable
     private readonly CancellationTokenSource _cts = new();
     private ClientWebSocket? _socket;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly SemaphoreSlim _pluginChanges = new(1, 1);
     private readonly object _lifecycle = new();
     private Task? _runTask;
     private Task? _disposeTask;
@@ -75,15 +76,37 @@ public sealed class DaemonClient : IAsyncDisposable
     /// bundle can take a while, so callers wait generously.
     /// </summary>
     public Task<JsonNode?> InstallPluginAsync(string path, TimeSpan timeout)
-        => QueryAsync("pluginInstall", "installPlugin", timeout, new Dictionary<string, object> { ["path"] = path });
+        => ChangePluginsAsync("installPlugin", timeout, new Dictionary<string, object> { ["path"] = path });
+
+    public Task<JsonNode?> AddWindowsPluginFolderAsync(string path, TimeSpan timeout)
+        => ChangePluginsAsync("addWindowsPluginFolder", timeout, new Dictionary<string, object> { ["path"] = path });
+
+    public Task<JsonNode?> RemoveWindowsPluginFolderAsync(string path, TimeSpan timeout)
+        => ChangePluginsAsync("removeWindowsPluginFolder", timeout, new Dictionary<string, object> { ["path"] = path });
 
     /// <summary>Bridge again what yabridge knows; the reply is as for an install.</summary>
     public Task<JsonNode?> SyncWindowsPluginsAsync(TimeSpan timeout)
-        => QueryAsync("pluginInstall", "syncWindowsPlugins", timeout);
+        => ChangePluginsAsync("syncWindowsPlugins", timeout);
 
     /// <summary>Read the catalogues again, for plugins installed by other means.</summary>
     public Task<JsonNode?> RescanPluginsAsync(TimeSpan timeout)
-        => QueryAsync("pluginInstall", "rescanPlugins", timeout);
+        => ChangePluginsAsync("rescanPlugins", timeout);
+
+    // Reads may share a reply; changes must each reach the daemon, even
+    // when two windows issue them together and both answer pluginInstall.
+    private async Task<JsonNode?> ChangePluginsAsync(string command, TimeSpan timeout, Dictionary<string, object>? fields = null)
+    {
+        CancellationToken stopping;
+        lock (_lifecycle)
+        {
+            if (_disposed) return null;
+            stopping = _cts.Token;
+        }
+        try { await _pluginChanges.WaitAsync(stopping); }
+        catch (OperationCanceledException) { return null; }
+        try { return await QueryAsync("pluginInstall", command, timeout, fields); }
+        finally { _pluginChanges.Release(); }
+    }
 
     private async Task<JsonNode?> QueryAsync(string type, string command, TimeSpan timeout, Dictionary<string, object>? fields = null)
     {

--- a/src/OpenXLR.UI/OptionsViewModel.cs
+++ b/src/OpenXLR.UI/OptionsViewModel.cs
@@ -64,6 +64,18 @@ public sealed class OptionsViewModel : ViewModelBase
     private bool _canSyncWindows;
     public bool CanSyncWindows { get => _canSyncWindows; private set => Set(ref _canSyncWindows, value); }
 
+    private string? _windowsImportNote;
+    public string? WindowsImportNote { get => _windowsImportNote; private set => Set(ref _windowsImportNote, value); }
+
+    public ObservableCollection<string> WindowsDirectories { get; } = [];
+    public bool HasWindowsDirectories => WindowsDirectories.Count > 0;
+
+    private bool _canManageWindows;
+    public bool CanManageWindows { get => _canManageWindows; private set => Set(ref _canManageWindows, value); }
+
+    private bool _systemBridge;
+    public bool SystemBridge { get => _systemBridge; private set => Set(ref _systemBridge, value); }
+
     /// <summary>Wine's own plugin folders waiting to be bridged, absolute.</summary>
     public System.Collections.Generic.IReadOnlyList<string> WineFolders { get; private set; } = [];
 
@@ -89,7 +101,7 @@ public sealed class OptionsViewModel : ViewModelBase
     public async System.Threading.Tasks.Task LoadPluginSetupAsync()
     {
         System.Text.Json.Nodes.JsonNode? setup = await _client.RequestPluginSetupAsync(TimeSpan.FromSeconds(10));
-        Avalonia.Threading.Dispatcher.UIThread.Post(() => ApplyPluginSetup(setup));
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => ApplyPluginSetup(setup));
     }
 
     internal void ApplyPluginSetup(System.Text.Json.Nodes.JsonNode? setup)
@@ -98,6 +110,7 @@ public sealed class OptionsViewModel : ViewModelBase
         {
             WindowsPlugins = "Windows plugins: the daemon did not answer.";
             CanSyncWindows = false;
+            CanManageWindows = false;
             return;
         }
         string lv2 = setup["lv2Directory"]?.GetValue<string>() ?? "~/.lv2";
@@ -113,7 +126,16 @@ public sealed class OptionsViewModel : ViewModelBase
         WindowsPlugins = WindowsLine(yabridge, wine, folders, setup["bridgeProvider"]?.GetValue<string>() == "openxlr");
         if (setup["windowsPluginDirectory"]?.GetValue<string>() is { } managedDirectory)
             PluginDirectories += $" OpenXLR's Windows plugin wrappers are in {managedDirectory}.";
+        WindowsImportNote = setup["windowsImportDirectory"]?.GetValue<string>() is { } imports
+            ? $"Single-plugin imports are kept in {imports}." : null;
         CanSyncWindows = yabridge is not null && wine;
+        CanManageWindows = yabridge is not null;
+        SystemBridge = yabridge is not null && setup["bridgeProvider"]?.GetValue<string>() != "openxlr";
+        WindowsDirectories.Clear();
+        foreach (string directory in (setup["windowsDirectories"] as System.Text.Json.Nodes.JsonArray ?? [])
+            .Select(f => f?.GetValue<string>()).OfType<string>().Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
+            WindowsDirectories.Add(directory);
+        Raise(nameof(HasWindowsDirectories));
         WineFolders = [.. (setup["wineFolders"] as System.Text.Json.Nodes.JsonArray ?? [])
             .Select(f => f?.GetValue<string>()).OfType<string>()];
         CanBridgeWine = WineFolders.Count > 0;

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -147,6 +147,8 @@
           <Button Name="Rescan" Content="Rescan" Padding="14,5" Click="OnRescanPlugins"
                   ToolTip.Tip="Read the plugin directories again, for plugins installed by other means"/>
         </StackPanel>
+        <Button Name="ManageFolders" Content="Manage folders…" Padding="14,5" Margin="0,4,0,0"
+                HorizontalAlignment="Left" Click="OnManagePluginFolders"/>
         <TextBlock Text="{Binding WindowsPlugins}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="0,4,0,0"/>
         <!-- A pair of versions that leaves a bridged plugin's own editor deaf
              to the mouse. Worth saying before the user spends an evening on it. -->

--- a/src/OpenXLR.UI/OptionsWindow.axaml.cs
+++ b/src/OpenXLR.UI/OptionsWindow.axaml.cs
@@ -53,6 +53,12 @@ public partial class OptionsWindow : Window
             await vm.Client.SyncWindowsPluginsAsync(TimeSpan.FromMinutes(4)), "the sync"), "Bridging Windows plugins…", vm);
     }
 
+    private async void OnManagePluginFolders(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is OptionsViewModel vm)
+            await new PluginFoldersWindow(vm).ShowDialog(this);
+    }
+
     private async void OnRescanPlugins(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not OptionsViewModel vm) return;
@@ -62,7 +68,7 @@ public partial class OptionsWindow : Window
 
     private async System.Threading.Tasks.Task PluginStepAsync(Func<System.Threading.Tasks.Task<string>> step, string busy, OptionsViewModel vm)
     {
-        InstallFile.IsEnabled = InstallFolder.IsEnabled = Rescan.IsEnabled = false;
+        InstallFile.IsEnabled = InstallFolder.IsEnabled = Rescan.IsEnabled = ManageFolders.IsEnabled = false;
         bool sync = SyncWindows.IsEnabled;
         SyncWindows.IsEnabled = BridgeWine.IsEnabled = false;
         PluginStatus.Text = busy;
@@ -70,7 +76,7 @@ public partial class OptionsWindow : Window
         catch (Exception ex) { PluginStatus.Text = ex.Message; }
         finally
         {
-            InstallFile.IsEnabled = InstallFolder.IsEnabled = Rescan.IsEnabled = true;
+            InstallFile.IsEnabled = InstallFolder.IsEnabled = Rescan.IsEnabled = ManageFolders.IsEnabled = true;
             SyncWindows.IsEnabled = sync;
             BridgeWine.IsEnabled = true;
             await vm.LoadPluginSetupAsync();

--- a/src/OpenXLR.UI/PluginFoldersWindow.axaml
+++ b/src/OpenXLR.UI/PluginFoldersWindow.axaml
@@ -1,0 +1,47 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:OpenXLR.UI"
+        x:Class="OpenXLR.UI.PluginFoldersWindow"
+        x:DataType="vm:OptionsViewModel"
+        Title="Windows plugin folders" Width="720" Height="480" MinWidth="480" MinHeight="380"
+        WindowStartupLocation="CenterOwner" Background="#16181d">
+  <Grid Margin="18" RowDefinitions="Auto,12,*,12,Auto,10,Auto,12,Auto">
+    <StackPanel Spacing="6">
+      <TextBlock Text="Windows VST3 and CLAP folders" FontSize="17" FontWeight="SemiBold"/>
+      <TextBlock Text="Add a folder containing Windows plugins to scan it through yabridge. Plugin files stay where they are."
+                 FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+      <TextBlock Text="{Binding WindowsImportNote}" IsVisible="{Binding WindowsImportNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                 FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+      <TextBlock Text="These folders are shared with other applications using system yabridge."
+                 IsVisible="{Binding SystemBridge}" FontSize="12" Foreground="#e0a05a" TextWrapping="Wrap"/>
+    </StackPanel>
+    <Border Grid.Row="2" Background="#1d2027" CornerRadius="8" Padding="8">
+      <Grid>
+        <ListBox Name="FolderList" ItemsSource="{Binding WindowsDirectories}"
+                 SelectionMode="Single" SelectionChanged="OnSelectionChanged"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="x:String">
+              <TextBlock Text="{Binding}" TextWrapping="Wrap" Margin="0,4,12,4" FontSize="12"/>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+        <TextBlock Text="No registered folders." IsVisible="{Binding !HasWindowsDirectories}"
+                   Margin="8" Foreground="#8b93a7" IsHitTestVisible="False"/>
+      </Grid>
+    </Border>
+    <WrapPanel Grid.Row="4" Orientation="Horizontal">
+      <Button Name="AddFolder" Content="Add folder…" Padding="14,5" Margin="0,0,8,0" Click="OnAddFolder"/>
+      <Button Name="RemoveFolder" Content="Remove from list" Padding="14,5" Margin="0,0,8,0" Click="OnRemoveFolder" IsEnabled="False"/>
+      <Button Name="RescanFolders" Content="Rescan" Padding="14,5" Click="OnRescan"/>
+    </WrapPanel>
+    <TextBlock Grid.Row="6" Text="Removal keeps the original files and removes their generated VST3 and CLAP wrappers. Remove affected inserts from your chains first."
+               FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+    <Grid Grid.Row="8" ColumnDefinitions="*,12,Auto">
+      <ScrollViewer MaxHeight="96" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <TextBlock Name="Status" FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,12,0"/>
+      </ScrollViewer>
+      <Button Grid.Column="2" Name="CloseButton" Content="Close" Padding="18,6" Click="OnClose"/>
+    </Grid>
+  </Grid>
+</Window>

--- a/src/OpenXLR.UI/PluginFoldersWindow.axaml.cs
+++ b/src/OpenXLR.UI/PluginFoldersWindow.axaml.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace OpenXLR.UI;
+
+public partial class PluginFoldersWindow : Window
+{
+    private static readonly TimeSpan ChangeTimeout = TimeSpan.FromMinutes(4);
+    private bool _busy;
+
+    public PluginFoldersWindow()
+    {
+        InitializeComponent();
+        Closing += (_, e) =>
+        {
+            if (_busy && e.CloseReason == WindowCloseReason.WindowClosing) e.Cancel = true;
+        };
+    }
+
+    public PluginFoldersWindow(OptionsViewModel vm) : this()
+    {
+        DataContext = vm;
+        Opened += async (_, _) => await RefreshAsync(vm);
+    }
+
+    private void UpdateButtons()
+    {
+        if (DataContext is not OptionsViewModel vm) return;
+        AddFolder.IsEnabled = RescanFolders.IsEnabled = !_busy && vm.CanSyncWindows;
+        RemoveFolder.IsEnabled = !_busy && vm.CanManageWindows && FolderList.SelectedItem is string;
+        FolderList.IsEnabled = CloseButton.IsEnabled = !_busy;
+    }
+
+    private async Task RefreshAsync(OptionsViewModel vm)
+    {
+        _busy = true;
+        UpdateButtons();
+        try
+        {
+            await vm.LoadPluginSetupAsync();
+            if (!vm.CanSyncWindows) Status.Text = vm.WindowsPlugins;
+        }
+        catch (Exception ex) { Status.Text = ex.Message; }
+        finally { _busy = false; UpdateButtons(); }
+    }
+
+    private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e) => UpdateButtons();
+
+    private async void OnAddFolder(object? sender, RoutedEventArgs e)
+    {
+        if (_busy || DataContext is not OptionsViewModel vm) return;
+        try
+        {
+            string? folder = (await PluginInstall.PickFolderAsync(this, "Add a Windows plugin folder", allowMultiple: false)).FirstOrDefault();
+            if (folder is not null)
+                await ChangeAsync(vm, () => vm.Client.AddWindowsPluginFolderAsync(folder, ChangeTimeout), "Adding folder…");
+        }
+        catch (Exception ex) { Status.Text = ex.Message; }
+    }
+
+    private async void OnRemoveFolder(object? sender, RoutedEventArgs e)
+    {
+        if (_busy || DataContext is not OptionsViewModel vm || FolderList.SelectedItem is not string folder) return;
+        string detail = $"Remove {folder} from the scan list and remove its generated VST3 and CLAP wrappers? The original plugin files will stay where they are.";
+        if (vm.SystemBridge) detail += " This also affects other applications using system yabridge.";
+        if (!await Dialogs.ConfirmAsync(this, "Remove plugin folder?", detail, "Remove from list")) return;
+        await ChangeAsync(vm, () => vm.Client.RemoveWindowsPluginFolderAsync(folder, ChangeTimeout), "Removing folder…");
+    }
+
+    private async void OnRescan(object? sender, RoutedEventArgs e)
+    {
+        if (!_busy && DataContext is OptionsViewModel vm)
+            await ChangeAsync(vm, () => vm.Client.SyncWindowsPluginsAsync(ChangeTimeout), "Syncing and rescanning…");
+    }
+
+    private async Task ChangeAsync(OptionsViewModel vm, Func<Task<JsonNode?>> change, string busy)
+    {
+        _busy = true;
+        UpdateButtons();
+        Status.Text = busy;
+        try { Status.Text = PluginInstall.Describe(await change(), "the folder operation"); }
+        catch (Exception ex) { Status.Text = ex.Message; }
+        finally
+        {
+            try { await vm.LoadPluginSetupAsync(); }
+            catch (Exception ex) { Status.Text += " " + ex.Message; }
+            _busy = false;
+            UpdateButtons();
+        }
+    }
+
+    private void OnClose(object? sender, RoutedEventArgs e) => Close();
+}

--- a/src/OpenXLR.UI/PluginInstall.cs
+++ b/src/OpenXLR.UI/PluginInstall.cs
@@ -46,13 +46,14 @@ public static class PluginInstall
     }
 
     /// <summary>Let the user pick a folder: a .vst3 or .lv2 bundle, or a folder holding plugins.</summary>
-    public static async Task<IReadOnlyList<string>> PickFolderAsync(Window owner)
+    public static async Task<IReadOnlyList<string>> PickFolderAsync(Window owner,
+        string title = "Install a plugin folder", bool allowMultiple = true)
     {
         IStorageFolder? start = await owner.StorageProvider.TryGetWellKnownFolderAsync(WellKnownFolder.Downloads);
         IReadOnlyList<IStorageFolder> folders = await owner.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
         {
-            Title = "Install a plugin folder",
-            AllowMultiple = true,
+            Title = title,
+            AllowMultiple = allowMultiple,
             SuggestedStartLocation = start,
         });
         return folders.Select(LocalPath).OfType<string>().ToList();


### PR DESCRIPTION
## Changes

- Add **Manage folders** under Plugins, with add, remove and rescan actions for Windows VST3 and CLAP sources.
- Remove only wrappers associated with the selected folder. Keep original files, unrelated wrappers and wrappers covered by retained folders. Refuse removal while affected inserts remain in the current chains.
- Refresh the catalogue and open pickers after folder removal. Report partial failures and warn when system yabridge's shared registry is in use.
- Copy a selected Windows file or bundle into its own managed folder instead of registering all its siblings. Link plugins already installed inside a Wine prefix so their location and prefix stay intact. Explicit folder picks still register in place.
- Serialize plugin changes so concurrent UI requests cannot share the wrong reply. Add the folder commands and import directory to the documented API.

## Verification

- Native-enabled Release build with warnings treated as errors: 0 warnings, 0 errors.
- .NET suite: 453 passed, 3 opt-in desktop tests skipped. The layout test ran separately under Xvfb and passed, including the manager at 480 and 720 pixels.
- Native audio and CLAP tests passed all 16 cases; editor tests passed all 10 cases.
- Real yabridge checks in isolated directories verified registration, in-use refusal, scoped wrapper cleanup and unchanged source hashes.
- A real Kotelnikov import from a folder containing four plugins generated only one wrapper. It still scanned after deleting the test download. Importing the Wine-installed copy preserved its prefix through a link and scanned successfully too.
- Local deployment tested and confirmed working. Mixer and window settings were preserved.

No version bump or release changes.
