### PR TITLE
Plugins: manage individual Windows plugins

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,8 +56,9 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `meters` | 15 Hz while the mixer is built | live stereo levels per channel and mix |
 | `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls, within the message size limit above and always including the plugins the saved chains use; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, `windowsDirectories` (the folders yabridge bridges) and `wineFolders` (Wine's own plugin folders that hold a plugin and are not bridged yet, offered as one press since a file dialog hides them) |
+| `windowsPluginFiles` | in answer to `getWindowsPluginFiles` | `ok`, `message` and `plugins`; each plugin file carries `path`, `name`, `format`, `enabled`, `canDelete`, `winePrefix` and `inUse`. Excluded files remain listed |
 | `pluginDiagnostics` | in answer to `getPluginDiagnostics` | `discovery`: daemon host/controller paths, Wine prefix, architecture, effective search paths, bounded `yabridgectl status` output and latest completed CLAP/VST3 scan reports |
-| `pluginInstall` | in answer to `installPlugin`, `addWindowsPluginFolder`, `removeWindowsPluginFolder`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user, ending with the bundles the scan that followed could not read, up to three by name and the rest as a count), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
+| `pluginInstall` | in answer to `installPlugin`, `addWindowsPluginFolder`, `removeWindowsPluginFolder`, `removeWindowsPluginInserts`, `setWindowsPluginEnabled`, `deleteWindowsPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user, ending with the bundles the scan that followed could not read, up to three by name and the rest as a count), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
 | `error` | when a command without a `requestId` is rejected | `message` |
 | `commandResult` | in answer to a command that carried a `requestId` | `requestId`, `error` (null on success); preceded by the state the result refers to |
 
@@ -96,7 +97,11 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `installPlugin` | `path` | install what is at an absolute path the user picked: a `.clap` or single-file `.vst3` is copied into `~/.clap` or `~/.vst3`, a `.vst3` or `.lv2` directory into `~/.vst3` or `~/.lv2`, a plain directory installs every plugin inside it. A single Windows VST3/CLAP file or VST3 bundle is copied into its own folder under `windowsImportDirectory`, and only that folder is registered and synced; a plugin already installed inside a Wine prefix is linked from the managed folder instead, preserving its original location and prefix. An explicit Windows plugin folder is registered in place. Archives, installers and VST2 files are refused with a message that says what to do. The catalogues are read again before the `pluginInstall` answer |
 | `addWindowsPluginFolder` | `path` | register an existing folder holding Windows VST3 or CLAP plugins and sync it, without copying source files or installing any native plugins alongside them; answered with `pluginInstall` |
 | `removeWindowsPluginFolder` | `path` | unregister a folder from `windowsDirectories`, sync retained folders and remove only its unused generated VST3/CLAP wrappers. Original files are kept. Refused while affected plugins remain in the mixer's insert chains. A missing source folder can still be removed from the list; answered with `pluginInstall` |
-| `syncWindowsPlugins` | none | run yabridge's sync over the folders it knows, then read the catalogues again; answered with `pluginInstall` |
+| `getWindowsPluginFiles` | `path` | list Windows VST3/CLAP files and bundles reachable from one registered folder, including excluded files; answered with `windowsPluginFiles`. Reads metadata without syncing or deleting |
+| `removeWindowsPluginInserts` | `path` | remove every current insert supplied by the selected registered Windows plugin file, including bypassed occurrences across inputs and mixes. Other inserts, files, exclusions and saved profiles are kept. Rewire affected paths and save current settings before answering with `pluginInstall`; requires a running mixer |
+| `setWindowsPluginEnabled` | `path`, `value` | enable with `true`, or exclude with `false`, one registered Windows plugin source using yabridge's blacklist. Excluding keeps original files and removes only that source's wrappers, and is refused while the plugin is used by inserts; answered with `pluginInstall` after a catalogue refresh |
+| `deleteWindowsPlugin` | `path` | permanently delete one standalone plugin file or bundle and its wrappers, then refresh the catalogue. Refused for unregistered, Wine-installed, symbolic-link or in-use sources; answered with `pluginInstall`. Clients must confirm deletion with the user first |
+| `syncWindowsPlugins` | none | run yabridge's sync over the folders it knows, clean missing-source wrappers belonging to those folders unless inserts still use them, then read the catalogues again; answered with `pluginInstall` |
 | `rescanPlugins` | none | read the plugin directories again, for plugins installed by other means; answered with `pluginInstall` |
 | `setInserts` | `channel`, `inserts[]` | replace a chain; `channel` is `xlr1`, `xlr2` or `mix:<id>`, each insert is `{id, kind, plugin, label?, bypass?, params?}` where `kind` is `"lv2"` with the plugin URI, `"clap"` with the plugin's id, or `"vst3"` with the class id as 32 hex digits; a CLAP or VST3 insert always runs in the native host, so its `nativeHost` reads true whatever was sent |
 | `setInsertBypass` | `channel`, `insertId`, `value` | bypass one insert |
@@ -141,6 +146,26 @@ insert-chain replacements and profile loads against those operations. Check
 `pluginInstall.ok` and `message` for the operation's outcome: a failed cleanup
 can leave the folder unregistered with some wrappers still present. Refresh
 `getPluginSetup` after either success or failure. Profiles are not rewritten.
+
+Individual-plugin commands use the same path limits. Before disabling or
+uninstalling an in-use plugin, a client can confirm and call
+`removeWindowsPluginInserts`. It resolves all classes exported by that file,
+not other formats or similarly named files. The reply says how many inserts
+and chains changed. A rewire failure preserves the failed chain definitions
+and reports partial completion; a save failure restores the previous chain
+settings and attempts to restore their audio paths. Clients must check
+`pluginInstall.ok` and its message, then refresh usage. The operation is
+serialized with profile loads, insert replacements and file-management
+operations. Profiles are not edited, so recalling one can add the plugin back.
+
+Exclusions are stored
+by canonical source path, so linked imports retain the same exclusion as
+the Wine-installed original. A folder-level exclusion must be removed through
+yabridge before a file blocked by it can be enabled. Exclusions are not global
+class-ID bans: a separately installed copy can still appear in the catalogue.
+`deleteWindowsPlugin` cannot run a Windows uninstaller. The UI opens Wine's
+installed-apps list in the reported `winePrefix`, waits for it to close, then
+syncs and rescans. It never imposes a deadline on an interactive uninstaller.
 
 LV2 insert definitions optionally carry `nativeHost: true` to select the native
 helper for that insert. Missing or false keeps LV2 in PipeWire filter-chain, even

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -64,7 +64,16 @@ message after refreshing the catalogue. Check that message's `ok` and
 reported there. Removal keeps the original files and refuses folders backing
 current inserts. With the system bridge, folder registration is shared with
 other applications. The [folder-management contract](api.md) covers partial
-failures and path limits.
+failures and path limits. `getWindowsPluginFiles` lists individual files in
+one registered folder. `removeWindowsPluginInserts` takes `path` and removes
+that file's plugin classes from all current chains, saving before it answers;
+confirm with the user first because affected audio paths are rebuilt. It
+keeps other inserts and saved profiles. `setWindowsPluginEnabled` takes `path` and a boolean
+`value`; `deleteWindowsPlugin` takes `path` and permanently removes a standalone
+file or bundle after the client has obtained confirmation. Both mutations
+return `pluginInstall` and refresh the catalogue. Wine-installed and linked
+files cannot be deleted through this API; use the Windows uninstaller in the
+appropriate Wine prefix.
 
 The [OpenAPI document](openapi-v1.json) describes the HTTP endpoints. Restarting
 the daemon rotates its per-session token once the new instance listens;

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -385,8 +385,8 @@ and the plugin is in the picker with a VST3 or CLAP badge. Nothing else
 has to be restarted.
 
 <a name="plugin-folders"></a>
-**Managing Windows plugin folders.** Open Options, PLUGINS, then "Manage
-folders…" to see the folders registered with the selected yabridge provider.
+**Managing Windows plugin folders.** Open Options, PLUGINS, then "Manage Windows
+plugins…" to see the folders registered with the selected yabridge provider.
 
 - "Add folder…" registers a folder holding Windows VST3 or CLAP plugins,
   syncs it and refreshes the catalogue. The original files stay in that
@@ -403,6 +403,43 @@ folder, including bypassed inserts. Folder removal does not edit saved
 profiles; re-add the folder before recalling a profile that needs it. It
 does not restart the audio service. If unregistering succeeds but cleanup
 fails, the result says so and the list refreshes to show the current state.
+
+**Managing individual plugins.** Select a registered folder to see its
+Windows VST3 and CLAP files. Each row says whether that source is enabled,
+disabled or in use by an insert chain.
+
+- "Disable in OpenXLR" excludes the selected source from yabridge and removes
+  its generated wrappers. Its files stay in place and the row remains listed.
+  "Enable in OpenXLR" restores it. A separately installed copy can still
+  appear in the picker; disabling one source does not ban a plugin name.
+- "Delete file…" permanently deletes a standalone file or bundle after a
+  confirmation. Other files in the same folder are kept. It is unavailable
+  for Wine-installed or linked sources, which may depend on an installer,
+  registry entries or shared resources.
+- "Wine uninstaller…" opens the installed-apps list in the selected plugin's
+  Wine prefix. Choose the plugin's installer entry there. Close other Wine
+  applications and remove affected inserts first: one installer entry may
+  remove several effects from the same package. OpenXLR waits without killing
+  the uninstaller on a timeout, then syncs and rescans when it closes.
+
+When a row says "In use", choose "Remove from all chains…" and confirm to
+remove every occurrence from the current input and mix chains, including
+bypassed inserts. Other plugins keep their order and settings. This requires
+a running mixer and can briefly interrupt affected audio paths. The current
+settings are saved before the operation completes, then the row refreshes so
+you can disable, delete or uninstall the plugin. Files and exclusions are not
+changed by this step. Saved profiles are kept too; recalling one can add the
+plugin back. If a chain could not be changed, the result names it rather than
+claiming the whole operation succeeded.
+
+Disable and delete actions are refused while the plugin remains in an insert
+chain, including a bypassed insert. The controls refresh the catalogue and
+open pickers after each change. Sync also removes wrappers whose source
+files have gone, but keeps unrelated wrappers and those still used by inserts.
+Exclusions are stored in the selected bridge's configuration; system-bridge
+exclusions affect other applications using that bridge too. A folder-level
+blacklist rule made outside OpenXLR must be removed through yabridge before a
+plugin blocked by that rule can be enabled here.
 
 With the OpenXLR companion, this manages its private registry and wrappers.
 With system yabridge, the same registry is used by other applications, so
@@ -434,8 +471,8 @@ Wine prefix and neighbouring files. Selecting an ordinary folder or using
 VST2 `.dll` files are left out because OpenXLR cannot load VST2.
 
 Older folder registrations are not silently removed. If an earlier
-single-file import registered Downloads, remove that entry with "Manage
-folders…" and import the plugins you want individually. Remove affected
+single-file import registered Downloads, remove that entry with "Manage Windows
+plugins…" and import the plugins you want individually. Remove affected
 inserts first if the manager asks you to. Removing a folder refreshes the
 catalogue and the open plugin pickers.
 

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -743,6 +743,69 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         }
     }
 
+    /// <summary>Remove every occurrence of the selected plugins, then save before acknowledging.</summary>
+    public (int Removed, int Chains, string? Error) RemovePluginInserts(
+        IReadOnlySet<(string Kind, string Plugin)> plugins, Func<MixerSettings, string?> save)
+    {
+        lock (_gate)
+        {
+            try
+            {
+                return RemovePluginInserts(_inserts, plugins,
+                    keys => { if (_built) RewireInsertKeysLocked(keys, endWine: false); },
+                    () =>
+                    {
+                        if (save(ExportSettings()) is string error) throw new IOException(error);
+                    });
+            }
+            finally { if (_built) EndUnusedWineLocked(); }
+        }
+    }
+
+    internal static (int Removed, int Chains, string? Error) RemovePluginInserts(
+        IDictionary<string, List<InsertDefinition>> inserts, IReadOnlySet<(string Kind, string Plugin)> plugins,
+        Action<IReadOnlyList<string>> rewire, Action save)
+    {
+        var edits = inserts.Select(e => (e.Key, Before: e.Value,
+            After: e.Value.Where(i => !plugins.Contains((i.Kind, i.Plugin))).ToList()))
+            .Where(e => e.Before.Count != e.After.Count).ToArray();
+        // Both hardware inputs share one feed rebuild; mixes are independent.
+        var groups = edits.GroupBy(e => (Input: e.Key is "xlr1" or "xlr2",
+            Key: e.Key is "xlr1" or "xlr2" ? "" : e.Key)).Select(g => g.ToArray()).ToArray();
+        var completed = new List<string[]>();
+        var errors = new List<string>();
+        int removed = 0, chains = 0;
+        foreach (var group in groups)
+        {
+            string[] keys = [.. group.Select(e => e.Key)];
+            foreach (var edit in group) inserts[edit.Key] = edit.After;
+            try { rewire(keys); }
+            catch (Exception ex)
+            {
+                foreach (var edit in group) inserts[edit.Key] = edit.Before;
+                errors.Add($"{string.Join(", ", keys)}: {ex.Message}");
+                try { rewire(keys); }
+                catch (Exception rollback) { errors.Add($"Could not restore {string.Join(", ", keys)} audio: {rollback.Message}"); }
+                continue;
+            }
+            completed.Add(keys);
+            removed += group.Sum(e => e.Before.Count - e.After.Count);
+            chains += group.Length;
+        }
+        try { save(); }
+        catch (Exception ex)
+        {
+            foreach (var edit in edits) inserts[edit.Key] = edit.Before;
+            var rollbackErrors = new List<string>(errors);
+            foreach (string[] keys in completed)
+                try { rewire(keys); }
+                catch (Exception rollback) { rollbackErrors.Add(rollback.Message); }
+            throw new InvalidOperationException("Could not save plugin removal; previous chain settings were restored: " + ex.Message
+                + (rollbackErrors.Count == 0 ? "" : " Audio recovery also reported: " + string.Join("; ", rollbackErrors)), ex);
+        }
+        return (removed, chains, errors.Count == 0 ? null : "Some chains could not be changed: " + string.Join("; ", errors));
+    }
+
     /// <summary>Bypass or re-enable one insert; rewires when built.</summary>
     public void SetInsertBypass(string channel, string insertId, bool bypass)
     {
@@ -756,11 +819,18 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
         }
     }
 
