### PR TITLE
Plugins: defer VST3 editor creation until requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ native/tests/*.o
 native/tests/editor
 native/tests/audio
 native/tests/clap
+native/tests/lifecycle
 # nix build output symlink
 result
 

--- a/native/Makefile
+++ b/native/Makefile
@@ -42,6 +42,13 @@ tests/clap.o: tests/clap.c host.c clap.c $(HEADERS)
 tests/clap: tests/clap.o lv2.o vst3.o
 	$(CXX) $^ -o $@ $(LDFLAGS) $(LDLIBS)
 
+# A plugin lifecycle check against a real plugin, run by hand (see README).
+tests/lifecycle.o: tests/lifecycle.c host.c $(HEADERS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+tests/lifecycle: tests/lifecycle.o lv2.o clap.o vst3.o
+	$(CXX) $^ -o $@ $(LDFLAGS) $(LDLIBS)
+
 .PHONY: test test-editor test-audio test-clap clean
 # The editor tests need a display; the others need nothing.
 test: test-audio test-clap test-editor
@@ -56,4 +63,4 @@ test-clap: tests/clap
 	./tests/clap
 
 clean:
-	rm -f openxlr-lv2-host $(OBJECTS) tests/editor tests/editor.o tests/audio tests/audio.o tests/clap tests/clap.o
+	rm -f openxlr-lv2-host $(OBJECTS) tests/editor tests/editor.o tests/audio tests/audio.o tests/clap tests/clap.o tests/lifecycle tests/lifecycle.o

--- a/native/README.md
+++ b/native/README.md
@@ -107,6 +107,44 @@ the helper by hand for a quick look:
 OPENXLR_HOST_TRACE=1 native/openxlr-lv2-host vst3 /usr/lib/vst3/Plugin.vst3 <class-id> test 2 48000
 ```
 
+## Checking a plugin's lifecycle
+
+`make -C native tests/lifecycle` builds a check that takes a real plugin
+through the host's own backend, load, activate, audio cycles, the editor
+and back, with no PipeWire graph and no daemon, and reports how any child
+process (a Wine plugin host) ended. It takes the same plugin arguments as
+the helper:
+
+```sh
+PATH="/usr/lib/openxlr/yabridge:$PATH" \
+  native/tests/lifecycle vst3 "$HOME/.local/share/openxlr/yabridge/vst3/Plugin.vst3" <class-id> \
+  --cycles 60 --editor-at 10
+```
+
+For a custom companion, replace `/usr/lib/openxlr/yabridge` with the selected
+bridge directory reported by `getPluginSetup`. Run under `xvfb-run -a` to
+keep the test editor off your desktop.
+
+`--frames N` sets the cycle length (2048), `--wait-before-activate MS` and
+`--wait-after-activate MS` add pauses that tell a time-based failure from
+one a call causes, `--editor-at N` opens the plugin's real editor on
+`DISPLAY` at that cycle and closes it ten cycles later (use `xvfb-run -a`
+to keep it off the desktop), and `--reactivate-at N` switches the plugin
+off and on again. It exits 0 with `PASS` when every step completed and the
+plugin unloaded; a plugin whose bridge process dies takes the check down
+with it, which is the point. The check does not reproduce the daemon's
+separate audio thread; thread-sensitive behaviour still needs a live insert.
+
+This is how the Elgato EQ 1.3.0 failure was found: the plugin answered
+audio, then its Wine process exited with status 255 (a pure virtual call)
+about 20 ms after activation, every time the host had created and released
+a view before activating. The host used to do exactly that while loading,
+to learn whether the plugin had an editor. It now assumes one and finds
+out when the editor is opened; the check with `--editor-at` shows the
+editor itself is fine, and `--reactivate-at` after it shows the plugin's
+limit, which the daemon never reaches because it activates once per
+process.
+
 ## Scope
 
 For the plugin: URID map and unmap, the worker extension, options, and the
@@ -143,7 +181,8 @@ daemon speaks plain values and the processor takes normalised ones, so the
 conversion happens on the main thread where the controller lives. The
 scanner (`openxlr-lv2-host scan-vst3 BUNDLE`) does not create editors,
 since that is most of the cost of describing a large module; every VST3
-plugin is assumed to have one and the host finds out when asked. The
+plugin is assumed to have one, and the host too creates no view before it
+is asked to open the editor, when a plugin without one says so. The
 interface headers are vendored under `vst3/` (MIT, VST 3.8.1); only their
 inline parts are used, so nothing of the SDK is compiled. Windows VST3
 plugins arrive through yabridge as ordinary bundles. The optional

--- a/native/host.c
+++ b/native/host.c
@@ -687,13 +687,15 @@ static void command(Host *h, char *line) {
   char symbol[MAX_SYMBOL + 1], extra;
   float value;
   if (!strcmp(line, "show")) {
-    // Two different disappointments, and the user can act on only one.
-    if (!h->has_editor)
-      puts("ui unavailable: this plugin has no editor the host can show");
-    else
-      puts(open_ui(h) ? "ui opened"
-                      : "ui unavailable: no X display; the daemon has none "
-                        "from your desktop session");
+    // Two different disappointments, and the user can act on only one. A
+    // backend may learn only while opening that there is no editor, so the
+    // answer is chosen after the attempt.
+    bool opened = h->has_editor && open_ui(h);
+    puts(opened          ? "ui opened"
+         : !h->has_editor ? "ui unavailable: this plugin has no editor the "
+                            "host can show"
+                          : "ui unavailable: no X display; the daemon has "
+                            "none from your desktop session");
   }
   else if (!strcmp(line, "hide"))
     close_ui(h);

--- a/native/tests/editor.c
+++ b/native/tests/editor.c
@@ -60,6 +60,32 @@ static const Backend test_backend = {
     .editor_idle = test_idle, .editor_resized = test_resize,
     .editor_constrain = test_constrain, .editor_coordinate_nudge = true};
 
+// A backend that learns only while opening that the plugin has no editor,
+// as the VST3 backend does now that it creates no view while loading.
+static bool refuse_open(Host *h) {
+  host_set_has_editor(h, false);
+  return false;
+}
+
+// Run one command as the daemon would and hand back the reply line.
+static void reply_to(Host *h, const char *line, char *reply, size_t size) {
+  FILE *capture = tmpfile();
+  assert(capture);
+  fflush(stdout);
+  int saved = dup(STDOUT_FILENO);
+  assert(saved >= 0 && dup2(fileno(capture), STDOUT_FILENO) >= 0);
+  char command_line[32];
+  snprintf(command_line, sizeof(command_line), "%s", line);
+  command(h, command_line);
+  fflush(stdout);
+  assert(dup2(saved, STDOUT_FILENO) >= 0);
+  close(saved);
+  rewind(capture);
+  assert(fgets(reply, (int)size, capture));
+  reply[strcspn(reply, "\n")] = 0;
+  fclose(capture);
+}
+
 static void drain(Host *h) {
   // No host timer is installed. Only readiness of the real X connection can
   // deliver these events. The old 30 Hz polling path cannot pass this test.
@@ -239,6 +265,25 @@ int main(void) {
   assert_bounds(&h, 128, 96, 128, 96);
   puts("PASS: fixed editors reject border resizing but accept plugin scaling");
   close_ui(&h);
+
+  // Whether a plugin has an editor is settled when one is asked for, not by
+  // creating a view while loading, and the reply to show still tells a
+  // plugin without an editor apart from a missing display.
+  Backend no_editor_backend = test_backend;
+  no_editor_backend.editor_open = refuse_open;
+  h.backend = &no_editor_backend;
+  char reply[160];
+  reply_to(&h, "show", reply, sizeof(reply));
+  assert(!strcmp(reply, "ui unavailable: this plugin has no editor the host can show"));
+  assert(!h.has_editor && !h.editor_source && !h.display && !h.editor_open);
+  reply_to(&h, "show", reply, sizeof(reply));  // and it is remembered
+  assert(!strcmp(reply, "ui unavailable: this plugin has no editor the host can show"));
+  h.has_editor = true;
+  h.backend = &test_backend;
+  reply_to(&h, "show", reply, sizeof(reply));
+  assert(!strcmp(reply, "ui opened") && h.editor_open);
+  close_ui(&h);
+  puts("PASS: a plugin without an editor is found out on opening and says so");
   fixed_editor = false;
   assert(open_ui(&h));
   drain(&h);

--- a/native/tests/lifecycle.c
+++ b/native/tests/lifecycle.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Take a real plugin through the host's backend without a PipeWire graph:
+// load, activate, audio cycles, the editor, deactivate, unload. Any child
+// the plugin starts (a Wine host for a bridged plugin) is reported as it
+// ends, without reaping it, so the bridge's own bookkeeping is untouched.
+// A plugin whose process dies takes this check down with it: that is the
+// signal. Exits 0 with PASS when every step completed.
+#define main host_program_main
+#include "../host.c"
+#undef main
+#include <time.h>
+
+static double started;
+
+static double now_ms(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+
+static void report(const char *what, double value) {
+  fprintf(stderr, "lifecycle: %s %.0f at %.0f ms\n", what, value, now_ms() - started);
+}
+
+static char *append_text(char *out, const char *text) {
+  while (*text)
+    *out++ = *text++;
+  return out;
+}
+
+static char *append_number(char *out, unsigned long value) {
+  char digits[32];
+  unsigned count = 0;
+  do {
+    digits[count++] = (char)('0' + value % 10);
+    value /= 10;
+  } while (value);
+  while (count)
+    *out++ = digits[--count];
+  return out;
+}
+
+static void child_ended(int sig, siginfo_t *info, void *context) {
+  const char *how = info->si_code == CLD_EXITED   ? "exited with status"
+                    : info->si_code == CLD_KILLED ? "killed by signal"
+                    : info->si_code == CLD_DUMPED ? "dumped core on signal"
+                                                  : "changed state";
+  // stdio is not signal-safe, and this may interrupt a bridge thread while
+  // it is printing. Keep the report on the stack and issue one write.
+  int saved_errno = errno;
+  char message[160], *out = append_text(message, "lifecycle: child ");
+  out = append_number(out, (unsigned long)info->si_pid);
+  out = append_text(out, " ");
+  out = append_text(out, how);
+  out = append_text(out, " ");
+  out = append_number(out, (unsigned long)info->si_status);
+  out = append_text(out, " at ");
+  out = append_number(out, (unsigned long)(now_ms() - started));
+  out = append_text(out, " ms\n");
+  (void)write(STDERR_FILENO, message, (size_t)(out - message));
+  errno = saved_errno;
+}
+
+// Sleep while servicing the plugin's run loop, as the host's main thread
+// does between commands.
+static void wait_ms(Host *h, long wait, const char *what) {
+  struct pw_loop *loop = pw_main_loop_get_loop(h->loop);
+  for (long waited = 0; waited < wait; waited += 10) {
+    pw_loop_iterate(loop, 0);
+    struct timespec tick = {0, 10000000};
+    nanosleep(&tick, NULL);
+  }
+  fprintf(stderr, "lifecycle: %s wait over at %.0f ms\n", what, now_ms() - started);
+}
+
+static long option(int argc, char **argv, int first, const char *name, long fallback) {
+  for (int i = first; i + 1 < argc; ++i)
+    if (!strcmp(argv[i], name))
+      return strtol(argv[i + 1], NULL, 10);
+  return fallback;
+}
+
+int main(int argc, char **argv) {
+  started = now_ms();
+  struct sigaction on_child = {0};
+  on_child.sa_sigaction = child_ended;
+  on_child.sa_flags = SA_SIGINFO | SA_RESTART;
+  sigaction(SIGCHLD, &on_child, NULL);
+  const Backend *backend = argc >= 2 ? backend_named(argv[1]) : NULL;
+  int first = backend ? 2 + backend->argument_count : 0;
+  if (!backend || argc < first) {
+    fputs("usage: lifecycle (lv2 URI | clap FILE ID | vst3 BUNDLE CLASS-ID)\n"
+          "       [--frames N] [--cycles N] [--wait-before-activate MS]\n"
+          "       [--wait-after-activate MS] [--editor-at N] [--reactivate-at N]\n",
+          stderr);
+    return 2;
+  }
+  uint32_t frames = (uint32_t)option(argc, argv, first, "--frames", 2048);
+  long cycles = option(argc, argv, first, "--cycles", 60);
+  long before = option(argc, argv, first, "--wait-before-activate", 0);
+  long after = option(argc, argv, first, "--wait-after-activate", 0);
+  long editor_at = option(argc, argv, first, "--editor-at", -1);
+  long reactivate_at = option(argc, argv, first, "--reactivate-at", -1);
+  if (frames == 0 || frames > MAX_FRAMES)
+    return 2;
+
+  static Host h;
+  h.backend = backend;
+  h.node_name = "openxlr-lifecycle";
+  h.rate = 48000;
+  h.channels = 2;
+  h.main_thread = pthread_self();
+  h.silence = calloc(MAX_FRAMES, sizeof(float));
+  h.scratch = calloc(MAX_FRAMES, sizeof(float));
+  if (!h.silence || !h.scratch || !configure_editor_environment())
+    return 1;
+  XSetErrorHandler(report_x_error);
+  XSetIOErrorHandler(lost_x_connection);
+  pw_init(NULL, NULL);
+  h.loop = pw_main_loop_new(NULL);
+  if (!h.loop)
+    return 1;
+  struct pw_loop *loop = pw_main_loop_get_loop(h.loop);
+  pw_loop_enter(loop);
+
+  if (!backend->load(&h, argv + 2)) {
+    fputs("lifecycle: load failed\n", stderr);
+    return 1;
+  }
+  fprintf(stderr, "lifecycle: loaded '%s', %u controls, at %.0f ms\n",
+          h.plugin_name, h.control_count, now_ms() - started);
+  if (before > 0)
+    wait_ms(&h, before, "pre-activate");
+  if (!backend->activate(&h)) {
+    fputs("lifecycle: activate failed\n", stderr);
+    return 1;
+  }
+  report("activated, result", 1);
+  if (after > 0)
+    wait_ms(&h, after, "post-activate");
+
+  float *in[MAX_CHANNELS] = {0}, *out[MAX_CHANNELS] = {0};
+  for (unsigned c = 0; c < h.channels; ++c) {
+    in[c] = calloc(MAX_FRAMES, sizeof(float));
+    out[c] = calloc(MAX_FRAMES, sizeof(float));
+    if (!in[c] || !out[c])
+      return 1;
+  }
+  double phase = 0;
+  long editor_close_at = editor_at >= 0 ? editor_at + 10 : -1;
+  for (long n = 0; n < cycles; ++n) {
+    if (n == reactivate_at) {
+      backend->deactivate(&h);
+      report("deactivated then activated, result", backend->activate(&h));
+    }
+    if (n == editor_at)
+      report("editor open, result", open_ui(&h));
+    if (n == editor_close_at) {
+      close_ui(&h);
+      report("editor closed, still open", h.editor_open);
+    }
+    for (uint32_t i = 0; i < frames; ++i) {
+      float sample = 0.25f * (float)sin(phase);
+      phase += 2 * 3.14159265358979323846 * 440.0 / 48000.0;
+      for (unsigned c = 0; c < h.channels; ++c)
+        in[c][i] = sample;
+    }
+    backend->process(&h, frames, in, out);
+    float peak = 0;
+    for (uint32_t i = 0; i < frames; ++i)
+      peak = fmaxf(peak, fabsf(out[0][i]));
+    printf("cycle %ld at %.0f ms, output peak %.3f\n", n, now_ms() - started, peak);
+    fflush(stdout);
+    for (int k = 0; k < 4; ++k)
+      pw_loop_iterate(loop, 0);
+    if (backend->main_thread)
+      backend->main_thread(&h);
+    if (h.editor_open)
+      pump_editor(&h, true);
+    struct timespec pause = {0, (long)(frames * 1000000000ULL / h.rate)};
+    nanosleep(&pause, NULL);
+  }
+  if (h.editor_open)
+    close_ui(&h);
+  backend->deactivate(&h);
+  backend->unload(&h);
+  pw_loop_leave(loop);
+  pw_main_loop_destroy(h.loop);
+  pw_deinit();
+  fprintf(stderr, "lifecycle: PASS, %ld cycles, unloaded at %.0f ms\n", cycles,
+          now_ms() - started);
+  return 0;
+}

--- a/native/vst3.cpp
+++ b/native/vst3.cpp
@@ -818,16 +818,6 @@ int main_bus_channels(Vst3 *v, BusDirection direction) {
   return info.channelCount;
 }
 
-bool editor_available(Vst3 *v) {
-  IPlugView *view = v->controller->createView(ViewType::kEditor);
-  if (!view)
-    return false;
-  bool ok = view->isPlatformTypeSupported(kPlatformTypeX11EmbedWindowID) ==
-            kResultTrue;
-  view->release();
-  return ok;
-}
-
 void release_plugin(Vst3 *v) {
   if (v->component_point && v->controller_point) {
     v->component_point->disconnect(v->controller_point);
@@ -931,7 +921,13 @@ bool vst3_load(Host *h, char **arguments) {
     v->records.push_back(r);
   }
   v->frame = new PlugFrame(v);
-  host_set_has_editor(h, editor_available(v));
+  // Whether the plugin has an editor is learnt when one is asked for, as the
+  // scanner already assumes. Creating a view here only to release it again
+  // is not a harmless question: a plugin can leave a callback to that view
+  // behind, and Elgato EQ 1.3.0 ends its process with a pure virtual call on
+  // the activation that follows. The daemon never activates twice in one
+  // process, so a view created after activation is the only kind it sees.
+  host_set_has_editor(h, true);
   return true;
 }
 
@@ -1143,12 +1139,15 @@ void vst3_main_thread(Host *h) {
 bool vst3_editor_open(Host *h) {
   Vst3 *v = of(h);
   v->view = v->controller->createView(ViewType::kEditor);
-  if (!v->view)
+  if (!v->view) {
+    host_set_has_editor(h, false);  // now known for certain
     return false;
+  }
   if (v->view->isPlatformTypeSupported(kPlatformTypeX11EmbedWindowID) !=
       kResultTrue) {
     v->view->release();
     v->view = nullptr;
+    host_set_has_editor(h, false);
     return false;
   }
   v->view->setFrame(v->frame);


### PR DESCRIPTION
## Changes

Elgato EQ 1.3.0.110 crashes when activation follows a VST3 editor view being created and released. OpenXLR did that while loading to check for editor availability.

- Defer view creation until the editor is actually requested, matching the scanner's existing behavior.
- Report a plugin with no compatible editor accurately after the open attempt.
- Add coverage for the deferred no-editor reply and a manual real-plugin lifecycle diagnostic.

## Verification

- The original Elgato EQ reproduction changed from exit 134 to exit 0 after removing the load-time probe.
- The real plugin processed 60 cycles, opened and closed its editor under Xvfb, and unloaded with Wine host exit 0.
- Filtering a 440 Hz tone confirmed actual EQ processing, not just process survival.
- Native build passed with warnings treated as errors. Audio and CLAP tests passed all 16 cases; editor tests passed all 11 cases.
- Deployed locally and confirmed working. The running helper was verified against the rebuilt binary.

The plugin still fails if explicitly deactivated and reactivated after a view has been created. OpenXLR activates once per helper process, so its normal lifecycle does not take that path. The diagnostic documents it.

No version bump or release changes. Individual-plugin management is a separate change.
