### PR TITLE
Window: compact the applications card

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ OPENXLR_TEST_TOOLTIP=1 xvfb-run -a -s '-screen 0 1600x1000x24' dotnet test src/O
 The window layout test runs in its own process using X11 and isolated
 configuration, runtime and session-bus settings. It checks narrow plugin
 windows and mixer widths from 640 to 2400 logical pixels. Set
-`OPENXLR_LAYOUT_ARTIFACTS` to a directory to save rendered previews.
+`OPENXLR_LAYOUT_ARTIFACTS` to a directory to save rendered previews. Set
+`OPENXLR_LAYOUT_FONT` to an installed font family, such as `DejaVu Sans`, to
+check wrapping with different font metrics.
 
 The tooltip test runs in its own process too. It drives a real pointer
 through the X server's XTEST extension, so it needs `libXtst`, and it

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -194,7 +194,9 @@ scroll horizontally and vertically. Resizing the window manually turns off autom
 ### 3.3 Put an application on a different channel
 
 The APPLICATIONS card lists every app that is currently registered with
-PipeWire as an audio client; a green light means it is playing.
+PipeWire as an audio client; a green light means it is playing. Manage… sits
+beside the APPLICATIONS heading, like Edit layout… beside SUBMIXER. The app
+controls wrap onto further rows when the window is narrower.
 
 An app's playback streams and audio client share the same identity even
 when PipeWire puts the process name only on the client. Windows executable

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -40,6 +40,8 @@ public sealed class WindowLayoutTests
                 AppBuilder.Configure<App>().UseSkia().UseHarfBuzz().UseX11().SetupWithoutStarting();
                 Application.Current!.RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Dark;
                 var main = new MainWindow();
+                if (Environment.GetEnvironmentVariable("OPENXLR_LAYOUT_FONT") is { Length: > 0 } font)
+                    main.FontFamily = new Avalonia.Media.FontFamily(font);
                 windows.Add(main);
                 // Stop the window's background connection before supplying a fixed fixture.
                 ((DaemonClient)typeof(MainWindow).GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -57,6 +59,16 @@ public sealed class WindowLayoutTests
                     AddInsert(mix.Inserts);
                     vm.Mixes.Add(mix);
                 }
+                foreach (string name in new[] { "Google Chrome", "Discord", "Karere", "Signal", "Steam", "Balatro" })
+                {
+                    var app = new AppStreamViewModel(new DaemonClient(), name, name,
+                        [new ChannelChoice("browser", "Browser"), new ChannelChoice("voicechat", "Voice Chat"), new ChannelChoice("game", "Game")]);
+                    app.ApplyFromDaemon(name == "Google Chrome" ? "browser" : name is "Steam" or "Balatro" ? "game" : "voicechat", true, true);
+                    vm.Apps.Add(app);
+                    vm.ActiveApps.Add(app);
+                }
+                main.DataContext = null;
+                main.DataContext = vm;
                 main.Show();
 
                 // No floor above the widest row: the window squeezes to 640.
@@ -112,6 +124,48 @@ public sealed class WindowLayoutTests
                             t => t.Classes.Contains("insertName"));
                         Assert.Single(master.GetVisualDescendants().OfType<Slider>());
                     }
+                    var appRows = main.FindControl<ItemsControl>("ApplicationRows")!;
+                    var manageApps = main.FindControl<Button>("ManageApps")!;
+                    var appCards = appRows.GetVisualDescendants().OfType<Border>()
+                        .Where(b => b.DataContext is AppStreamViewModel && b.Padding == new Thickness(8, 6)).ToArray();
+                    Assert.Equal(6, appCards.Length);
+                    var appWrap = appRows.GetVisualDescendants().OfType<WrapPanel>().Single();
+                    foreach (var appCard in appCards) Assert.Equal(4, appCard.Margin.Right);
+                    // Font metrics differ across desktops. A chip stays on
+                    // the preceding row exactly when its measured width fits.
+                    for (int i = 1; i < appCards.Length; i++)
+                    {
+                        var previous = appCards[i - 1];
+                        var current = appCards[i];
+                        var before = previous.TranslatePoint(default, appWrap)!.Value;
+                        var here = current.TranslatePoint(default, appWrap)!.Value;
+                        double end = before.X + previous.Bounds.Width + previous.Margin.Right
+                            + current.Margin.Left + current.Bounds.Width + current.Margin.Right;
+                        if (end <= appWrap.Bounds.Width)
+                            Assert.Equal(before.Y, here.Y);
+                        else
+                            Assert.True(here.Y > before.Y, "An app wider than the remaining space did not wrap.");
+                    }
+                    var appHeader = (StackPanel)main.FindControl<Expander>("ApplicationsTile")!.Header!;
+                    var heading = appHeader.Children.OfType<TextBlock>().Single();
+                    Assert.Same(appHeader, manageApps.Parent);
+                    double headingCenter = heading.TranslatePoint(default, main)!.Value.Y + heading.Bounds.Height / 2;
+                    double manageCenter = manageApps.TranslatePoint(default, main)!.Value.Y + manageApps.Bounds.Height / 2;
+                    Assert.InRange(Math.Abs(headingCenter - manageCenter), 0, 1);
+                    Assert.True(manageApps.TranslatePoint(default, main)!.Value.X > heading.TranslatePoint(default, main)!.Value.X + heading.Bounds.Width);
+                    var editLayout = main.GetVisualDescendants().OfType<Button>().Single(b => b.Content as string == "Edit layout…");
+                    Assert.Equal(editLayout.Padding, manageApps.Padding);
+                    Assert.Equal(editLayout.FontSize, manageApps.FontSize);
+                    Assert.Equal(editLayout.MinHeight, manageApps.MinHeight);
+                    Assert.True(manageApps.IsEnabled);
+                    AssertInside(manageApps, main);
+                    foreach (var appCard in appCards)
+                    {
+                        AssertInside(appCard, main);
+                        AssertNoOverlap([appCard, manageApps]);
+                    }
+                    Assert.DoesNotContain(main.GetVisualDescendants().OfType<TextBlock>(),
+                        t => t.Text?.StartsWith("Running audio-capable apps appear here", StringComparison.Ordinal) == true);
                     Capture(main, "mixer-" + width);
                     var page = main.GetVisualDescendants().OfType<ScrollViewer>().First();
                     page.Offset = new Vector(0, page.Extent.Height);

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -148,7 +148,7 @@
        the cards follow the available width. Every card sizes to its content;
        the page scrolls when the window is shorter. -->
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-  <StackPanel Name="MixerContent" Margin="16" MaxWidth="1300" HorizontalAlignment="Center">
+  <StackPanel Name="MixerContent" Margin="16" MaxWidth="1300" HorizontalAlignment="Stretch">
 
     <!-- header -->
     <Border Classes="card" Margin="0,0,0,8">