-    private void RewireInsertKeyLocked(string key)
+    private void RewireInsertKeyLocked(string key) => RewireInsertKeysLocked([key]);
+
+    private void RewireInsertKeysLocked(IReadOnlyList<string> keys, bool endWine = true)
     {
-        _restarts.Forget(key);
-        if (MixForKey(key) is MixDefinition mix) WireMixChainLocked(mix);
-        else if (IsInsertChannel(key)) WireInputFeedsLocked();
+        foreach (string key in keys) _restarts.Forget(key);
+        if (MixForKey(keys[0]) is MixDefinition mix) WireMixChainLocked(mix);
+        else if (keys.Any(IsInsertChannel)) WireInputFeedsLocked();
+        if (endWine) EndUnusedWineLocked();
+    }
+
+    private void EndUnusedWineLocked()
+    {
         // The new chain is up: if it holds no bridged plugin any more, Wine is
         // resident for nothing, and it would still be resident hours later
         // when the daemon stops. The decision is taken here, under the lock,

--- a/src/OpenXLR.Core/Mixing/PluginCatalog.cs
+++ b/src/OpenXLR.Core/Mixing/PluginCatalog.cs
@@ -70,6 +70,18 @@ public static class PluginCatalog
     public static HashSet<(string Kind, string Plugin)> Identities()
         => [.. Plugins.Select(p => (p.Kind, p.Plugin))];
 
+    /// <summary>Plugin identities supplied by exactly these files or bundle directories.</summary>
+    public static HashSet<(string Kind, string Plugin)> IdentitiesUnder(IReadOnlyCollection<string> paths)
+        => IdentitiesUnder(Plugins, paths);
+
+    internal static HashSet<(string Kind, string Plugin)> IdentitiesUnder(IEnumerable<PluginInfo> catalogue, IReadOnlyCollection<string> paths)
+    {
+        string[] roots = [.. paths.Select(WindowsPluginWrappers.Normalize)];
+        return [.. catalogue.Where(p => p.Path is not null
+                && roots.Any(root => WindowsPluginWrappers.Under(WindowsPluginWrappers.Normalize(p.Path), root)))
+            .Select(p => (p.Kind, p.Plugin))];
+    }
+
     /// <summary>The same, but only for plugins that came from one of these directories.</summary>
     public static int CountUnder(IReadOnlyCollection<string> directories, HashSet<(string Kind, string Plugin)> known)
         => Plugins.Count(p => !known.Contains((p.Kind, p.Plugin))

--- a/src/OpenXLR.Core/Mixing/PluginInstaller.cs
+++ b/src/OpenXLR.Core/Mixing/PluginInstaller.cs
@@ -25,6 +25,9 @@ public enum PluginItemKind
 
 public sealed record PluginItem(PluginItemKind Kind, string Path);
 
+public sealed record WindowsPluginFile(string Path, string Name, string Format, bool Enabled, bool CanDelete, string? WinePrefix, bool InUse = false);
+public sealed record WindowsPluginFiles(bool Ok, string Message, IReadOnlyList<WindowsPluginFile> Plugins);
+
 /// <summary>Where plugins are found and installed, and what is there to bridge Windows ones.</summary>
 public sealed record PluginSetup(
     bool HostInstalled,
@@ -291,13 +294,14 @@ public sealed class PluginInstaller
         return imported.Count > 0 ? directory : null;
     }
 
-    private static bool InWinePrefix(string source)
+    private static bool InWinePrefix(string source) => WinePrefixFor(source) is not null;
+
+    private static string? WinePrefixFor(string source)
     {
-        FileSystemInfo info = Directory.Exists(source) ? new DirectoryInfo(source) : new FileInfo(source);
-        string path = info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? Path.GetFullPath(source);
+        string path = WindowsPluginWrappers.Canonical(source);
         for (string? parent = Path.GetDirectoryName(path); parent is not null; parent = Path.GetDirectoryName(parent))
-            if (File.Exists(Path.Combine(parent, "system.reg")) && Directory.Exists(Path.Combine(parent, "drive_c"))) return true;
-        return false;
+            if (File.Exists(Path.Combine(parent, "system.reg")) && Directory.Exists(Path.Combine(parent, "drive_c"))) return parent;
+        return null;
     }
 
     private static void Copy(string source, string directory, List<string> installed, List<string> destinations, List<string> notes,
@@ -445,6 +449,196 @@ public sealed class PluginInstaller
         }
     }
 
+    /// <summary>The individual Windows plugins reachable from one registered folder, including exclusions.</summary>
+    public WindowsPluginFiles ListWindowsPlugins(string folder, IReadOnlyCollection<string>? inUsePluginPaths = null)
+    {
+        if (!ValidPluginPath(folder)) return new(false, "The folder path has to be absolute and contain no control characters.", []);
+        try
+        {
+            folder = WindowsPluginWrappers.Normalize(folder);
+            if (!TryWindowsDirectories(out IReadOnlyList<string> folders, out string? error)) return new(false, error!, []);
+            if (!folders.Contains(folder, StringComparer.Ordinal)) return new(false, "This folder is not registered with yabridge.", []);
+            if (!TryBlacklist(out HashSet<string> excluded, out error)) return new(false, error!, []);
+            string[] usedTargets = inUsePluginPaths is { Count: > 0 }
+                ? WindowsPluginWrappers.Read(BridgedVst3Directory, BridgedClapDirectory)
+                    .Where(w => WindowsPluginWrappers.InUse(w, inUsePluginPaths))
+                    .SelectMany(w => w.Targets).Select(WindowsPluginWrappers.Canonical).Distinct(StringComparer.Ordinal).ToArray()
+                : [];
+            var plugins = new List<WindowsPluginFile>();
+            foreach (PluginItem item in Items(folder).Where(i => i.Kind == PluginItemKind.WindowsPlugin))
+            {
+                string path = WindowsPluginWrappers.Normalize(item.Path);
+                string? prefix = WinePrefixFor(path);
+                string canonical = WindowsPluginWrappers.Canonical(path);
+                bool used = usedTargets.Any(t => WindowsPluginWrappers.Under(t, canonical));
+                plugins.Add(new(path, Path.GetFileName(path), Path.GetExtension(path).TrimStart('.').ToLowerInvariant(),
+                    !PluginBlocked(path, folders, excluded), prefix is null && !WindowsPluginWrappers.HasLink(path), prefix, used));
+            }
+            return new(true, "", plugins.DistinctBy(p => p.Path).OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToArray());
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return new(false, $"Could not list the plugins: {ex.Message}", []);
+        }
+    }
+
+    /// <summary>Resolve the selected source to bridge paths without changing files or exclusions.</summary>
+    public bool TryWindowsPluginWrappers(string path, out IReadOnlyList<string> wrappers, out string? error)
+    {
+        wrappers = [];
+        try
+        {
+            if (!TryPlugin(path, out path, out _, out _, out error)) return false;
+            wrappers = WindowsPluginWrappers.ForPlugin(
+                WindowsPluginWrappers.Read(BridgedVst3Directory, BridgedClapDirectory), path)
+                .Select(w => w.Path).ToArray();
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            error = $"Could not resolve the plugin's bridge wrappers: {ex.Message}";
+            return false;
+        }
+    }
+
+    /// <summary>Exclude or restore one canonical Windows plugin without changing its source files.</summary>
+    public InstallOutcome SetWindowsPluginEnabled(string path, bool enabled, IReadOnlyCollection<string>? inUsePluginPaths = null)
+    {
+        bool changed = false;
+        try
+        {
+            if (!TryPlugin(path, out path, out IReadOnlyList<string> folders, out HashSet<string> excluded, out string? error))
+                return new(false, error!, []);
+            string canonical = WindowsPluginWrappers.Canonical(path);
+            if (enabled && PluginBlocked(path, folders, excluded, ignoreExact: canonical))
+                return new(false, "This plugin is excluded by a folder-level rule. Remove that rule in yabridge before enabling the plugin.", []);
+            if (enabled && !excluded.Contains(canonical)) return new(true, "This plugin is already enabled.", []);
+            IReadOnlyList<WindowsPluginWrappers.Wrapper> wrappers = WindowsPluginWrappers.ForPlugin(
+                WindowsPluginWrappers.Read(BridgedVst3Directory, BridgedClapDirectory), path);
+            if (!enabled && wrappers.Any(w => WindowsPluginWrappers.InUse(w, inUsePluginPaths)))
+                return new(false, "Remove this plugin from your insert chains before excluding it.", []);
+            if (_wine is null) return new(false, "Wine is not installed. It is needed to sync the plugin wrappers safely.", []);
+            if (!PrepareManagedBridge()) return new(false, "The OpenXLR bridge could not select its packaged libraries.", []);
+            if (enabled || !excluded.Contains(canonical))
+            {
+                ProcessResult? result = Run("blacklist", enabled ? "rm" : "add", canonical);
+                if (result?.Ok != true) return new(false, $"yabridge could not change the plugin exclusion: {Tail(result)}", []);
+                changed = true;
+            }
+            if (!TryBlacklist(out excluded, out error))
+                return new(false, $"The exclusion command completed, but its result could not be checked: {error} Wrappers were kept.", []);
+            if (excluded.Contains(canonical) == enabled)
+                return new(false, "yabridge did not apply the requested exclusion. Wrappers were kept.", []);
+            ProcessResult? sync = Run("sync");
+            if (sync?.Ok != true)
+                return new(false, $"The plugin exclusion is saved, but syncing failed and wrappers were kept: {Tail(sync)}", []);
+            int removed = 0;
+            if (!enabled)
+            {
+                // Sync may have retargeted a shared wrapper name to another
+                // plugin. Only delete wrappers still pointing at this one.
+                wrappers = WindowsPluginWrappers.ForPlugin(WindowsPluginWrappers.Read(BridgedVst3Directory, BridgedClapDirectory), path);
+                foreach (var wrapper in wrappers) { wrapper.Remove(); removed++; }
+            }
+            return new(true, enabled ? $"Enabled {Path.GetFileName(path)} and synced its bridge wrappers."
+                : $"Excluded {Path.GetFileName(path)} and removed {removed} bridge wrappers. Original plugin files were kept.", [],
+                [BridgedVst3Directory, BridgedClapDirectory]);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return new(false, changed ? $"The exclusion changed, but wrapper cleanup did not finish: {ex.Message} Original files were kept."
+                : $"Could not change the plugin exclusion: {ex.Message}", []);
+        }
+    }
+
+    /// <summary>Delete one standalone Windows plugin, never an installer-managed or linked source.</summary>
+    public InstallOutcome DeleteWindowsPlugin(string path, IReadOnlyCollection<string>? inUsePluginPaths = null)
+    {
+        bool deleting = false;
+        try
+        {
+            if (!TryPlugin(path, out path, out _, out HashSet<string> excluded, out string? error)) return new(false, error!, []);
+            if (WinePrefixFor(path) is not null || WindowsPluginWrappers.HasLink(path))
+                return new(false, "This plugin is installed in Wine or reached through a symbolic link. Use its Wine uninstaller; its files were kept.", []);
+            string canonical = WindowsPluginWrappers.Canonical(path);
+            IReadOnlyList<WindowsPluginWrappers.Wrapper> wrappers = WindowsPluginWrappers.ForPlugin(
+                WindowsPluginWrappers.Read(BridgedVst3Directory, BridgedClapDirectory), path);
+            if (wrappers.Any(w => WindowsPluginWrappers.InUse(w, inUsePluginPaths)))
+                return new(false, "Remove this plugin from your insert chains before deleting its files.", []);
+            if (_wine is null) return new(false, "Wine is not installed. It is needed to sync the remaining plugins safely.", []);
+            if (!PrepareManagedBridge()) return new(false, "The OpenXLR bridge could not select its packaged libraries.", []);
+            deleting = true;
+            Remove(path);
+            if (excluded.Contains(canonical))
+            {
+                // rm accepts a missing path when it exactly matches a saved
+                // canonical entry; an obsolete symlink alias would not work.
+                ProcessResult? unexclude = Run("blacklist", "rm", canonical);
+                if (unexclude?.Ok != true) return new(false, $"Plugin files were deleted, but their exclusion could not be removed: {Tail(unexclude)}", []);
+            }
+            ProcessResult? sync = Run("sync");
+            if (sync?.Ok != true) return new(false, $"Plugin files were deleted, but syncing failed and wrappers were kept: {Tail(sync)}", []);
+            wrappers = WindowsPluginWrappers.ForPlugin(WindowsPluginWrappers.Read(BridgedVst3Directory, BridgedClapDirectory), path);
+            foreach (var wrapper in wrappers) wrapper.Remove();
+            return new(true, $"Deleted {Path.GetFileName(path)} and removed {wrappers.Count} bridge wrappers. Other plugins were kept.", []);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return new(false, deleting ? $"Plugin deletion did not finish; some files may already be removed: {ex.Message}"
+                : $"Could not delete the plugin: {ex.Message}", []);
+        }
+    }
+
+    private static bool ValidPluginPath(string? path)
+        => !string.IsNullOrWhiteSpace(path) && path.Length <= 4096 && !path.Any(char.IsControl) && Path.IsPathFullyQualified(path);
+
+    private bool TryPlugin(string path, out string normalized, out IReadOnlyList<string> folders, out HashSet<string> excluded, out string? error)
+    {
+        normalized = path;
+        folders = [];
+        excluded = new(StringComparer.Ordinal);
+        error = "The plugin path must be absolute and contain no control characters.";
+        if (!ValidPluginPath(path)) return false;
+        normalized = WindowsPluginWrappers.Normalize(path);
+        if (!TryWindowsDirectories(out folders, out error)) return false;
+        string requested = normalized;
+        if (!folders.Where(f => WindowsPluginWrappers.Under(requested, f))
+            .Any(f => Items(f).Any(i => i.Kind == PluginItemKind.WindowsPlugin && WindowsPluginWrappers.Normalize(i.Path) == requested)))
+        {
+            error = "This is not a Windows VST3 or CLAP plugin in a registered folder.";
+            return false;
+        }
+        return TryBlacklist(out excluded, out error);
+    }
+
+    private bool TryBlacklist(out HashSet<string> excluded, out string? error)
+    {
+        excluded = new(StringComparer.Ordinal);
+        ProcessResult? list = Run("blacklist", "list");
+        if (list?.Ok != true) { error = $"yabridge could not list plugin exclusions: {Tail(list)}"; return false; }
+        foreach (string line in list.StdoutText.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            if (line.StartsWith('/')) excluded.Add(WindowsPluginWrappers.Normalize(line));
+        error = null;
+        return true;
+    }
+
+    private static bool PluginBlocked(string path, IReadOnlyList<string> folders, HashSet<string> excluded, string? ignoreExact = null)
+    {
+        // yabridge checks each canonical entry it visits. An ancestor outside
+        // a registered root is not visited, nor are the parents of a link's target.
+        foreach (string folder in folders.Where(f => WindowsPluginWrappers.Under(path, f)))
+        {
+            bool blocked = false;
+            for (string? current = path; current is not null && WindowsPluginWrappers.Under(current, folder); current = Path.GetDirectoryName(current))
+            {
+                string canonical = WindowsPluginWrappers.Canonical(current);
+                if (canonical != ignoreExact && excluded.Contains(canonical)) { blocked = true; break; }
+            }
+            if (!blocked) return false;
+        }
+        return true;
+    }
+
     /// <summary>Unregister one source and remove only its unused VST3/CLAP wrappers, never its plugins.</summary>
     public InstallOutcome RemoveWindowsFolder(string path, IReadOnlyCollection<string>? inUsePluginPaths = null)
     {
@@ -495,19 +689,37 @@ public sealed class PluginInstaller
     }
 
     /// <summary>Bridge again whatever yabridge knows, for plugins installed into those folders since.</summary>
-    public InstallOutcome SyncWindows()
+    public InstallOutcome SyncWindows(IReadOnlyCollection<string>? inUsePluginPaths = null)
     {
         if (_yabridgectl is null) return new(false, "yabridge is not installed.", []);
         if (_wine is null) return new(false, "Wine is not installed, and yabridge needs it.", []);
         if (!PrepareManagedBridge()) return new(false, "The OpenXLR bridge could not select its packaged libraries.", []);
-        IReadOnlyList<string> directories = WindowsDirectories();
+        if (!TryWindowsDirectories(out IReadOnlyList<string> directories, out string? error)) return new(false, error!, []);
         if (directories.Count == 0) return new(false, "yabridge has no plugin folders yet. Add a Windows plugin to give it one.", []);
         ProcessResult? sync = Run("sync");
-        if (sync is null || sync.ExitCode != 0) return new(false, $"yabridge could not bridge the plugins: {Tail(sync)}", []);
-        return new(true, directories.Count == 1
+        if (sync?.Ok != true) return new(false, $"yabridge could not bridge the plugins: {Tail(sync)}", []);
+        if (!TryWindowsDirectories(out directories, out error))
+            return new(false, $"Plugins were synced, but missing-source wrappers were kept: {error}", []);
+        int removed = 0, kept = 0;
+        try
+        {
+            foreach (var wrapper in WindowsPluginWrappers.Missing(BridgedVst3Directory, BridgedClapDirectory, directories))
+            {
+                if (WindowsPluginWrappers.InUse(wrapper, inUsePluginPaths)) { kept++; continue; }
+                wrapper.Remove();
+                removed++;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return new(false, $"Plugins were synced, but missing-source wrapper cleanup did not finish: {ex.Message}", []);
+        }
+        string message = directories.Count == 1
             ? $"Bridged the Windows plugins in {Shorten(directories[0])}."
-            : $"Bridged the Windows plugins in {directories.Count} folders.", directories.Select(Shorten).ToList(),
-            [BridgedVst3Directory, BridgedClapDirectory]);
+            : $"Bridged the Windows plugins in {directories.Count} folders.";
+        if (removed > 0) message += $" Removed {removed} wrappers whose source plugins are missing.";
+        if (kept > 0) message += $" Kept {kept} missing-source wrappers still used by insert chains.";
+        return new(true, message, directories.Select(Shorten).ToList(), [BridgedVst3Directory, BridgedClapDirectory]);
     }
 
     private string BridgedVst3Directory => _managed is null ? Path.Combine(_vst3, "yabridge")

--- a/src/OpenXLR.Core/Mixing/WindowsPluginWrappers.cs
+++ b/src/OpenXLR.Core/Mixing/WindowsPluginWrappers.cs
@@ -3,7 +3,7 @@ namespace OpenXLR.Core.Mixing;
 /// <summary>Only yabridge wrappers whose Windows targets belong to a removed source folder.</summary>
 internal static class WindowsPluginWrappers
 {
-    internal sealed record Wrapper(string Path, string? WindowsLink = null)
+    internal sealed record Wrapper(string Path, string? WindowsLink, IReadOnlyList<string> Targets)
     {
         public void Remove()
         {
@@ -22,6 +22,42 @@ internal static class WindowsPluginWrappers
         => path == directory || path.StartsWith(directory == "/" ? "/" : directory + "/", StringComparison.Ordinal);
 
     internal static IReadOnlyList<Wrapper> Find(string vst3, string clap, string removed, IReadOnlyCollection<string> retained)
+        => Select(Read(vst3, clap), targets => targets.All(t => Under(t, removed))
+            && !targets.Any(t => retained.Any(d => Under(t, d))));
+
+    internal static IReadOnlyList<Wrapper> ForPlugin(IReadOnlyList<Wrapper> wrappers, string plugin)
+    {
+        string canonical = Canonical(plugin);
+        return Select(wrappers, targets =>
+        {
+            int matching = targets.Count(t => Under(Canonical(t), canonical));
+            if (matching > 0 && matching != targets.Count)
+                throw new IOException("A bridge wrapper is shared by multiple source plugins; its files were kept.");
+            return matching == targets.Count;
+        });
+    }
+
+    internal static IReadOnlyList<Wrapper> Missing(string vst3, string clap, IReadOnlyCollection<string> folders)
+        => Select(Read(vst3, clap), targets => targets.All(t => !File.Exists(t) && !Directory.Exists(t)
+            && folders.Any(d => Under(t, d) || Under(Canonical(t), Canonical(d)))));
+
+    internal static bool InUse(Wrapper wrapper, IReadOnlyCollection<string>? paths)
+        => paths?.Any(p => Under(Normalize(p), wrapper.Path)) == true;
+
+    private static IReadOnlyList<Wrapper> Select(IReadOnlyList<Wrapper> wrappers, Func<IReadOnlyList<string>, bool> matches)
+    {
+        var selected = new List<Wrapper>();
+        foreach (Wrapper wrapper in wrappers)
+        {
+            if (wrapper.Targets.Count == 0 || !matches(wrapper.Targets)) continue;
+            if (wrapper.WindowsLink is null) CheckBundle(wrapper.Path);
+            else if (!IsElf(wrapper.Path)) throw new IOException($"The CLAP file {wrapper.Path} is not a Linux bridge wrapper.");
+            selected.Add(wrapper);
+        }
+        return selected;
+    }
+
+    internal static IReadOnlyList<Wrapper> Read(string vst3, string clap)
     {
         var wrappers = new List<Wrapper>();
         foreach (string bundle in Entries(vst3, vst3: true))
@@ -40,21 +76,13 @@ internal static class WindowsPluginWrappers
                     targets.Add(LinkTarget(module) ?? throw new IOException($"The Windows module in {bundle} is not a yabridge link."));
                 }
             }
-            if (targets.Count > 0 && targets.All(t => Under(t, removed)) && !targets.Any(t => retained.Any(d => Under(t, d))))
-            {
-                CheckBundle(bundle);
-                wrappers.Add(new(bundle));
-            }
+            if (targets.Count > 0) wrappers.Add(new(bundle, null, targets));
         }
         foreach (string module in Entries(clap, vst3: false))
         {
             string link = System.IO.Path.ChangeExtension(module, ".clap-win");
             string? target = LinkTarget(link);
-            if (target is not null && Under(target, removed) && !retained.Any(d => Under(target, d)))
-            {
-                if (!IsElf(module)) throw new IOException($"The CLAP file {module} is not a Linux bridge wrapper.");
-                wrappers.Add(new(module, link));
-            }
+            if (target is not null) wrappers.Add(new(module, link, [target]));
         }
         return wrappers;
     }
@@ -118,6 +146,39 @@ internal static class WindowsPluginWrappers
     {
         string? target = new FileInfo(path).LinkTarget;
         return target is null ? null : Normalize(System.IO.Path.GetFullPath(target, System.IO.Path.GetDirectoryName(path)!));
+    }
+
+    // yabridgectl stores canonical blacklist paths. Resolve ancestor links
+    // too, and retain a missing tail so an uninstalled path can be matched.
+    internal static string Canonical(string path)
+    {
+        int links = 0;
+        return Resolve(System.IO.Path.IsPathFullyQualified(path) ? path : System.IO.Path.GetFullPath(path));
+
+        string Resolve(string full)
+        {
+            string root = System.IO.Path.GetPathRoot(full)!;
+            string current = root;
+            foreach (string part in full[root.Length..].Split(System.IO.Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (part == ".") continue;
+                if (part == "..") { current = System.IO.Path.GetDirectoryName(current) ?? root; continue; }
+                current = System.IO.Path.Combine(current, part);
+                string? target = new FileInfo(current).LinkTarget;
+                if (target is null) continue;
+                if (++links > 40) throw new IOException($"Too many symbolic links in {path}.");
+                current = Resolve(System.IO.Path.IsPathFullyQualified(target) ? target
+                    : System.IO.Path.Combine(System.IO.Path.GetDirectoryName(current)!, target));
+            }
+            return Normalize(current);
+        }
+    }
+
+    internal static bool HasLink(string path)
+    {
+        for (string? current = Normalize(path); current is not null; current = System.IO.Path.GetDirectoryName(current))
+            if (new FileInfo(current).LinkTarget is not null) return true;
+        return false;
     }
 
     private static void EnsureNotLink(string path)

--- a/src/OpenXLR.Core/ProcessRunner.cs
+++ b/src/OpenXLR.Core/ProcessRunner.cs
@@ -106,6 +106,22 @@ public static class ProcessRunner
         return new ProcessResult(exit, outData, Encoding.UTF8.GetString(errData), timedOut, outTrunc || errTrunc);
     }
 
+    /// <summary>
+    /// Run a user-facing program without a deadline or captured output. Its
+    /// lifetime belongs to the user: never kill an installer halfway through.
+    /// </summary>
+    public static async Task<int> RunInteractiveAsync(string exe, IReadOnlyList<string> args,
+        IReadOnlyDictionary<string, string>? environment = null)
+    {
+        var start = new ProcessStartInfo(exe) { UseShellExecute = false };
+        foreach (string argument in args) start.ArgumentList.Add(argument);
+        if (environment is not null)
+            foreach ((string name, string value) in environment) start.Environment[name] = value;
+        using Process process = Process.Start(start) ?? throw new InvalidOperationException($"failed to start {exe}");
+        await process.WaitForExitAsync().ConfigureAwait(false);
+        return process.ExitCode;
+    }
+
     private static async Task<(byte[] Data, bool Truncated)> ReadCappedAsync(Stream pipe, int cap, CancellationTokenSource breach)
     {
         var buf = new byte[16 * 1024];

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -26,7 +26,11 @@ public static class CommandValidation
         {
             case "addWindowsPluginFolder":
             case "removeWindowsPluginFolder":
-                return CheckPluginFolderPath(cmd);
+            case "getWindowsPluginFiles":
+            case "removeWindowsPluginInserts":
+            case "setWindowsPluginEnabled":
+            case "deleteWindowsPlugin":
+                return CheckPluginPath(cmd);
             case "createChannel":
             case "createMix":
                 return BadName(cmd.Name) ? $"{cmd.Cmd}: name must contain 1 to 60 printable characters" : null;
@@ -134,10 +138,10 @@ public static class CommandValidation
         }
     }
 
-    internal static string? CheckPluginFolderPath(Command cmd)
+    internal static string? CheckPluginPath(Command cmd)
         => string.IsNullOrWhiteSpace(cmd.Path) || cmd.Path.Length > 4096
            || cmd.Path.Any(char.IsControl) || !Path.IsPathFullyQualified(cmd.Path)
-            ? $"{cmd.Cmd}: path must be an absolute folder path of at most 4096 characters"
+            ? $"{cmd.Cmd}: path must be an absolute path of at most 4096 characters"
             : null;
 
     private static string? Finite(Command cmd, string field)

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -494,6 +494,29 @@ public sealed class MixerService : IHostedService, IDisposable
         return null;
     }
 
+    /// <summary>Remove current uses and persist them before file-management actions become available.</summary>
+    public (int Removed, int Chains, string? Error) RemovePluginInserts(IReadOnlySet<(string Kind, string Plugin)> plugins)
+    {
+        if (!_mixer.Built) return (0, 0, "The audio mixer must be running to remove plugins from its current chains.");
+        (int Removed, int Chains, string? Error) result = (0, 0, null);
+        try
+        {
+            _saves.RunSaved(() =>
+            {
+                if (_stopping.IsCancellationRequested || _saves.Closed)
+                    throw new InvalidOperationException("The mixer is stopping.");
+                result = _mixer.RemovePluginInserts(plugins, settings => settings.Save());
+            });
+        }
+        catch (Exception ex)
+        {
+            Changed?.Invoke();
+            return (0, 0, ex.Message);
+        }
+        Changed?.Invoke();
+        return result;
+    }
+
     /// <summary>The current mixer scene for saving into a profile, or null.</summary>
     public OpenXLR.Core.MixerScene? ExportScene() => _mixer.Built ? _mixer.ExportScene() : null;
 

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -108,6 +108,16 @@ public sealed record PluginSetupMessage(PluginSetup Setup)
     [JsonIgnore] public PluginSetup Setup { get; } = Setup;
 }
 
+/// <summary>Files in one registered Windows plugin folder, including excluded files.</summary>
+public sealed record WindowsPluginFilesMessage(WindowsPluginFiles Result)
+{
+    [JsonPropertyName("type")] public string Type => "windowsPluginFiles";
+    [JsonPropertyName("ok")] public bool Ok => Result.Ok;
+    [JsonPropertyName("message")] public string Message => Result.Message;
+    [JsonPropertyName("plugins")] public IReadOnlyList<WindowsPluginFile> Plugins => Result.Plugins;
+    [JsonIgnore] public WindowsPluginFiles Result { get; } = Result;
+}
+
 /// <summary>Reply to plugin installation, folder management, sync and rescan: what happened, and what the catalogue gained.</summary>
 public sealed record PluginInstallMessage(bool Ok, string Message, IReadOnlyList<string> Installed, int Added, int Total)
 {

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -213,15 +213,44 @@ public sealed class WebSocketHub
                 break;
             case "addWindowsPluginFolder":
             case "removeWindowsPluginFolder":
-                error = CommandValidation.CheckPluginFolderPath(cmd);
+                error = CommandValidation.CheckPluginPath(cmd);
                 if (error is not null) break;
                 await reply(await Task.Run(() => InstallPlugin(installer =>
                     cmd.Cmd == "addWindowsPluginFolder"
                         ? installer.AddWindowsFolder(cmd.Path!)
                         : installer.RemoveWindowsFolder(cmd.Path!, InsertPluginPaths()))));
                 break;
+            case "getWindowsPluginFiles":
+                error = CommandValidation.CheckPluginPath(cmd);
+                if (error is not null) break;
+                await reply(await Task.Run(() =>
+                {
+                    lock (_installGate)
+                        return new WindowsPluginFilesMessage(new OpenXLR.Core.Mixing.PluginInstaller()
+                            .ListWindowsPlugins(cmd.Path!, InsertPluginPaths()));
+                }));
+                break;
+            case "removeWindowsPluginInserts":
+                error = CommandValidation.CheckPluginPath(cmd);
+                if (error is not null) break;
+                await reply(await Task.Run(() => RemoveWindowsPluginInserts(cmd.Path!)));
+                break;
+            case "setWindowsPluginEnabled":
+            case "deleteWindowsPlugin":
+                error = CommandValidation.CheckPluginPath(cmd);
+                if (error is not null) break;
+                if (cmd.Cmd == "setWindowsPluginEnabled" && cmd.Value.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+                {
+                    error = "setWindowsPluginEnabled: value must be a boolean";
+                    break;
+                }
+                await reply(await Task.Run(() => InstallPlugin(installer =>
+                    cmd.Cmd == "setWindowsPluginEnabled"
+                        ? installer.SetWindowsPluginEnabled(cmd.Path!, cmd.Value.GetBoolean(), InsertPluginPaths())
+                        : installer.DeleteWindowsPlugin(cmd.Path!, InsertPluginPaths()))));
+                break;
             case "syncWindowsPlugins":
-                await reply(await Task.Run(() => InstallPlugin(installer => installer.SyncWindows())));
+                await reply(await Task.Run(() => InstallPlugin(installer => installer.SyncWindows(InsertPluginPaths()))));
                 break;
             case "rescanPlugins":
                 await reply(await Task.Run(() => InstallPlugin(_ => new OpenXLR.Core.Mixing.InstallOutcome(true, "", []))));
@@ -413,6 +442,29 @@ public sealed class WebSocketHub
             string message = note.Length == 0 ? outcome.Message
                 : outcome.Message.Length == 0 ? note : outcome.Message + " " + note;
             return new PluginInstallMessage(outcome.Ok, message, outcome.Installed, added, total);
+        }
+    }
+
+    private PluginInstallMessage RemoveWindowsPluginInserts(string path)
+    {
+        lock (_installGate)
+        {
+            try
+            {
+                var installer = new OpenXLR.Core.Mixing.PluginInstaller();
+                if (!installer.TryWindowsPluginWrappers(path, out var wrappers, out string? error))
+                    return new(false, error!, [], 0, OpenXLR.Core.Mixing.PluginCatalog.Plugins.Count);
+                var identities = OpenXLR.Core.Mixing.PluginCatalog.IdentitiesUnder(wrappers);
+                var result = _mixer.RemovePluginInserts(identities);
+                string message = result.Removed == 0 ? "No inserts were removed."
+                    : $"Removed {result.Removed} inserts from {result.Chains} current chains. Plugin files and saved profiles were kept.";
+                if (result.Error is not null) message += " " + result.Error;
+                return new(result.Error is null, message, [], 0, OpenXLR.Core.Mixing.PluginCatalog.Plugins.Count);
+            }
+            catch (Exception ex)
+            {
+                return new(false, ex.Message, [], 0, OpenXLR.Core.Mixing.PluginCatalog.Plugins.Count);
+            }
         }
     }
 

--- a/src/OpenXLR.Tests/DaemonClientTests.cs
+++ b/src/OpenXLR.Tests/DaemonClientTests.cs
@@ -185,16 +185,54 @@ public sealed class DaemonClientTests
         await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
         var remove = client.RemoveWindowsPluginFolderAsync("/plugins/old", TimeSpan.FromSeconds(5));
         var sync = client.SyncWindowsPluginsAsync(TimeSpan.FromSeconds(5));
+        var removeUses = client.RemoveWindowsPluginInsertsAsync("/plugins/new/EQ.vst3", TimeSpan.FromSeconds(5));
         release.SetResult();
         Assert.Equal("addWindowsPluginFolder", (await add)!["message"]!.GetValue<string>());
         Assert.Equal("removeWindowsPluginFolder", (await remove)!["message"]!.GetValue<string>());
         Assert.Equal("syncWindowsPlugins", (await sync)!["message"]!.GetValue<string>());
+        Assert.Equal("removeWindowsPluginInserts", (await removeUses)!["message"]!.GetValue<string>());
         Assert.Equal(new (string, string?)[]
         {
             ("addWindowsPluginFolder", "/plugins/new"),
             ("removeWindowsPluginFolder", "/plugins/old"),
             ("syncWindowsPlugins", null),
+            ("removeWindowsPluginInserts", "/plugins/new/EQ.vst3"),
         }, commands);
+    }
+
+    [Fact]
+    public async Task FilesFromDifferentFoldersDoNotShareAReply()
+    {
+        var received = Completion();
+        var release = Completion();
+        int requests = 0;
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                var command = await SocketTestServer.Receive(socket, stop);
+                if (command["cmd"]!.GetValue<string>() == "auth") continue;
+                if (++requests == 1) { received.SetResult(); await release.Task.WaitAsync(stop); }
+                await SocketTestServer.Send(socket, new
+                {
+                    type = "windowsPluginFiles", ok = true,
+                    plugins = new[] { new { path = command["path"]!.GetValue<string>() + "/EQ.vst3" } },
+                }, stop);
+                await SocketTestServer.Send(socket, new { type = "commandResult", requestId = command["requestId"]!.GetValue<string>() }, stop);
+            }
+        });
+        await using var client = new DaemonClient(server.Url);
+        var connected = Completion();
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var first = client.RequestWindowsPluginFilesAsync("/first", TimeSpan.FromSeconds(5));
+        await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var second = client.RequestWindowsPluginFilesAsync("/second", TimeSpan.FromSeconds(5));
+        release.SetResult();
+        Assert.Equal("/first/EQ.vst3", (await first)!["plugins"]![0]!["path"]!.GetValue<string>());
+        Assert.Equal("/second/EQ.vst3", (await second)!["plugins"]![0]!["path"]!.GetValue<string>());
+        Assert.Equal(2, requests);
     }
 
     private static TaskCompletionSource Completion()

--- a/src/OpenXLR.Tests/HttpApiTests.cs
+++ b/src/OpenXLR.Tests/HttpApiTests.cs
@@ -97,13 +97,13 @@ public sealed class HttpApiTests
                 new StringContent("{\"cmd\":\"getDiagnostics\"}", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.OK, valid.StatusCode);
             Assert.Contains("\"ok\":true", await valid.Content.ReadAsStringAsync());
-            foreach (string command in new[] { "addWindowsPluginFolder", "removeWindowsPluginFolder" })
+            foreach (string command in new[] { "addWindowsPluginFolder", "removeWindowsPluginFolder", "getWindowsPluginFiles", "removeWindowsPluginInserts", "setWindowsPluginEnabled", "deleteWindowsPlugin" })
             {
                 using var folder = await http.PostAsync("/api/v1/commands",
                     new StringContent(System.Text.Json.JsonSerializer.Serialize(new { cmd = command, path = "relative/plugins" }),
                         Encoding.UTF8, "application/json"));
                 Assert.Equal(HttpStatusCode.BadRequest, folder.StatusCode);
-                Assert.Contains("absolute folder path", await folder.Content.ReadAsStringAsync());
+                Assert.Contains("absolute path", await folder.Content.ReadAsStringAsync());
             }
             using var pluginDiagnostics = await http.PostAsync("/api/v1/commands",
                 new StringContent("{\"cmd\":\"getPluginDiagnostics\"}", Encoding.UTF8, "application/json"));