@@ -528,15 +528,20 @@
     <!-- running applications and the channel each is routed to -->
     <Border Classes="card" Margin="0,0,0,8" IsVisible="{Binding HasMixer}">
       <Expander Name="ApplicationsTile" Classes="tile" Theme="{StaticResource TileExpanderTheme}" IsExpanded="True">
-        <Expander.Header><TextBlock Text="APPLICATIONS" Classes="h"/></Expander.Header>
-      <StackPanel Spacing="8">
-        <ItemsControl ItemsSource="{Binding ActiveApps}">
+        <Expander.Header>
+          <StackPanel Orientation="Horizontal" Spacing="10">
+            <TextBlock Text="APPLICATIONS" Classes="h" VerticalAlignment="Center"/>
+            <Button Name="ManageApps" Content="Manage…" Padding="8,1" FontSize="11" MinHeight="0" VerticalAlignment="Center"
+                    IsEnabled="{Binding HasApps}" Click="OnManageApps"/>
+          </StackPanel>
+        </Expander.Header>
+        <ItemsControl Name="ApplicationRows" ItemsSource="{Binding ActiveApps}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
           </ItemsControl.ItemsPanel>
           <ItemsControl.ItemTemplate>
             <DataTemplate x:DataType="vm:AppStreamViewModel">
-              <Border Background="#23262f" CornerRadius="6" Padding="8,6" Margin="0,0,8,8">
+              <Border Background="#23262f" CornerRadius="6" Padding="8,6" Margin="0,0,4,8">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                   <Ellipse Width="8" Height="8" VerticalAlignment="Center"
                            Fill="{Binding Active, Converter={x:Static vm:Converters.BoolToBrush}}"
@@ -549,14 +554,6 @@
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>
-        <Grid ColumnDefinitions="*,Auto">
-          <TextBlock TextWrapping="Wrap" VerticalAlignment="Center"
-                     Text="Running audio-capable apps appear here (green light = playing) and are routed automatically. Changing one is remembered."
-                     FontSize="11" Foreground="#6b7285"/>
-          <Button Grid.Column="1" Content="Manage…" Padding="12,4" Margin="8,0,0,0"
-                  Click="OnManageApps" IsEnabled="{Binding HasApps}"/>
-        </Grid>
-      </StackPanel>
       </Expander>
     </Border>
 


### PR DESCRIPTION
## Changes

- Move Manage beside the Applications heading, matching Edit layout in the Submixer heading.
- Remove the redundant explanatory text below the apps.
- Reduce horizontal gaps from 8 to 4 pixels without changing dropdown sizes, so the reported six-app set fits on one row at full card width.
- Keep the mixer content stretched within its existing width cap, so wrapped app rows cannot shrink the entire page.
- Update the manual and layout regression tests.

## Verification

- Native-enabled Release build with warnings treated as errors: 0 warnings, 0 errors.
- .NET suite: 487 passed, 3 opt-in desktop tests skipped.
- Separate Xvfb layout checks passed at 100% and 175% scaling, across window widths from 640 to 2400 pixels. The six-app fixture covers Google Chrome, Discord, Karere, Signal, Steam and Balatro with their actual routing labels.
- Inspected rendered layouts and confirmed the local UI works. No audio-service restart or routing changes were needed.

No version bump or release changes.