--- a/src/OpenXLR.Tests/PluginFolderUiTests.cs
+++ b/src/OpenXLR.Tests/PluginFolderUiTests.cs
@@ -48,13 +48,37 @@ public sealed class PluginFolderUiTests : IDisposable
         Assert.False(vm.CanSyncWindows);
     }
 
+    [Fact]
+    public void PluginFileReplyUsesTheFieldsTheManagerReads()
+    {
+        var result = new OpenXLR.Core.Mixing.WindowsPluginFiles(true, "", [
+            new("/wine/EQ.vst3", "EQ.vst3", "vst3", false, false, "/wine", true),
+        ]);
+        string wire = System.Text.Json.JsonSerializer.Serialize(new WindowsPluginFilesMessage(result),
+            new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+        JsonNode reply = JsonNode.Parse(wire)!;
+        Assert.Equal("windowsPluginFiles", reply["type"]!.GetValue<string>());
+        Assert.True(reply["ok"]!.GetValue<bool>());
+        JsonNode row = reply["plugins"]![0]!;
+        Assert.Equal("/wine/EQ.vst3", row["path"]!.GetValue<string>());
+        Assert.False(row["enabled"]!.GetValue<bool>());
+        Assert.False(row["canDelete"]!.GetValue<bool>());
+        Assert.Equal("/wine", row["winePrefix"]!.GetValue<string>());
+        Assert.True(row["inUse"]!.GetValue<bool>());
+        Assert.Null(reply["result"]);
+    }
+
     [Theory]
     [InlineData("addWindowsPluginFolder")]
     [InlineData("removeWindowsPluginFolder")]
+    [InlineData("getWindowsPluginFiles")]
+    [InlineData("removeWindowsPluginInserts")]
+    [InlineData("setWindowsPluginEnabled")]
+    [InlineData("deleteWindowsPlugin")]
     public void FolderCommandsRequireBoundedAbsolutePaths(string command)
     {
         foreach (string? path in new[] { null, "", "plugins", "~/plugins", "/plugins\nother", "/" + new string('x', 4096) })
-            Assert.Contains(command, CommandValidation.CheckPluginFolderPath(new Command { Cmd = command, Path = path }));
-        Assert.Null(CommandValidation.CheckPluginFolderPath(new Command { Cmd = command, Path = "/home/user/Windows plugins" }));
+            Assert.Contains(command, CommandValidation.CheckPluginPath(new Command { Cmd = command, Path = path }));
+        Assert.Null(CommandValidation.CheckPluginPath(new Command { Cmd = command, Path = "/home/user/Windows plugins" }));
     }
 }

--- a/src/OpenXLR.Tests/ProcessRunnerTests.cs
+++ b/src/OpenXLR.Tests/ProcessRunnerTests.cs
@@ -41,6 +41,23 @@ public sealed class ProcessRunnerTests
     }
 
     [Fact]
+    public async Task InteractiveProgramsKeepArgumentsAndEnvironmentSeparate()
+    {
+        string output = Path.Combine(Path.GetTempPath(), "openxlr-interactive-" + Guid.NewGuid());
+        string? before = Environment.GetEnvironmentVariable("WINEPREFIX");
+        try
+        {
+            int exit = await ProcessRunner.RunInteractiveAsync("sh",
+                ["-c", "printf '%s\\n%s' \"$WINEPREFIX\" \"$1\" > \"$2\"; exit 7", "test", "literal ; $HOME", output],
+                new Dictionary<string, string> { ["WINEPREFIX"] = "/a prefix with spaces" });
+            Assert.Equal(7, exit);
+            Assert.Equal("/a prefix with spaces\nliteral ; $HOME", File.ReadAllText(output));
+            Assert.Equal(before, Environment.GetEnvironmentVariable("WINEPREFIX"));
+        }
+        finally { File.Delete(output); }
+    }
+
+    [Fact]
     public async Task HelpersRunInTheCLocale()
     {
         ProcessResult r = await ProcessRunner.RunAsync("sh", ["-c", "printf '%s' \"$LC_ALL\""]);

--- a/src/OpenXLR.Tests/RemovePluginInsertsTests.cs
+++ b/src/OpenXLR.Tests/RemovePluginInsertsTests.cs
@@ -1,0 +1,108 @@
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class RemovePluginInsertsTests
+{
+    private static InsertDefinition Insert(string id, string plugin, bool bypass = false, string kind = "vst3")
+        => new() { Id = id, Kind = kind, Plugin = plugin, Bypass = bypass, Params = new() { ["gain"] = 0.25 } };
+
+    [Fact]
+    public void RemovalCoversEveryChainAndBypassedCopyWithoutChangingOtherInserts()
+    {
+        var first = Insert("first", "other");
+        var last = Insert("last", "other", bypass: true);
+        var otherFormat = Insert("other-format", "eq", kind: "clap");
+        List<InsertDefinition> untouched = [Insert("chat", "other")];
+        var chains = new Dictionary<string, List<InsertDefinition>>
+        {
+            ["xlr1"] = [first, Insert("a", "eq"), Insert("b", "eq", bypass: true), last],
+            ["xlr2"] = [Insert("c", "eq")],
+            ["mix:monitor"] = [Insert("d", "eq"), otherFormat],
+            ["mix:stream"] = [Insert("e", "eq", bypass: true)],
+            ["mix:chat"] = untouched,
+        };
+        var rewired = new List<string[]>();
+        int saves = 0;
+        var result = Mixer.RemovePluginInserts(chains, new HashSet<(string, string)> { ("vst3", "eq") },
+            keys => rewired.Add(keys.ToArray()), () =>
+            {
+                saves++;
+                Assert.DoesNotContain(chains.Values.SelectMany(c => c), i => i.Kind == "vst3" && i.Plugin == "eq");
+            });
+        Assert.Equal((5, 4, null), result);
+        Assert.Equal(1, saves);
+        Assert.Equal(3, rewired.Count);
+        Assert.Single(rewired, keys => keys.SequenceEqual(new[] { "xlr1", "xlr2" }));
+        Assert.DoesNotContain(rewired, keys => keys.Contains("mix:chat"));
+        Assert.Equal(new[] { first, last }, chains["xlr1"]);
+        Assert.Same(first, chains["xlr1"][0]);
+        Assert.Same(last, chains["xlr1"][1]);
+        Assert.Equal(0.25, first.Params["gain"]);
+        Assert.True(last.Bypass);
+        Assert.Same(otherFormat, Assert.Single(chains["mix:monitor"]));
+        Assert.Same(untouched, chains["mix:chat"]);
+    }
+
+    [Fact]
+    public void AFailedSharedInputRewireKeepsBothInputDefinitionsAndReportsPartialSuccess()
+    {
+        List<InsertDefinition> first = [Insert("a", "eq")], second = [Insert("b", "eq")];
+        var chains = new Dictionary<string, List<InsertDefinition>>
+        {
+            ["xlr1"] = first, ["xlr2"] = second, ["mix:stream"] = [Insert("c", "eq")],
+        };
+        int saves = 0;
+        var result = Mixer.RemovePluginInserts(chains, new HashSet<(string, string)> { ("vst3", "eq") },
+            keys => { if (keys.Contains("xlr1")) throw new IOException("input rewire failed"); }, () => saves++);
+        Assert.Equal(1, result.Removed);
+        Assert.Equal(1, result.Chains);
+        Assert.Contains("xlr1, xlr2", result.Error);
+        Assert.Same(first, chains["xlr1"]);
+        Assert.Same(second, chains["xlr2"]);
+        Assert.Empty(chains["mix:stream"]);
+        Assert.Equal(1, saves);
+    }
+
+    [Fact]
+    public void AFailedSaveRestoresDefinitionsBeforeRewiringBack()
+    {
+        List<InsertDefinition> before = [Insert("a", "eq")];
+        var chains = new Dictionary<string, List<InsertDefinition>> { ["mix:monitor"] = before };
+        var counts = new List<int>();
+        var error = Assert.Throws<InvalidOperationException>(() => Mixer.RemovePluginInserts(chains,
+            new HashSet<(string, string)> { ("vst3", "eq") },
+            _ => counts.Add(chains["mix:monitor"].Count), () => throw new IOException("disk full")));
+        Assert.Contains("disk full", error.Message);
+        Assert.Same(before, chains["mix:monitor"]);
+        Assert.Equal(new[] { 0, 1 }, counts);
+    }
+
+    [Fact]
+    public void MissingMatchesDoNotRewireButStillFlushPendingSettings()
+    {
+        List<InsertDefinition> before = [Insert("a", "other")];
+        var chains = new Dictionary<string, List<InsertDefinition>> { ["mix:monitor"] = before };
+        int saves = 0;
+        var result = Mixer.RemovePluginInserts(chains, new HashSet<(string, string)> { ("vst3", "eq") },
+            _ => Assert.Fail("An unaffected chain was rewired."), () => saves++);
+        Assert.Equal((0, 0, null), result);
+        Assert.Equal(1, saves);
+        Assert.Same(before, chains["mix:monitor"]);
+    }
+
+    [Fact]
+    public void AllClassesInTheSelectedBundleAreResolvedWithoutMatchingSiblingPaths()
+    {
+        static PluginInfo Plugin(string id, string? path)
+            => new("vst3", id, id, "EQ", 2, 2, "in", "out", [], [], [], []) { Path = path };
+        PluginInfo[] catalogue = [
+            Plugin("one", "/wrappers/EQ.vst3"),
+            Plugin("two", "/wrappers/EQ.vst3/Contents/x86_64-linux/EQ.so"),
+            Plugin("other", "/wrappers/EQ.vst3-other"),
+            Plugin("unknown", null),
+        ];
+        var ids = PluginCatalog.IdentitiesUnder(catalogue, ["/wrappers/EQ.vst3"]);
+        Assert.Equal(new HashSet<(string, string)> { ("vst3", "one"), ("vst3", "two") }, ids);
+    }
+}

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -220,11 +220,36 @@ public sealed class WindowLayoutTests
                 folders.Show();
                 foreach (double width in new[] { 480d, 720 })
                 {
-                    Layout(folders, width, 480);
+                    Layout(folders, width, width >= 720 ? 820 : 680);
                     var list = folders.FindControl<ListBox>("FolderList")!;
                     Assert.Equal(2, list.ItemCount);
+                    Assert.InRange(list.Bounds.Height, 220, 240);
                     list.SelectedIndex = 0;
                     Assert.True(folders.FindControl<Button>("RemoveFolder")!.IsEnabled);
+                    folders.ApplyPluginFiles(JsonNode.Parse("""
+                        {"ok":true,"plugins":[
+                          {"path":"/imports/EQ.vst3","name":"Elgato EQ","format":"vst3","enabled":true,"canDelete":true,"inUse":false},
+                          {"path":"/wine/TDR.clap","name":"TDR plugin","format":"clap","enabled":false,"canDelete":false,"winePrefix":"/wine","inUse":false},
+                          {"path":"/wine/Active.vst3","name":"Active effect","format":"vst3","enabled":true,"canDelete":false,"winePrefix":"/wine","inUse":true}
+                        ]}
+                        """));
+                    var files = folders.FindControl<ListBox>("PluginList")!;
+                    Assert.Equal(3, files.ItemCount);
+                    files.SelectedIndex = 0;
+                    Assert.True(folders.FindControl<Button>("DeletePlugin")!.IsEnabled);
+                    Assert.False(folders.FindControl<Button>("RemoveUses")!.IsVisible);
+                    Assert.False(folders.FindControl<Button>("WineUninstaller")!.IsVisible);
+                    files.SelectedIndex = 1;
+                    Assert.False(folders.FindControl<Button>("DeletePlugin")!.IsEnabled);
+                    Assert.Equal("Enable in OpenXLR", folders.FindControl<Button>("TogglePlugin")!.Content);
+                    Assert.True(folders.FindControl<Button>("WineUninstaller")!.IsEnabled);
+                    files.SelectedIndex = 2;
+                    Assert.False(folders.FindControl<Button>("TogglePlugin")!.IsEnabled);
+                    Assert.False(folders.FindControl<Button>("WineUninstaller")!.IsEnabled);
+                    Assert.True(folders.FindControl<Button>("RemoveUses")!.IsVisible);
+                    Assert.True(folders.FindControl<Button>("RemoveUses")!.IsEnabled);
+                    folders.FindControl<TextBlock>("Status")!.Text = "";   // the fixture replaces the disconnected query
+                    Layout(folders, width, width >= 720 ? 820 : 680);
                     foreach (var button in folders.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible))
                         AssertInside(button, folders);
                     AssertInside(list, folders);

--- a/src/OpenXLR.Tests/WindowsIndividualPluginTests.cs
+++ b/src/OpenXLR.Tests/WindowsIndividualPluginTests.cs
@@ -1,0 +1,401 @@
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+public sealed class WindowsIndividualPluginTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "openxlr-individual-" + Guid.NewGuid().ToString("N"));
+    private static readonly byte[] Windows = [(byte)'M', (byte)'Z', 0x90, 0];
+    private static readonly byte[] Elf = [0x7f, (byte)'E', (byte)'L', (byte)'F', 2, 1];
+    private string Registry => Path.Combine(_root, "folders");
+    private string Exclusions => Path.Combine(_root, "excluded");
+    private string[] Calls => File.ReadAllLines(Path.Combine(_root, "calls"));
+    private string Vst3 => Path.Combine(_root, "vst3", "yabridge");
+    private string Clap => Path.Combine(_root, "clap", "yabridge");
+
+    public WindowsIndividualPluginTests() => Directory.CreateDirectory(_root);
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    private string Source(string relative, byte[]? bytes = null)
+    {
+        string path = Path.Combine(_root, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, bytes ?? Windows);
+        return path;
+    }
+
+    private PluginInstaller Installer(string[] folders, string[]? excluded = null, string? fail = null, string? sync = null)
+    {
+        File.WriteAllLines(Registry, folders);
+        File.WriteAllLines(Exclusions, excluded ?? []);
+        string controller = Path.Combine(_root, "yabridgectl");
+        File.WriteAllText(controller, $$"""
+            #!/bin/sh
+            printf '%s\n' "$*" >> '{{_root}}/calls'
+            stage="$1"
+            if [ "$1" = blacklist ]; then stage="$1 $2"; fi
+            if [ "$stage" = '{{fail}}' ]; then printf 'test failure\n' >&2; exit 1; fi
+            case "$1" in
+              list) cat '{{Registry}}' ;;
+              blacklist)
+                case "$2" in
+                  list) cat '{{Exclusions}}' ;;
+                  add)
+                    [ -e "$3" ] || exit 2
+                    resolved=$(readlink -f -- "$3") || exit 2
+                    grep -Fx -- "$resolved" '{{Exclusions}}' >/dev/null || printf '%s\n' "$resolved" >> '{{Exclusions}}'
+                    ;;
+                  rm)
+                    grep -Fx -- "$3" '{{Exclusions}}' >/dev/null || exit 2
+                    grep -Fxv -- "$3" '{{Exclusions}}' > '{{Exclusions}}.new'
+                    mv '{{Exclusions}}.new' '{{Exclusions}}'
+                    ;;
+                esac ;;
+              sync) {{sync ?? ":"}} ;;
+            esac
+            exit 0
+            """);
+        if (!OperatingSystem.IsWindows()) File.SetUnixFileMode(controller,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return new(Path.Combine(_root, "lv2"), Path.Combine(_root, "clap"), Path.Combine(_root, "vst3"), controller, "/bin/true",
+            windowsImportDirectory: Path.Combine(_root, "imports"));
+    }
+
+    private string Vst3Wrapper(string name, string source)
+    {
+        string bundle = Path.Combine(Vst3, name + ".vst3");
+        string contents = Path.Combine(bundle, "Contents");
+        Directory.CreateDirectory(Path.Combine(contents, "x86_64-linux"));
+        Directory.CreateDirectory(Path.Combine(contents, "x86_64-win"));
+        File.WriteAllBytes(Path.Combine(contents, "x86_64-linux", name + ".so"), Elf);
+        File.CreateSymbolicLink(Path.Combine(contents, "x86_64-win", name + ".vst3"), source);
+        return bundle;
+    }
+
+    private string ClapWrapper(string name, string source)
+    {
+        Directory.CreateDirectory(Clap);
+        string module = Path.Combine(Clap, name + ".clap");
+        File.WriteAllBytes(module, Elf);
+        File.CreateSymbolicLink(Path.ChangeExtension(module, ".clap-win"), source);
+        return module;
+    }
+
+    [Fact]
+    public void ResolvingAnImportedWinePluginForChainRemovalDoesNotChangeFilesOrExclusions()
+    {
+        string source = Source("prefix/drive_c/EQ.vst3");
+        Source("prefix/system.reg", [1]);
+        string alias = Path.Combine(_root, "imports", "EQ.vst3");
+        Directory.CreateDirectory(Path.GetDirectoryName(alias)!);
+        File.CreateSymbolicLink(alias, source);
+        string wrapper = Vst3Wrapper("EQ", alias);
+        var installer = Installer([Path.GetDirectoryName(alias)!]);
+
+        Assert.True(installer.TryWindowsPluginWrappers(alias, out var paths, out string? error), error);
+        Assert.Equal(new[] { wrapper }, paths);
+        Assert.False(installer.TryWindowsPluginWrappers(source, out _, out _));
+        Assert.Equal(Windows, File.ReadAllBytes(source));
+        Assert.Equal(source, new FileInfo(alias).LinkTarget);
+        Assert.Empty(File.ReadAllLines(Exclusions));
+        Assert.Equal(new[] { "list", "blacklist list", "list" }, Calls);
+    }
+
+    [Fact]
+    public void ListingIncludesExcludedPluginsButNotNativePluginsOrOtherFolders()
+    {
+        string vst = Source("plugins/Eq.vst3");
+        string clap = Source("plugins/Comp.clap");
+        Source("plugins/Native.clap", Elf);
+        Source("elsewhere/Other.vst3");
+        string folder = Path.GetDirectoryName(vst)!;
+        string wrapper = Vst3Wrapper("Eq", vst);
+        var installer = Installer([folder], [clap]);
+
+        WindowsPluginFiles result = installer.ListWindowsPlugins(folder, [wrapper]);
+
+        Assert.True(result.Ok, result.Message);
+        Assert.Equal(2, result.Plugins.Count);
+        var eq = Assert.Single(result.Plugins, p => p.Path == vst);
+        Assert.Equal("Eq.vst3", eq.Name);
+        Assert.Equal("vst3", eq.Format);
+        Assert.True(eq.Enabled);
+        Assert.True(eq.CanDelete);
+        Assert.True(eq.InUse);
+        Assert.Null(eq.WinePrefix);
+        var comp = Assert.Single(result.Plugins, p => p.Path == clap);
+        Assert.False(comp.Enabled);
+        Assert.False(comp.InUse);
+        Assert.Equal("clap", comp.Format);
+        Assert.False(installer.ListWindowsPlugins(Path.GetDirectoryName(folder)!).Ok);
+        Assert.False(installer.ListWindowsPlugins("relative").Ok);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExclusionRemovesOnlyOnePluginsWrappersAndKeepsItsFiles(bool clap)
+    {
+        string source = Source(clap ? "plugins/Eq.clap" : "plugins/Eq.vst3");
+        string other = Source("plugins/Other.vst3");
+        string wrapper = clap ? ClapWrapper("Eq", source) : Vst3Wrapper("Eq", source);
+        string otherWrapper = Vst3Wrapper("Other", other);
+        var installer = Installer([Path.GetDirectoryName(source)!]);
+
+        InstallOutcome result = installer.SetWindowsPluginEnabled(source, false);
+
+        Assert.True(result.Ok, result.Message);
+        Assert.Equal([source], File.ReadAllLines(Exclusions));
+        Assert.False(File.Exists(wrapper) || Directory.Exists(wrapper));
+        Assert.True(Directory.Exists(otherWrapper));
+        Assert.Equal(Windows, File.ReadAllBytes(source));
+        Assert.Equal(Windows, File.ReadAllBytes(other));
+        Assert.DoesNotContain(Calls, c => c.Contains("--prune"));
+        Assert.True(installer.SetWindowsPluginEnabled(source, false).Ok);
+        Assert.Single(Calls, c => c.StartsWith("blacklist add", StringComparison.Ordinal));
+        Assert.True(installer.SetWindowsPluginEnabled(source, true).Ok);
+        Assert.Empty(File.ReadAllLines(Exclusions));
+        Assert.True(installer.SetWindowsPluginEnabled(source, true).Ok);
+        Assert.Single(Calls, c => c.StartsWith("blacklist rm", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void WineImportsUseCanonicalExclusionsAndCannotDeleteTheOriginal()
+    {
+        string original = Source("prefix/drive_c/VST3/Eq.vst3");
+        Source("prefix/system.reg", [1]);
+        string managed = Path.Combine(_root, "imports", "Eq.vst3");
+        Directory.CreateDirectory(Path.GetDirectoryName(managed)!);
+        File.CreateSymbolicLink(managed, original);
+        string wrapper = Vst3Wrapper("Eq", managed);
+        var installer = Installer([Path.GetDirectoryName(managed)!]);
+
+        var row = Assert.Single(installer.ListWindowsPlugins(Path.GetDirectoryName(managed)!).Plugins);
+        Assert.Equal(Path.Combine(_root, "prefix"), row.WinePrefix);
+        Assert.False(row.CanDelete);
+        Assert.True(installer.SetWindowsPluginEnabled(managed, false).Ok);
+        Assert.Equal([original], File.ReadAllLines(Exclusions));
+        Assert.False(Directory.Exists(wrapper));
+        Assert.False(Assert.Single(installer.ListWindowsPlugins(Path.GetDirectoryName(managed)!).Plugins).Enabled);
+        Assert.False(installer.DeleteWindowsPlugin(managed).Ok);
+        Assert.True(File.Exists(original));
+        Assert.NotNull(new FileInfo(managed).LinkTarget);
+        Assert.True(installer.SetWindowsPluginEnabled(managed, true).Ok);
+        Assert.Contains("blacklist rm " + original, Calls);
+    }
+
+    [Fact]
+    public void AnExcludedAncestorIsNotRemovedToEnableOnePlugin()
+    {
+        string source = Source("plugins/nested/Eq.vst3");
+        string root = Path.Combine(_root, "plugins");
+        string blocked = Path.GetDirectoryName(source)!;
+        var installer = Installer([root], [blocked, source]);
+        Assert.False(Assert.Single(installer.ListWindowsPlugins(root).Plugins).Enabled);
+        var result = installer.SetWindowsPluginEnabled(source, true);
+        Assert.False(result.Ok);
+        Assert.Contains("folder-level", result.Message);
+        Assert.Equal(new[] { blocked, source }, File.ReadAllLines(Exclusions));
+        Assert.DoesNotContain(Calls, c => c.StartsWith("blacklist rm", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BlacklistedParentsOutsideTheWalkDoNotDisableAnImportedLink()
+    {
+        string original = Source("original/Eq.vst3");
+        string managed = Path.Combine(_root, "imports", "Eq.vst3");
+        Directory.CreateDirectory(Path.GetDirectoryName(managed)!);
+        File.CreateSymbolicLink(managed, original);
+        var installer = Installer([Path.GetDirectoryName(managed)!], [Path.GetDirectoryName(original)!]);
+        Assert.True(Assert.Single(installer.ListWindowsPlugins(Path.GetDirectoryName(managed)!).Plugins).Enabled);
+    }
+
+    [Fact]
+    public void ASeparateNestedRegistrationCanBypassAnAncestorExclusion()
+    {
+        string source = Source("plugins/nested/Eq.vst3");
+        string parent = Path.Combine(_root, "plugins");
+        string nested = Path.GetDirectoryName(source)!;
+        var installer = Installer([parent, nested], [parent, source]);
+        Assert.True(installer.SetWindowsPluginEnabled(source, true).Ok);
+        Assert.Equal([parent], File.ReadAllLines(Exclusions));
+        Assert.True(Assert.Single(installer.ListWindowsPlugins(nested).Plugins).Enabled);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InUsePluginsAreRefusedBeforeExclusionOrDeletion(bool delete)
+    {
+        string source = Source("plugins/Eq.vst3");
+        string wrapper = Vst3Wrapper("Eq", source);
+        var installer = Installer([Path.GetDirectoryName(source)!]);
+        var result = delete ? installer.DeleteWindowsPlugin(source, [wrapper])
+            : installer.SetWindowsPluginEnabled(source, false, [wrapper]);
+        Assert.False(result.Ok);
+        Assert.Contains("insert chains", result.Message);
+        Assert.True(File.Exists(source));
+        Assert.True(Directory.Exists(wrapper));
+        Assert.Empty(File.ReadAllLines(Exclusions));
+        Assert.DoesNotContain(Calls, c => c.StartsWith("blacklist add", StringComparison.Ordinal) || c == "sync");
+    }
+
+    [Fact]
+    public void DeletingOneStandalonePluginKeepsItsSiblingAndClearsItsOwnExclusion()
+    {
+        string source = Source("plugins/Eq.vst3");
+        string other = Source("plugins/Other.vst3");
+        string wrapper = Vst3Wrapper("Eq", source);
+        string otherWrapper = Vst3Wrapper("Other", other);
+        var installer = Installer([Path.GetDirectoryName(source)!], [source, other]);
+        var result = installer.DeleteWindowsPlugin(source);
+        Assert.True(result.Ok, result.Message);
+        Assert.False(File.Exists(source));
+        Assert.False(Directory.Exists(wrapper));
+        Assert.True(File.Exists(other));
+        Assert.True(Directory.Exists(otherWrapper));
+        Assert.Equal([other], File.ReadAllLines(Exclusions));
+    }
+
+    [Fact]
+    public void DeletingABundleDoesNotFollowItsResourceLink()
+    {
+        string module = Source("plugins/Eq.vst3/Contents/x86_64-win/Eq.vst3");
+        string bundle = Path.Combine(_root, "plugins", "Eq.vst3");
+        string resources = Source("shared/keep.txt", [1, 2, 3]);
+        Directory.CreateSymbolicLink(Path.Combine(bundle, "Contents", "Resources"), Path.GetDirectoryName(resources)!);
+        string wrapper = Vst3Wrapper("Eq", module);
+        var installer = Installer([Path.GetDirectoryName(bundle)!]);
+        var result = installer.DeleteWindowsPlugin(bundle);
+        Assert.True(result.Ok, result.Message);
+        Assert.False(Directory.Exists(bundle));
+        Assert.False(Directory.Exists(wrapper));
+        Assert.Equal(new byte[] { 1, 2, 3 }, File.ReadAllBytes(resources));
+    }
+
+    [Fact]
+    public void DeletionRefusesWineSourcesLinksNativeFilesAndUnregisteredPaths()
+    {
+        string wine = Source("prefix/drive_c/VST3/Eq.vst3");
+        Source("prefix/system.reg", [1]);
+        string native = Source("plugins/Native.clap", Elf);
+        string outside = Source("outside/Other.vst3");
+        string link = Path.Combine(_root, "plugins", "Link.vst3");
+        File.CreateSymbolicLink(link, outside);
+        var installer = Installer([Path.GetDirectoryName(wine)!, Path.GetDirectoryName(native)!]);
+        foreach (string path in new[] { wine, native, outside, link, Path.GetDirectoryName(native)!, "relative" })
+            Assert.False(installer.DeleteWindowsPlugin(path).Ok);
+        Assert.True(File.Exists(wine));
+        Assert.True(File.Exists(native));
+        Assert.True(File.Exists(outside));
+        Assert.NotNull(new FileInfo(link).LinkTarget);
+    }
+
+    [Fact]
+    public void AnAncestorSourceLinkAlsoPreventsDeletion()
+    {
+        string original = Source("original/Eq.vst3");
+        string alias = Path.Combine(_root, "alias");
+        Directory.CreateSymbolicLink(alias, Path.GetDirectoryName(original)!);
+        var installer = Installer([alias]);
+        string selected = Path.Combine(alias, "Eq.vst3");
+        var row = Assert.Single(installer.ListWindowsPlugins(alias).Plugins);
+        Assert.False(row.CanDelete);
+        Assert.False(installer.DeleteWindowsPlugin(selected).Ok);
+        Assert.True(File.Exists(original));
+        Assert.Equal(original, WindowsPluginWrappers.Canonical(selected));
+    }
+
+    [Theory]
+    [InlineData("list")]
+    [InlineData("blacklist list")]
+    [InlineData("blacklist add")]
+    public void FailedExclusionPrerequisitesDoNotDeleteSourceOrWrapper(string fail)
+    {
+        string source = Source("plugins/Eq.vst3");
+        string wrapper = Vst3Wrapper("Eq", source);
+        var result = Installer([Path.GetDirectoryName(source)!], fail: fail).SetWindowsPluginEnabled(source, false);
+        Assert.False(result.Ok);
+        Assert.Contains("test failure", result.Message);
+        Assert.True(File.Exists(source));
+        Assert.True(Directory.Exists(wrapper));
+        Assert.Empty(File.ReadAllLines(Exclusions));
+    }
+
+    [Fact]
+    public void FailedSyncReportsAnExclusionThatWasAlreadySaved()
+    {
+        string source = Source("plugins/Eq.vst3");
+        string wrapper = Vst3Wrapper("Eq", source);
+        var result = Installer([Path.GetDirectoryName(source)!], fail: "sync").SetWindowsPluginEnabled(source, false);
+        Assert.False(result.Ok);
+        Assert.Contains("saved", result.Message);
+        Assert.Equal([source], File.ReadAllLines(Exclusions));
+        Assert.True(Directory.Exists(wrapper));
+        Assert.True(File.Exists(source));
+    }
+
+    [Fact]
+    public void ASharedWrapperRetargetedBySyncIsKept()
+    {
+        string source = Source("plugins/Eq.vst3");
+        string other = Source("other/Eq.vst3");
+        string wrapper = Vst3Wrapper("Eq", source);
+        string link = Path.Combine(wrapper, "Contents", "x86_64-win", "Eq.vst3");
+        var installer = Installer([Path.GetDirectoryName(source)!, Path.GetDirectoryName(other)!],
+            sync: $"ln -sfn '{other}' '{link}'");
+        Assert.True(installer.SetWindowsPluginEnabled(source, false).Ok);
+        Assert.True(Directory.Exists(wrapper));
+        Assert.Equal(other, new FileInfo(link).LinkTarget);
+    }
+
+    [Fact]
+    public void AWrapperCombiningDifferentSourceArchitecturesIsNotPartiallyDeleted()
+    {
+        string first = Source("plugins/Eq.vst3");
+        string other = Source("other/Eq.vst3");
+        string wrapper = Vst3Wrapper("Eq", first);
+        string win32 = Path.Combine(wrapper, "Contents", "i386-win");
+        Directory.CreateDirectory(win32);
+        File.CreateSymbolicLink(Path.Combine(win32, "Eq.vst3"), other);
+        var installer = Installer([Path.GetDirectoryName(first)!, Path.GetDirectoryName(other)!]);
+        var result = installer.SetWindowsPluginEnabled(first, false);
+        Assert.False(result.Ok);
+        Assert.Contains("shared by multiple", result.Message);
+        Assert.Empty(File.ReadAllLines(Exclusions));
+        Assert.True(Directory.Exists(wrapper));
+        Assert.True(File.Exists(first));
+        Assert.True(File.Exists(other));
+    }
+
+    [Fact]
+    public void SyncCleansOnlyRegisteredMissingSourcesAndKeepsInUseWrappers()
+    {
+        string live = Source("plugins/Live.vst3");
+        string folder = Path.GetDirectoryName(live)!;
+        string missing = Vst3Wrapper("Gone", Path.Combine(folder, "Gone.vst3"));
+        string used = Vst3Wrapper("Used", Path.Combine(folder, "Used.vst3"));
+        string orphan = Vst3Wrapper("Unregistered", Path.Combine(_root, "elsewhere", "Gone.vst3"));
+        string healthy = Vst3Wrapper("Live", live);
+        string clap = ClapWrapper("Gone", Path.Combine(folder, "Gone.clap"));
+        var result = Installer([folder]).SyncWindows([used]);
+        Assert.True(result.Ok, result.Message);
+        Assert.False(Directory.Exists(missing));
+        Assert.False(File.Exists(clap));
+        Assert.True(Directory.Exists(used));
+        Assert.True(Directory.Exists(orphan));
+        Assert.True(Directory.Exists(healthy));
+        Assert.Contains("Kept 1", result.Message);
+        Assert.DoesNotContain(Calls, c => c.Contains("--prune"));
+    }
+
+    [Fact]
+    public void FailedSyncNeverCleansMissingSourceWrappers()
+    {
+        string source = Source("plugins/Live.vst3");
+        string missing = Vst3Wrapper("Gone", Path.Combine(Path.GetDirectoryName(source)!, "Gone.vst3"));
+        var result = Installer([Path.GetDirectoryName(source)!], fail: "sync").SyncWindows();
+        Assert.False(result.Ok);
+        Assert.True(Directory.Exists(missing));
+    }
+}

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -76,25 +76,38 @@ public sealed class DaemonClient : IAsyncDisposable
     /// bundle can take a while, so callers wait generously.
     /// </summary>
     public Task<JsonNode?> InstallPluginAsync(string path, TimeSpan timeout)
-        => ChangePluginsAsync("installPlugin", timeout, new Dictionary<string, object> { ["path"] = path });
+        => PluginOperationAsync("installPlugin", timeout, new Dictionary<string, object> { ["path"] = path });
 
     public Task<JsonNode?> AddWindowsPluginFolderAsync(string path, TimeSpan timeout)
-        => ChangePluginsAsync("addWindowsPluginFolder", timeout, new Dictionary<string, object> { ["path"] = path });
+        => PluginOperationAsync("addWindowsPluginFolder", timeout, new Dictionary<string, object> { ["path"] = path });
 
     public Task<JsonNode?> RemoveWindowsPluginFolderAsync(string path, TimeSpan timeout)
-        => ChangePluginsAsync("removeWindowsPluginFolder", timeout, new Dictionary<string, object> { ["path"] = path });
+        => PluginOperationAsync("removeWindowsPluginFolder", timeout, new Dictionary<string, object> { ["path"] = path });
+
+    public Task<JsonNode?> RequestWindowsPluginFilesAsync(string folder, TimeSpan timeout)
+        => PluginOperationAsync("getWindowsPluginFiles", timeout, new Dictionary<string, object> { ["path"] = folder }, "windowsPluginFiles");
+
+    public Task<JsonNode?> SetWindowsPluginEnabledAsync(string path, bool enabled, TimeSpan timeout)
+        => PluginOperationAsync("setWindowsPluginEnabled", timeout, new Dictionary<string, object> { ["path"] = path, ["value"] = enabled });
+
+    public Task<JsonNode?> RemoveWindowsPluginInsertsAsync(string path, TimeSpan timeout)
+        => PluginOperationAsync("removeWindowsPluginInserts", timeout, new Dictionary<string, object> { ["path"] = path });
+
+    public Task<JsonNode?> DeleteWindowsPluginAsync(string path, TimeSpan timeout)
+        => PluginOperationAsync("deleteWindowsPlugin", timeout, new Dictionary<string, object> { ["path"] = path });
 
     /// <summary>Bridge again what yabridge knows; the reply is as for an install.</summary>
     public Task<JsonNode?> SyncWindowsPluginsAsync(TimeSpan timeout)
-        => ChangePluginsAsync("syncWindowsPlugins", timeout);
+        => PluginOperationAsync("syncWindowsPlugins", timeout);
 
     /// <summary>Read the catalogues again, for plugins installed by other means.</summary>
     public Task<JsonNode?> RescanPluginsAsync(TimeSpan timeout)
-        => ChangePluginsAsync("rescanPlugins", timeout);
+        => PluginOperationAsync("rescanPlugins", timeout);
 
     // Reads may share a reply; changes must each reach the daemon, even
     // when two windows issue them together and both answer pluginInstall.
-    private async Task<JsonNode?> ChangePluginsAsync(string command, TimeSpan timeout, Dictionary<string, object>? fields = null)
+    private async Task<JsonNode?> PluginOperationAsync(string command, TimeSpan timeout,
+        Dictionary<string, object>? fields = null, string replyType = "pluginInstall")
     {
         CancellationToken stopping;
         lock (_lifecycle)
@@ -104,7 +117,7 @@ public sealed class DaemonClient : IAsyncDisposable
         }
         try { await _pluginChanges.WaitAsync(stopping); }
         catch (OperationCanceledException) { return null; }
-        try { return await QueryAsync("pluginInstall", command, timeout, fields); }
+        try { return await QueryAsync(replyType, command, timeout, fields); }
         finally { _pluginChanges.Release(); }
     }
 
@@ -260,7 +273,7 @@ public sealed class DaemonClient : IAsyncDisposable
             else if (type == "state") { LastStateJson = text; StateReceived?.Invoke(node); }
             else if (type == "diagnostics") StoreReply(type, node);
             else if (type == "plugins") StoreReply(type, node["plugins"]);
-            else if (type is "pluginSetup" or "pluginInstall" or "pluginDiagnostics") StoreReply(type, node);
+            else if (type is "pluginSetup" or "pluginInstall" or "pluginDiagnostics" or "windowsPluginFiles") StoreReply(type, node);
             else if (type == "commandResult" && node["requestId"]?.GetValue<string>() is string requestId)
             {
                 CompleteQuery(requestId);

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -147,7 +147,7 @@
           <Button Name="Rescan" Content="Rescan" Padding="14,5" Click="OnRescanPlugins"
                   ToolTip.Tip="Read the plugin directories again, for plugins installed by other means"/>
         </StackPanel>
-        <Button Name="ManageFolders" Content="Manage folders…" Padding="14,5" Margin="0,4,0,0"
+        <Button Name="ManageFolders" Content="Manage Windows plugins…" Padding="14,5" Margin="0,4,0,0"
                 HorizontalAlignment="Left" Click="OnManagePluginFolders"/>
         <TextBlock Text="{Binding WindowsPlugins}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="0,4,0,0"/>
         <!-- A pair of versions that leaves a bridged plugin's own editor deaf

--- a/src/OpenXLR.UI/PluginFoldersWindow.axaml
+++ b/src/OpenXLR.UI/PluginFoldersWindow.axaml
@@ -3,42 +3,70 @@
         xmlns:vm="using:OpenXLR.UI"
         x:Class="OpenXLR.UI.PluginFoldersWindow"
         x:DataType="vm:OptionsViewModel"
-        Title="Windows plugin folders" Width="720" Height="480" MinWidth="480" MinHeight="380"
+        Title="Windows plugins" Width="760" Height="820" MinWidth="480" MinHeight="380"
         WindowStartupLocation="CenterOwner" Background="#16181d">
-  <Grid Margin="18" RowDefinitions="Auto,12,*,12,Auto,10,Auto,12,Auto">
-    <StackPanel Spacing="6">
-      <TextBlock Text="Windows VST3 and CLAP folders" FontSize="17" FontWeight="SemiBold"/>
-      <TextBlock Text="Add a folder containing Windows plugins to scan it through yabridge. Plugin files stay where they are."
-                 FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
-      <TextBlock Text="{Binding WindowsImportNote}" IsVisible="{Binding WindowsImportNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                 FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
-      <TextBlock Text="These folders are shared with other applications using system yabridge."
-                 IsVisible="{Binding SystemBridge}" FontSize="12" Foreground="#e0a05a" TextWrapping="Wrap"/>
-    </StackPanel>
-    <Border Grid.Row="2" Background="#1d2027" CornerRadius="8" Padding="8">
-      <Grid>
-        <ListBox Name="FolderList" ItemsSource="{Binding WindowsDirectories}"
-                 SelectionMode="Single" SelectionChanged="OnSelectionChanged"
-                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-          <ListBox.ItemTemplate>
-            <DataTemplate x:DataType="x:String">
-              <TextBlock Text="{Binding}" TextWrapping="Wrap" Margin="0,4,12,4" FontSize="12"/>
-            </DataTemplate>
-          </ListBox.ItemTemplate>
-        </ListBox>
-        <TextBlock Text="No registered folders." IsVisible="{Binding !HasWindowsDirectories}"
-                   Margin="8" Foreground="#8b93a7" IsHitTestVisible="False"/>
-      </Grid>
-    </Border>
-    <WrapPanel Grid.Row="4" Orientation="Horizontal">
-      <Button Name="AddFolder" Content="Add folder…" Padding="14,5" Margin="0,0,8,0" Click="OnAddFolder"/>
-      <Button Name="RemoveFolder" Content="Remove from list" Padding="14,5" Margin="0,0,8,0" Click="OnRemoveFolder" IsEnabled="False"/>
-      <Button Name="RescanFolders" Content="Rescan" Padding="14,5" Click="OnRescan"/>
-    </WrapPanel>
-    <TextBlock Grid.Row="6" Text="Removal keeps the original files and removes their generated VST3 and CLAP wrappers. Remove affected inserts from your chains first."
-               FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
-    <Grid Grid.Row="8" ColumnDefinitions="*,12,Auto">
-      <ScrollViewer MaxHeight="96" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+  <Grid Margin="18" RowDefinitions="*,12,Auto">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+      <StackPanel Spacing="8" Margin="0,0,12,0">
+        <TextBlock Text="Windows VST3 and CLAP plugins" FontSize="17" FontWeight="SemiBold"/>
+        <TextBlock Text="Choose a folder, then select an individual plugin below."
+                   FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+        <TextBlock Text="{Binding WindowsImportNote}" IsVisible="{Binding WindowsImportNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                   FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+        <TextBlock Text="These folders and exclusions are shared with other applications using system yabridge."
+                   IsVisible="{Binding SystemBridge}" FontSize="12" Foreground="#e0a05a" TextWrapping="Wrap"/>
+        <Border Background="#1d2027" CornerRadius="8" Padding="8" Height="240">
+          <Grid>
+            <ListBox Name="FolderList" ItemsSource="{Binding WindowsDirectories}"
+                     SelectionMode="Single" SelectionChanged="OnSelectionChanged"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+              <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                  <TextBlock Text="{Binding}" TextWrapping="Wrap" Margin="0,4,12,4" FontSize="12"/>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+            <TextBlock Text="No registered folders." IsVisible="{Binding !HasWindowsDirectories}"
+                       Margin="8" Foreground="#8b93a7" IsHitTestVisible="False"/>
+          </Grid>
+        </Border>
+        <WrapPanel Orientation="Horizontal">
+          <Button Name="AddFolder" Content="Add folder…" Padding="14,5" Margin="0,0,8,4" Click="OnAddFolder"/>
+          <Button Name="RemoveFolder" Content="Remove from list" Padding="14,5" Margin="0,0,8,4" Click="OnRemoveFolder" IsEnabled="False"/>
+          <Button Name="RescanFolders" Content="Rescan" Padding="14,5" Margin="0,0,0,4" Click="OnRescan"/>
+        </WrapPanel>
+        <Border Background="#1d2027" CornerRadius="8" Padding="8" Height="190">
+          <Grid>
+            <ListBox Name="PluginList" SelectionMode="Single" SelectionChanged="OnPluginSelectionChanged"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+              <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="vm:WindowsPluginEntry">
+                  <Grid ColumnDefinitions="*,8,45,8,64" Margin="0,5,12,5">
+                    <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Path}"/>
+                    <TextBlock Grid.Column="2" Text="{Binding FormatLabel}" FontSize="11" Foreground="#8b93a7"/>
+                    <TextBlock Grid.Column="4" Text="{Binding Status}" FontSize="11"/>
+                  </Grid>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+            <TextBlock Name="EmptyPlugins" Text="Select a folder to see its plugins." Margin="8"
+                       Foreground="#8b93a7" IsHitTestVisible="False" TextWrapping="Wrap"/>
+          </Grid>
+        </Border>
+        <WrapPanel Orientation="Horizontal">
+          <Button Name="RemoveUses" Content="Remove from all chains…" Padding="14,5" Margin="0,0,8,4"
+                  Click="OnRemoveUses" IsVisible="False"/>
+          <Button Name="TogglePlugin" Content="Disable in OpenXLR" Padding="14,5" Margin="0,0,8,4" Click="OnTogglePlugin" IsEnabled="False"/>
+          <Button Name="DeletePlugin" Content="Delete file…" Padding="14,5" Margin="0,0,8,4" Click="OnDeletePlugin" IsEnabled="False"/>
+          <Button Name="WineUninstaller" Content="Wine uninstaller…" Padding="14,5" Margin="0,0,0,4" Click="OnWineUninstaller" IsVisible="False"/>
+        </WrapPanel>
+        <TextBlock Name="PluginDetail" Text="Select a plugin to manage it." FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+        <TextBlock Text="Disabling keeps the files. Delete file permanently removes a standalone plugin. Wine-installed plugins use their uninstaller. Changes refresh the plugin catalogue."
+                   FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+      </StackPanel>
+    </ScrollViewer>
+    <Grid Grid.Row="2" ColumnDefinitions="*,12,Auto">
+      <ScrollViewer MaxHeight="80" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
         <TextBlock Name="Status" FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,12,0"/>
       </ScrollViewer>
       <Button Grid.Column="2" Name="CloseButton" Content="Close" Padding="18,6" Click="OnClose"/>

--- a/src/OpenXLR.UI/PluginFoldersWindow.axaml.cs
+++ b/src/OpenXLR.UI/PluginFoldersWindow.axaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -7,24 +9,41 @@ using Avalonia.Interactivity;
 
 namespace OpenXLR.UI;
 
+public sealed record WindowsPluginEntry(string Path, string Name, string Format, bool Enabled,
+    bool CanDelete, string? WinePrefix, bool InUse)
+{
+    public string Status => InUse ? "In use" : Enabled ? "Enabled" : "Disabled";
+    public string FormatLabel => Format.ToUpperInvariant();
+}
+
 public partial class PluginFoldersWindow : Window
 {
     private static readonly TimeSpan ChangeTimeout = TimeSpan.FromMinutes(4);
+    private readonly ObservableCollection<WindowsPluginEntry> _plugins = [];
     private bool _busy;
+    private WindowsPluginEntry? SelectedPlugin => PluginList.SelectedItem as WindowsPluginEntry;
 
     public PluginFoldersWindow()
     {
         InitializeComponent();
+        PluginList.ItemsSource = _plugins;
         Closing += (_, e) =>
         {
             if (_busy && e.CloseReason == WindowCloseReason.WindowClosing) e.Cancel = true;
+        };
+        Opened += (_, _) =>
+        {
+            var screen = Screens.ScreenFromWindow(this);
+            if (screen is null) return;
+            double height = screen.WorkingArea.Height / screen.Scaling - 60;
+            if (height > 300) { MinHeight = Math.Min(MinHeight, height); MaxHeight = height; }
         };
     }
 
     public PluginFoldersWindow(OptionsViewModel vm) : this()
     {
         DataContext = vm;
-        Opened += async (_, _) => await RefreshAsync(vm);
+        Opened += async (_, _) => await RunAsync(vm, () => Task.FromResult(""), "Reading plugin folders…");
     }
 
     private void UpdateButtons()
@@ -32,23 +51,76 @@ public partial class PluginFoldersWindow : Window
         if (DataContext is not OptionsViewModel vm) return;
         AddFolder.IsEnabled = RescanFolders.IsEnabled = !_busy && vm.CanSyncWindows;
         RemoveFolder.IsEnabled = !_busy && vm.CanManageWindows && FolderList.SelectedItem is string;
-        FolderList.IsEnabled = CloseButton.IsEnabled = !_busy;
+        FolderList.IsEnabled = PluginList.IsEnabled = CloseButton.IsEnabled = !_busy;
+        WindowsPluginEntry? selected = SelectedPlugin;
+        RemoveUses.IsVisible = selected?.InUse == true;
+        RemoveUses.IsEnabled = !_busy && selected?.InUse == true;
+        TogglePlugin.Content = selected?.Enabled == false ? "Enable in OpenXLR" : "Disable in OpenXLR";
+        TogglePlugin.IsEnabled = !_busy && vm.CanSyncWindows && selected is { InUse: false };
+        DeletePlugin.IsEnabled = !_busy && vm.CanManageWindows && selected is { InUse: false, CanDelete: true };
+        WineUninstaller.IsVisible = selected?.WinePrefix is not null;
+        WineUninstaller.IsEnabled = !_busy && vm.CanSyncWindows && selected is { InUse: false };
+        PluginDetail.Text = selected is null ? "Select a plugin to manage it." : selected.Path
+            + (selected.InUse ? "\nRemove this plugin from its insert chains before disabling or uninstalling it." : "");
     }
 
-    private async Task RefreshAsync(OptionsViewModel vm)
+    private async Task RefreshCoreAsync(OptionsViewModel vm)
     {
+        string? folder = FolderList.SelectedItem as string;
+        await vm.LoadPluginSetupAsync();
+        FolderList.SelectedItem = folder is not null && vm.WindowsDirectories.Contains(folder)
+            ? folder : vm.WindowsDirectories.FirstOrDefault();
+        if (!vm.CanManageWindows) Status.Text = vm.WindowsPlugins;
+        await LoadFilesAsync(vm);
+    }
+
+    private async Task LoadFilesAsync(OptionsViewModel vm)
+    {
+        if (FolderList.SelectedItem is not string folder)
+        {
+            ApplyPluginFiles(null);
+            return;
+        }
+        JsonNode? reply = await vm.Client.RequestWindowsPluginFilesAsync(folder, TimeSpan.FromSeconds(20));
+        if (FolderList.SelectedItem as string != folder) return;
+        ApplyPluginFiles(reply);
+        if (reply is null) Status.Text = "The daemon did not answer the plugin-file request.";
+        else if (reply["ok"]?.GetValue<bool>() != true)
+            Status.Text = reply["message"]?.GetValue<string>() ?? "Could not read the plugin folder.";
+        else if (reply["message"]?.GetValue<string>() is { Length: > 0 } note)
+            Status.Text = string.IsNullOrEmpty(Status.Text) ? note : Status.Text + " " + note;
+    }
+
+    internal void ApplyPluginFiles(JsonNode? reply)
+    {
+        string? selected = SelectedPlugin?.Path;
+        _plugins.Clear();
+        if (reply?["ok"]?.GetValue<bool>() == true)
+            foreach (JsonNode item in (reply["plugins"] as JsonArray ?? []).OfType<JsonNode>())
+                _plugins.Add(new(item["path"]!.GetValue<string>(), item["name"]!.GetValue<string>(),
+                    item["format"]!.GetValue<string>(), item["enabled"]!.GetValue<bool>(),
+                    item["canDelete"]!.GetValue<bool>(), item["winePrefix"]?.GetValue<string>(),
+                    item["inUse"]?.GetValue<bool>() ?? false));
+        PluginList.SelectedItem = _plugins.FirstOrDefault(p => p.Path == selected);
+        EmptyPlugins.IsVisible = _plugins.Count == 0;
+        EmptyPlugins.Text = FolderList.SelectedItem is null ? "Select a folder to see its plugins."
+            : reply?["ok"]?.GetValue<bool>() == true ? "No Windows VST3 or CLAP plugin files found."
+            : "Plugin list is unavailable.";
+        UpdateButtons();
+    }
+
+    private async void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_busy || DataContext is not OptionsViewModel vm) return;
         _busy = true;
         UpdateButtons();
-        try
-        {
-            await vm.LoadPluginSetupAsync();
-            if (!vm.CanSyncWindows) Status.Text = vm.WindowsPlugins;
-        }
+        Status.Text = "";
+        try { await LoadFilesAsync(vm); }
         catch (Exception ex) { Status.Text = ex.Message; }
         finally { _busy = false; UpdateButtons(); }
     }
 
-    private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e) => UpdateButtons();
+    private void OnPluginSelectionChanged(object? sender, SelectionChangedEventArgs e) => UpdateButtons();
 
     private async void OnAddFolder(object? sender, RoutedEventArgs e)
     {
@@ -71,22 +143,71 @@ public partial class PluginFoldersWindow : Window
         await ChangeAsync(vm, () => vm.Client.RemoveWindowsPluginFolderAsync(folder, ChangeTimeout), "Removing folder…");
     }
 
+    private async void OnRemoveUses(object? sender, RoutedEventArgs e)
+    {
+        if (_busy || DataContext is not OptionsViewModel vm || SelectedPlugin is not { InUse: true } plugin) return;
+        if (!await Dialogs.ConfirmAsync(this, "Remove plugin from all chains?",
+            $"Remove every occurrence of {plugin.Name} from the current input and mix chains, including bypassed inserts? Other plugins stay in their existing order. Audio may pause briefly in affected chains. Plugin files, exclusions and saved profiles are not changed.", "Remove from all chains")) return;
+        await ChangeAsync(vm, () => vm.Client.RemoveWindowsPluginInsertsAsync(plugin.Path, ChangeTimeout), "Removing plugin from all chains…");
+    }
+
+    private async void OnTogglePlugin(object? sender, RoutedEventArgs e)
+    {
+        if (_busy || DataContext is not OptionsViewModel vm || SelectedPlugin is not { } plugin) return;
+        if (plugin.Enabled && !await Dialogs.ConfirmAsync(this, "Disable plugin?",
+            $"Disable {plugin.Name} in the selected yabridge configuration? Its files will stay in place."
+            + (vm.SystemBridge ? " This also affects other applications using system yabridge." : ""), "Disable")) return;
+        await ChangeAsync(vm, () => vm.Client.SetWindowsPluginEnabledAsync(plugin.Path, !plugin.Enabled, ChangeTimeout),
+            plugin.Enabled ? "Disabling plugin…" : "Enabling plugin…");
+    }
+
+    private async void OnDeletePlugin(object? sender, RoutedEventArgs e)
+    {
+        if (_busy || DataContext is not OptionsViewModel vm || SelectedPlugin is not { CanDelete: true } plugin) return;
+        if (!await Dialogs.ConfirmAsync(this, "Delete plugin file?",
+            $"Permanently delete {plugin.Path} and its generated wrappers? Only this standalone file or bundle is removed; other plugins in the folder stay. This cannot be undone.", "Delete file")) return;
+        await ChangeAsync(vm, () => vm.Client.DeleteWindowsPluginAsync(plugin.Path, ChangeTimeout), "Deleting plugin…");
+    }
+
+    private async void OnWineUninstaller(object? sender, RoutedEventArgs e)
+    {
+        if (_busy || DataContext is not OptionsViewModel vm || SelectedPlugin is not { WinePrefix: not null } plugin
+            || FolderList.SelectedItem is not string folder) return;
+        if (!await Dialogs.ConfirmAsync(this, "Open Wine uninstaller?",
+            $"Open the installed-apps list for {plugin.WinePrefix}? Choose the plugin's installer entry there. An uninstaller may remove several effects from the same package. Close other Wine applications and remove affected inserts first. OpenXLR will rescan when the uninstaller closes.", "Open uninstaller")) return;
+        await RunAsync(vm, async () =>
+        {
+            JsonNode? fresh = await vm.Client.RequestWindowsPluginFilesAsync(folder, TimeSpan.FromSeconds(20));
+            JsonNode? item = (fresh?["plugins"] as JsonArray)?.FirstOrDefault(p => p?["path"]?.GetValue<string>() == plugin.Path);
+            if (fresh?["ok"]?.GetValue<bool>() != true || item is null) return "Could not verify the plugin before opening the uninstaller.";
+            if (item["inUse"]?.GetValue<bool>() == true) return "Remove this plugin from its insert chains before uninstalling it.";
+            if (item["winePrefix"]?.GetValue<string>() is not { Length: > 0 } prefix) return "This plugin no longer belongs to a Wine prefix.";
+            int exit = await ProcessRunner.RunInteractiveAsync("wine", ["uninstaller"],
+                new Dictionary<string, string> { ["WINEPREFIX"] = prefix });
+            string result = PluginInstall.Describe(await vm.Client.SyncWindowsPluginsAsync(ChangeTimeout), "the rescan");
+            return (exit == 0 ? "Wine uninstaller closed. " : $"Wine uninstaller exited with code {exit}. ") + result;
+        }, "Waiting for Wine uninstaller…");
+    }
+
     private async void OnRescan(object? sender, RoutedEventArgs e)
     {
         if (!_busy && DataContext is OptionsViewModel vm)
             await ChangeAsync(vm, () => vm.Client.SyncWindowsPluginsAsync(ChangeTimeout), "Syncing and rescanning…");
     }
 
-    private async Task ChangeAsync(OptionsViewModel vm, Func<Task<JsonNode?>> change, string busy)
+    private Task ChangeAsync(OptionsViewModel vm, Func<Task<JsonNode?>> change, string busy)
+        => RunAsync(vm, async () => PluginInstall.Describe(await change(), "the plugin operation"), busy);
+
+    private async Task RunAsync(OptionsViewModel vm, Func<Task<string>> operation, string busy)
     {
         _busy = true;
         UpdateButtons();
         Status.Text = busy;
-        try { Status.Text = PluginInstall.Describe(await change(), "the folder operation"); }
+        try { Status.Text = await operation(); }
         catch (Exception ex) { Status.Text = ex.Message; }
         finally
         {
-            try { await vm.LoadPluginSetupAsync(); }
+            try { await RefreshCoreAsync(vm); }
             catch (Exception ex) { Status.Text += " " + ex.Message; }
             _busy = false;
             UpdateButtons();


### PR DESCRIPTION
## Changes

- List individual Windows VST3/CLAP sources with enabled, disabled and in-use states.
- Disable or restore a source through the selected bridge's exclusion list without deleting its files.
- Delete standalone files only after confirmation. Protect Wine-installed and linked sources, and open Wine's uninstaller in the appropriate prefix instead.
- Rescan after changes and clean missing-source wrappers without touching unrelated or in-use wrappers.
- Add **Remove from all chains** for in-use plugins. Remove every current occurrence, including bypassed inserts, preserve other plugins and saved profiles, and save before acknowledging. Rewire failures retain the affected definitions; failed saves restore the previous settings.
- Give the folder list more height, expose the operations through the API, and update the manual.

## Verification

- Native-enabled Release build with warnings treated as errors: 0 warnings, 0 errors.
- .NET suite: 487 passed, 3 opt-in desktop tests skipped. The separate Xvfb layout check passed at narrow and wide sizes.
- Real yabridge checks in isolated directories verified canonical exclusions, restoration, standalone deletion, sibling preservation, in-use guards and missing-source wrapper cleanup.
- Tests cover multi-chain removal, duplicate and bypassed occurrences, input grouping, rewire failures, save rollback, request serialization, validation and the manager's controls.
- Local deployment confirmed working. Current mixer and window settings were preserved during deployment.

No version bump or release changes. The Elgato EQ lifecycle fix is separate.
