### PR TITLE
Plugins: add editable native editor compatibility rules

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,8 @@ Messages from the daemon, each a JSON object with a `type` field:
 | `plugins` | in answer to `listPlugins` | the installed LV2, CLAP and VST3 plugins with their controls, within the message size limit above and always including the plugins the saved chains use; `supported` is false, with `unsupportedFeatures` listed, for a plugin that needs a host feature the PipeWire chain lacks |
 | `pluginSetup` | in answer to `getPluginSetup` | where installs go (`lv2Directory`, `clapDirectory`, `vst3Directory`), `hostInstalled`, `yabridge` (its version, or null when not installed), `wine`, `windowsDirectories` (the folders yabridge bridges) and `wineFolders` (Wine's own plugin folders that hold a plugin and are not bridged yet, offered as one press since a file dialog hides them) |
 | `windowsPluginFiles` | in answer to `getWindowsPluginFiles` | `ok`, `message` and `plugins`; each plugin file carries `path`, `name`, `format`, `enabled`, `canDelete`, `winePrefix` and `inUse`. Excluded files remain listed |
+| `nativeEditorRules` | in answer to `getNativeEditorRules` or `setNativeEditorRule` | `rules` with `kind`, `plugin`, `name`, `reason`, `defaultBlocked`, `override` and effective `blocked`; `error` describes a refused change or unreadable configuration |
+| `nativeEditorRulesChanged` | after a successful rule change | notification to refresh the catalogue and editor availability; no plugin rescan is needed |
 | `pluginDiagnostics` | in answer to `getPluginDiagnostics` | `discovery`: daemon host/controller paths, Wine prefix, architecture, effective search paths, bounded `yabridgectl status` output and latest completed CLAP/VST3 scan reports |
 | `pluginInstall` | in answer to `installPlugin`, `addWindowsPluginFolder`, `removeWindowsPluginFolder`, `removeWindowsPluginInserts`, `setWindowsPluginEnabled`, `deleteWindowsPlugin`, `syncWindowsPlugins` and `rescanPlugins` | `ok`, `message` (a sentence or two for the user, ending with the bundles the scan that followed could not read, up to three by name and the rest as a count), `installed` (the bundles or folders put in place), `added` (plugins in the catalogue that were not before) and `total` |
 | `error` | when a command without a `requestId` is rejected | `message` |
@@ -106,7 +108,9 @@ a bare `error` message, so an editor can wait for the acknowledgement:
 | `setInserts` | `channel`, `inserts[]` | replace a chain; `channel` is `xlr1`, `xlr2` or `mix:<id>`, each insert is `{id, kind, plugin, label?, bypass?, params?}` where `kind` is `"lv2"` with the plugin URI, `"clap"` with the plugin's id, or `"vst3"` with the class id as 32 hex digits; a CLAP or VST3 insert always runs in the native host, so its `nativeHost` reads true whatever was sent |
 | `setInsertBypass` | `channel`, `insertId`, `value` | bypass one insert |
 | `setInsertParam` | `channel`, `insertId`, `symbol`, `value` | one plugin control, by the catalogue's `symbol` (LV2 port symbol or decimal CLAP/VST3 parameter id); use catalogue ranges and scale points |
-| `showInsertUi` | `channel`, `insertId` | open an enabled insert's native editor when the optional host is installed |
+| `getNativeEditorRules` | none | read release defaults and explicit user overrides for native editor compatibility |
+| `setNativeEditorRule` | `kind`, `plugin`, `name?`, `blocked?` | set `blocked:true` to use OpenXLR controls, `false` to allow the native editor, or null/absent to remove the override and follow release defaults. Saved atomically before success; answered with `nativeEditorRules` |
+| `showInsertUi` | `channel`, `insertId` | open an enabled insert's native editor when the optional host is installed and the editor policy allows it; a blocked editor is refused without changing the audio instance |
 | `assignApp` | `identity`, `channel`, `label?` | route an app (creates a registry entry if unseen); `channel: "ignore"` stops managing it, its streams go back to the system default output and stay wherever the desktop routes them |
 | `assignStream` | `streamId`, `channel` | route one live stream by its PipeWire id; also remembered for the app; `ignore` works here too |
 | `forgetApp` | `identity` | drop an app and its remembered channel |
@@ -167,6 +171,22 @@ class-ID bans: a separately installed copy can still appear in the catalogue.
 installed-apps list in the reported `winePrefix`, waits for it to close, then
 syncs and rescans. It never imposes a deadline on an interactive uninstaller.
 
+Native editor compatibility is separate from DSP support. Catalogue entries
+carry `nativeUiBlocked`; live insert status also carries `nativeUiBlocked`
+and `nativeUiBlockReason`. Blocking leaves `supported`, native-host support,
+processing, parameters and bypass state unchanged. Clients should open their
+generated controls when blocked and refresh availability on
+`nativeEditorRulesChanged`. Existing editor windows are not closed.
+
+Rules use the format and stable plugin id, not the filename or display name.
+Only explicit overrides are saved; an untouched plugin follows the defaults
+in each release. An explicit allow or block survives future default changes.
+The initial release default blocks the Elgato De-Esser VST3 editor. Rule ids
+are bounded at 512 characters, names at 200, and the file at 1024 overrides
+and 1 MiB.
+Malformed stored choices are not silently overwritten; release defaults stay
+in force and the rules response reports the error.
+
 LV2 insert definitions optionally carry `nativeHost: true` to select the native
 helper for that insert. Missing or false keeps LV2 in PipeWire filter-chain, even
 when the helper is installed. Unsupported native selections are rejected.
@@ -207,6 +227,10 @@ All under `~/.config/openxlr/` (or `$XDG_CONFIG_HOME/openxlr/`):
 - `bridge/yabridgectl/config.toml`: the managed companion's folder registry,
   separate from the system yabridgectl configuration. Private wrappers live
   under `$XDG_DATA_HOME/openxlr/yabridge` (default `~/.local/share/openxlr/yabridge`).
+- `native-editors.json`: native editor compatibility overrides. Format
+  `{"version":1,"overrides":[{"kind":"vst3","plugin":"<class-id>","name":"Plugin name","blocked":true}]}`.
+  Release defaults are not copied into this file. Remove an override through
+  `setNativeEditorRule` with null `blocked` to follow release defaults again.
 - `ui.json`: window preferences (tray, start minimized, autostart
   toggles)
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -75,6 +75,13 @@ return `pluginInstall` and refresh the catalogue. Wine-installed and linked
 files cannot be deleted through this API; use the Windows uninstaller in the
 appropriate Wine prefix.
 
+`getNativeEditorRules` and `setNativeEditorRule` use the same command endpoint.
+The setter takes `kind`, `plugin`, optional `name`, and `blocked`: true forces
+OpenXLR controls, false allows the native editor, and null/absent restores the
+release default. It returns `nativeEditorRules` after saving. This changes only
+editor availability, not audio processing or insert chains. `showInsertUi`
+rejects blocked editors over HTTP just as it does over WebSocket.
+
 The [OpenAPI document](openapi-v1.json) describes the HTTP endpoints. Restarting
 the daemon rotates its per-session token once the new instance listens;
 clients must reread it.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -267,6 +267,33 @@ plugin. A plugin's own editor can be opened as well, with the native
 host described in 3.12. CLAP and VST3 plugins appear in the same picker
 and always run in that host. VST2 plugins cannot be loaded.
 
+<a name="native-editor-compatibility"></a>
+**Native editor compatibility.** Open Options, PLUGINS, then "Native editors"
+to choose plugins that should use OpenXLR's generated controls instead of their
+own editor. The initial release list includes Elgato De-Esser because its
+native editor freezes under Wine.
+
+- Find an installed plugin and press "Use OpenXLR controls" to add a block.
+- Select a blocked entry and choose "Allow native editor" to try its own
+  window again, for example after a Wine or plugin update.
+- "Use release default" removes your override. Untouched entries follow the
+  list shipped with each OpenXLR release, so a plugin can be unblocked when
+  its editor has been verified to work. Your explicit choices always win.
+
+A blocked plugin keeps processing audio in the same host. Its cog opens the
+OpenXLR controls, and the Plugin UI button is unavailable. A "Native editors"
+button after Bypass opens the compatibility list with that plugin selected.
+The rule takes effect on the next open; an existing native window is not forcibly closed.
+Changes are saved immediately without an audio restart. Allowed overrides
+remain listed so you can return them to release defaults later.
+
+Rules identify plugins by format and stable id, so moving or renaming a file
+does not bypass a rule. Only your overrides are stored in
+`~/.config/openxlr/native-editors.json`, honoring `XDG_CONFIG_HOME`. If that
+file is damaged, Options reports it and keeps the release defaults in force
+rather than overwriting it. Repair or remove the file and restart the daemon
+to reload it.
+
 <a name="install-plugins"></a>
 **Installing plugins.** The quickest set comes from your distribution:
 on Arch, `lsp-plugins-lv2` and `x42-plugins` cover the microphone path

--- a/src/OpenXLR.Core/Mixing/Inserts.cs
+++ b/src/OpenXLR.Core/Mixing/Inserts.cs
@@ -37,7 +37,11 @@ public sealed record InsertDefinition
 /// <summary>An insert as pushed to clients: its definition plus live status.</summary>
 public sealed record InsertStatus(InsertDefinition Insert, string? Error,
     IReadOnlyDictionary<string, double>? Meters = null,
-    bool NativeHostRunning = false);
+    bool NativeHostRunning = false)
+{
+    public bool NativeUiBlocked { get; init; }
+    public string? NativeUiBlockReason { get; init; }
+}
 
 /// <summary>A control port of a plugin, enough to build a sensible slider.</summary>
 public sealed record PluginParam(
@@ -69,6 +73,8 @@ public sealed record PluginInfo(
 
     public bool Supported => UnsupportedFeatures.Count == 0;
     public bool HasNativeUi { get; init; }
+    /// <summary>Editor compatibility only; never changes whether the plugin can process audio.</summary>
+    public bool NativeUiBlocked { get; init; }
 
     /// <summary>CLAP and VST3: the bundle the plugin is loaded from. Null for LV2, which lilv locates.</summary>
     public string? Path { get; init; }

--- a/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
+++ b/src/OpenXLR.Core/Mixing/Lv2Catalog.cs
@@ -139,7 +139,7 @@ public static class Lv2Catalog
     /// will read.
     /// </summary>
     internal static int Footprint(PluginInfo p)
-        => 220 + p.Plugin.Length + p.Name.Length + p.Category.Length
+        => 252 + p.Plugin.Length + p.Name.Length + p.Category.Length
            + p.Params.Sum(q => 152 + q.Symbol.Length + q.Name.Length + q.ScalePoints.Sum(sp => 24 + sp.Label.Length))
            + p.RequiredFeatures.Sum(f => f.Length + 4) + (p.InputSymbols.Count + p.OutputSymbols.Count) * 16;
 

--- a/src/OpenXLR.Core/Mixing/Mixer.cs
+++ b/src/OpenXLR.Core/Mixing/Mixer.cs
@@ -841,11 +841,14 @@ public sealed partial class Mixer : IDisposable, ILayoutInfo
     }
 
     /// <summary>Capture the host under the mixer lock, then open its UI outside it.</summary>
-    public void ShowInsertUi(string channel, string insertId)
+    public void ShowInsertUi(string channel, string insertId, Func<InsertDefinition, string?>? editorError = null)
     {
         NativePluginHost? host;
         lock (_gate)
         {
+            InsertDefinition? insert = InsertsFor(channel).FirstOrDefault(i => i.Id == insertId);
+            if (insert is not null && editorError?.Invoke(insert) is string reason)
+                throw new InvalidOperationException($"Native editor disabled: {reason}");
             host = _chains.GetValueOrDefault(channel)?.InsertStages
                 .FirstOrDefault(stage => stage.Id == insertId).Stage?.NativeHost;
             if (host is null)

--- a/src/OpenXLR.Core/Mixing/NativeEditorPolicy.cs
+++ b/src/OpenXLR.Core/Mixing/NativeEditorPolicy.cs
@@ -1,0 +1,296 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenXLR.Core.Mixing;
+
+/// <summary>
+/// One plugin whose own editor window OpenXLR does not open. Kind and plugin
+/// are the plugin's identity, the same pair inserts and the catalogue use, so
+/// a rule follows the plugin wherever its files are installed.
+/// </summary>
+public sealed record NativeEditorRule(string Kind, string Plugin, string Name, string Reason);
+
+/// <summary>
+/// One rule as the Options list shows it: what this release ships, what the
+/// user chose, and what the two add up to. Override is null while the user
+/// has made no choice, so the entry follows the release default.
+/// </summary>
+public sealed record NativeEditorRuleState(string Kind, string Plugin, string Name, string Reason,
+    bool DefaultBlocked, bool? Override, bool Blocked);
+
+/// <summary>
+/// Which plugins run without their own editor. A few plugins bring an editor
+/// that hangs or crashes under the bridge while their audio side is fine, so
+/// the insert keeps processing and the user gets the OpenXLR generated
+/// controls instead of the plugin's window.
+///
+/// The list of known cases ships with the release. The file under the
+/// configuration directory holds only what the user decided, never a copy of
+/// the release list, so an OpenXLR that adds or drops a case changes what the
+/// user did not touch and leaves every choice they made alone.
+///
+/// Reads take no lock and touch no disk: the overrides are an immutable map
+/// replaced whole, since IsBlocked is asked once per editor request and from
+/// several threads. A write goes to disk first and is only adopted when the
+/// file is on disk, so a failed save leaves the running policy as it was.
+///
+/// This decides editor windows only. Nothing here changes whether a plugin is
+/// supported, whether it runs in the native host, or how it is processed.
+/// </summary>
+public sealed class NativeEditorPolicy
+{
+    /// <summary>Why an entry the user added by hand is blocked.</summary>
+    public const string ChosenReason = "You turned this editor off in Options.";
+
+    /// <summary>
+    /// What a blocked entry says when its own rule carries no usable text, so
+    /// a caller asking why an editor stayed closed always has something to
+    /// show the user.
+    /// </summary>
+    public const string UnstatedReason = "This editor is known not to work here; the OpenXLR controls do.";
+
+    private const int CurrentVersion = 1;
+    private const int MaxPluginLength = 512;
+    private const int MaxNameLength = 200;
+    private const int MaxReasonLength = 400;
+    private const int MaxOverrides = 1024;
+    private const long MaxFileBytes = 1024 * 1024;
+
+    /// <summary>
+    /// The known cases this release ships. Every entry is blocked unless the
+    /// user says otherwise.
+    /// </summary>
+    public static IReadOnlyList<NativeEditorRule> Curated { get; } =
+    [
+        new("vst3", "ABCDEF019182FAEB4D616E75466C7665", "Elgato De-Esser",
+            "Its native editor freezes under Wine; the OpenXLR controls work."),
+    ];
+
+    /// <summary>~/.config/openxlr/native-editors.json, honouring XDG_CONFIG_HOME.</summary>
+    public static string DefaultPath => OpenXlrPaths.ConfigFile("native-editors.json");
+
+    private readonly string _path;
+    private readonly IReadOnlyList<NativeEditorRule> _defaults;
+    private readonly Dictionary<(string Kind, string Plugin), NativeEditorRule> _byIdentity;
+    private readonly object _gate = new();
+    private readonly string? _error;
+    private volatile IReadOnlyDictionary<(string Kind, string Plugin), Choice> _overrides;
+
+    /// <summary>
+    /// Read the user's choices for this release's list. A missing file is the
+    /// normal first run; a file that cannot be read or was written by another
+    /// version leaves Error set and the release list in force.
+    /// </summary>
+    public NativeEditorPolicy(string? path = null, IReadOnlyList<NativeEditorRule>? defaults = null)
+    {
+        _path = string.IsNullOrWhiteSpace(path) ? DefaultPath : path;
+        var normalized = new List<NativeEditorRule>();
+        _byIdentity = new();
+        foreach (NativeEditorRule rule in defaults ?? Curated)
+        {
+            if (Normalize(rule.Kind, rule.Plugin, rule.Name, out string kind, out string plugin, out string? name) is string problem)
+                throw new ArgumentException($"Built-in native editor rule is not usable: {problem}", nameof(defaults));
+            // A blocked entry must always be able to say why, so a rule with
+            // no usable text of its own borrows the general one.
+            string reason = (rule.Reason ?? string.Empty).Trim();
+            if (reason.Length == 0 || reason.Length > MaxReasonLength || reason.Any(char.IsControl)) reason = UnstatedReason;
+            var clean = rule with { Kind = kind, Plugin = plugin, Name = name ?? plugin, Reason = reason };
+            if (!_byIdentity.TryAdd((kind, plugin), clean))
+                throw new ArgumentException($"Built-in native editor rules name {kind} {plugin} twice.", nameof(defaults));
+            normalized.Add(clean);
+        }
+        _defaults = normalized;
+        (_overrides, _error) = Load(_path);
+    }
+
+    /// <summary>What is wrong with the stored file, or null when it read cleanly.</summary>
+    public string? Error => _error;
+
+    /// <summary>
+    /// Every rule the Options list shows: this release's cases in their order,
+    /// then the plugins the user named that the release does not know about.
+    /// </summary>
+    public IReadOnlyList<NativeEditorRuleState> Rules
+    {
+        get
+        {
+            IReadOnlyDictionary<(string Kind, string Plugin), Choice> overrides = _overrides;
+            var rules = new List<NativeEditorRuleState>();
+            foreach (NativeEditorRule rule in _defaults)
+            {
+                bool? choice = overrides.TryGetValue((rule.Kind, rule.Plugin), out Choice? entry) ? entry.Blocked : null;
+                rules.Add(new(rule.Kind, rule.Plugin, rule.Name, rule.Reason, true, choice, choice ?? true));
+            }
+            foreach (KeyValuePair<(string Kind, string Plugin), Choice> pair in overrides
+                .Where(p => !_byIdentity.ContainsKey(p.Key))
+                .OrderBy(p => p.Key.Kind, StringComparer.Ordinal)
+                .ThenBy(p => p.Key.Plugin, StringComparer.Ordinal))
+                rules.Add(new(pair.Key.Kind, pair.Key.Plugin, pair.Value.Name ?? pair.Key.Plugin,
+                    pair.Value.Blocked ? ChosenReason : "You allowed this native editor in Options.",
+                    false, pair.Value.Blocked, pair.Value.Blocked));
+            return rules;
+        }
+    }
+
+    /// <summary>Whether this plugin's own editor stays closed. No disk access.</summary>
+    public bool IsBlocked(string? kind, string? plugin) => Decide(kind, plugin).Blocked;
+
+    /// <summary>Why the editor stays closed, or null when it may open.</summary>
+    public string? BlockReason(string? kind, string? plugin)
+    {
+        (bool blocked, string? reason) = Decide(kind, plugin);
+        return blocked ? reason : null;
+    }
+
+    /// <summary>
+    /// Record the user's choice for one plugin: true blocks its editor, false
+    /// allows it, null drops the choice so the plugin follows this release's
+    /// list again. The file is written before the change takes effect, so a
+    /// returned message means nothing changed, in memory or on disk.
+    /// </summary>
+    public string? Set(string kind, string plugin, string? name, bool? blocked)
+    {
+        if (Normalize(kind, plugin, name, out string cleanKind, out string cleanPlugin, out string? cleanName) is string problem)
+            return problem;
+        lock (_gate)
+        {
+            if (_error is not null) return _error;
+            var next = new Dictionary<(string Kind, string Plugin), Choice>(_overrides);
+            var identity = (cleanKind, cleanPlugin);
+            if (blocked is bool choice)
+            {
+                next.TryGetValue(identity, out Choice? current);
+                if (current is null && next.Count >= MaxOverrides) return $"At most {MaxOverrides} native-editor overrides can be stored.";
+                var entry = new Choice(choice, cleanName ?? current?.Name ?? _byIdentity.GetValueOrDefault(identity)?.Name);
+                if (entry == current) return null;
+                next[identity] = entry;
+            }
+            else if (!next.Remove(identity)) return null;
+            if (Write(next) is string failure) return failure;
+            _overrides = next;
+            return null;
+        }
+    }
+
+    private (bool Blocked, string? Reason) Decide(string? kind, string? plugin)
+    {
+        if (Normalize(kind, plugin, null, out string cleanKind, out string cleanPlugin, out _) is not null) return (false, null);
+        var identity = (cleanKind, cleanPlugin);
+        bool known = _byIdentity.TryGetValue(identity, out NativeEditorRule? rule);
+        if (_overrides.TryGetValue(identity, out Choice? entry))
+            return (entry.Blocked, known ? rule!.Reason : ChosenReason);
+        return known ? (true, rule!.Reason) : (false, null);
+    }
+
+    private string? Write(IReadOnlyDictionary<(string Kind, string Plugin), Choice> overrides)
+    {
+        var file = new StoredFile(CurrentVersion,
+        [
+            .. overrides
+                .OrderBy(p => p.Key.Kind, StringComparer.Ordinal)
+                .ThenBy(p => p.Key.Plugin, StringComparer.Ordinal)
+                .Select(p => new StoredChoice(p.Key.Kind, p.Key.Plugin, p.Value.Name, p.Value.Blocked))
+        ]);
+        try
+        {
+            string text = JsonSerializer.Serialize(file, Json);
+            if (System.Text.Encoding.UTF8.GetByteCount(text) > MaxFileBytes)
+                return "The native-editor overrides file would be too large. Remove unused overrides first.";
+            OpenXlrPaths.WriteAtomic(_path, text);
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return $"{_path}: {ex.Message}";
+        }
+    }
+
+    private static (IReadOnlyDictionary<(string Kind, string Plugin), Choice> Overrides, string? Error) Load(string path)
+    {
+        var empty = new Dictionary<(string Kind, string Plugin), Choice>();
+        string text;
+        try
+        {
+            if (Directory.Exists(path)) return (empty, Damaged(path, "the path is a directory"));
+            if (!File.Exists(path)) return (empty, null);
+            if (new FileInfo(path).Length > MaxFileBytes) return (empty, Damaged(path, "the file is too large"));
+            text = File.ReadAllText(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return (empty, Damaged(path, ex.Message));
+        }
+
+        StoredFile? file;
+        try { file = JsonSerializer.Deserialize<StoredFile>(text, Json); }
+        catch (JsonException ex) { return (empty, Damaged(path, ex.Message)); }
+        if (file is null) return (empty, Damaged(path, "it holds nothing"));
+        if (file.Version != CurrentVersion)
+            return (empty, Damaged(path, $"it was written by another version of OpenXLR (format {file.Version})"));
+
+        if (file.Overrides is null || file.Overrides.Count > MaxOverrides)
+            return (empty, Damaged(path, "the overrides list is missing or too large"));
+        var overrides = new Dictionary<(string Kind, string Plugin), Choice>();
+        foreach (StoredChoice entry in file.Overrides)
+        {
+            if (entry is null || entry.Blocked is null) return (empty, Damaged(path, "an override is missing its decision"));
+            if (Normalize(entry.Kind, entry.Plugin, entry.Name, out string kind, out string plugin, out string? name) is string problem)
+                return (empty, Damaged(path, problem));
+            if (!overrides.TryAdd((kind, plugin), new Choice(entry.Blocked.Value, name)))
+                return (empty, Damaged(path, $"it names {kind} {plugin} twice"));
+        }
+        return (overrides, null);
+    }
+
+    private static string Damaged(string path, string detail)
+        => $"{path} could not be read ({detail}). It was left untouched; repair or remove it, then restart the daemon. The release defaults are in use.";
+
+    /// <summary>
+    /// Check one identity and put it in the form the policy keys on: a known
+    /// kind, a VST3 class id as 32 upper case hex digits, an id and a name
+    /// that are bounded plain text. Returns null when the input is usable.
+    /// </summary>
+    private static string? Normalize(string? kind, string? plugin, string? name,
+        out string cleanKind, out string cleanPlugin, out string? cleanName)
+    {
+        cleanKind = (kind ?? string.Empty).Trim().ToLowerInvariant();
+        cleanPlugin = (plugin ?? string.Empty).Trim();
+        cleanName = string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+
+        if (kind?.Any(char.IsControl) == true || plugin?.Any(char.IsControl) == true || name?.Any(char.IsControl) == true
+            || (plugin?.Length ?? 0) > MaxPluginLength)
+            return "Plugin identities and names must be bounded plain text without control characters.";
+        if (cleanKind is not ("lv2" or "clap" or "vst3"))
+            return $"\"{kind}\" is not a plugin kind OpenXLR knows (lv2, clap or vst3).";
+        if (cleanName is not null && (cleanName.Length > MaxNameLength || cleanName.Any(char.IsControl)))
+            return $"A plugin name must be plain text of at most {MaxNameLength} characters.";
+
+        if (cleanKind == "vst3")
+        {
+            string id = string.Concat(cleanPlugin.Where(c => c is not ('-' or '{' or '}')));
+            if (id.Length != 32 || !id.All(Uri.IsHexDigit))
+                return "A VST3 plugin is named by its class id, 32 hexadecimal digits.";
+            cleanPlugin = id.ToUpperInvariant();
+            return null;
+        }
+        if (cleanPlugin.Length == 0 || cleanPlugin.Length > MaxPluginLength
+            || cleanPlugin.Any(c => char.IsControl(c) || char.IsWhiteSpace(c)))
+            return $"A plugin id must be plain text without spaces, of at most {MaxPluginLength} characters.";
+        return null;
+    }
+
+    /// <summary>One user decision: blocked or allowed, with a name to show it by.</summary>
+    private sealed record Choice(bool Blocked, string? Name);
+
+    private sealed record StoredChoice(string Kind, string Plugin, string? Name, bool? Blocked);
+
+    private sealed record StoredFile(int Version, IReadOnlyList<StoredChoice>? Overrides);
+
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}

--- a/src/OpenXLR.Daemon/CommandValidation.cs
+++ b/src/OpenXLR.Daemon/CommandValidation.cs
@@ -24,6 +24,10 @@ public static class CommandValidation
     {
         switch (cmd.Cmd)
         {
+            case "getNativeEditorRules":
+                return null;
+            case "setNativeEditorRule":
+                return CheckEditorRule(cmd);
             case "addWindowsPluginFolder":
             case "removeWindowsPluginFolder":
             case "getWindowsPluginFiles":
@@ -137,6 +141,13 @@ public static class CommandValidation
                 return null;   // the service knows the rest, or reports the command as unknown
         }
     }
+
+    internal static string? CheckEditorRule(Command cmd)
+        => cmd.Kind is not ("lv2" or "clap" or "vst3") || string.IsNullOrWhiteSpace(cmd.Plugin)
+           || cmd.Plugin.Length > MaxUri || cmd.Plugin.Any(char.IsControl)
+           || cmd.Name is { Length: > 200 } || cmd.Name?.Any(char.IsControl) == true
+            ? "setNativeEditorRule: need a valid kind, plugin id and optional name"
+            : null;
 
     internal static string? CheckPluginPath(Command cmd)
         => string.IsNullOrWhiteSpace(cmd.Path) || cmd.Path.Length > 4096

--- a/src/OpenXLR.Daemon/MixerService.cs
+++ b/src/OpenXLR.Daemon/MixerService.cs
@@ -48,14 +48,16 @@ public sealed class MixerService : IHostedService, IDisposable
     /// mixer over the user's file.
     /// </summary>
     private readonly SettingsSaver _saves;
+    public NativeEditorPolicy EditorPolicy { get; }
 
     public MixerService(ILogger<MixerService> log, IConfiguration config, DeviceManager devices,
-        IHostApplicationLifetime? lifetime = null)
+        IHostApplicationLifetime? lifetime = null, NativeEditorPolicy? editorPolicy = null)
     {
         _log = log;
         _config = config;
         _devices = devices;
         _lifetime = lifetime;
+        EditorPolicy = editorPolicy ?? new NativeEditorPolicy();
         _mixer = new(new PipeWireAdapter(_progress.Mark, note => _log.LogInformation("{msg}", note)));
         _saves = new SettingsSaver(
             () => _mixer.ExportSettings().Save(),
@@ -147,7 +149,20 @@ public sealed class MixerService : IHostedService, IDisposable
     public event Action? Changed;
 
     /// <summary>Null until the graph is built.</summary>
-    public MixerState? Snapshot() => _mixer.Built ? _mixer.Snapshot() with { LayoutWarning = ResourceWarning } : null;
+    public MixerState? Snapshot()
+    {
+        if (!_mixer.Built) return null;
+        MixerState state = _mixer.Snapshot();
+        return state with
+        {
+            LayoutWarning = ResourceWarning,
+            Inserts = state.Inserts.ToDictionary(e => e.Key, e => (IReadOnlyList<InsertStatus>)e.Value.Select(insert =>
+            {
+                string? reason = EditorPolicy.BlockReason(insert.Insert.Kind, insert.Insert.Plugin);
+                return insert with { NativeUiBlocked = reason is not null, NativeUiBlockReason = reason };
+            }).ToArray()),
+        };
+    }
 
     /// <summary>Selectable sinks and sources, or null when the mixer is off.</summary>
     public IReadOnlyList<AudioNode>? Devices() => _mixer.Built ? _mixer.ListDevices() : null;
@@ -479,7 +494,7 @@ public sealed class MixerService : IHostedService, IDisposable
                     break;
                 case "showInsertUi":
                     if (cmd.Channel is null || cmd.InsertId is null) return "showInsertUi: need 'channel' and 'insertId'";
-                    _mixer.ShowInsertUi(cmd.Channel, cmd.InsertId);
+                    _mixer.ShowInsertUi(cmd.Channel, cmd.InsertId, insert => EditorPolicy.BlockReason(insert.Kind, insert.Plugin));
                     return null;
                 default:
                     return $"unknown mixer command '{cmd.Cmd}'";

--- a/src/OpenXLR.Daemon/Protocol.cs
+++ b/src/OpenXLR.Daemon/Protocol.cs
@@ -82,6 +82,24 @@ public sealed record Command
 
     /// <summary>Plugin installs and folder management: the file or directory the user picked, absolute.</summary>
     [JsonPropertyName("path")] public string? Path { get; init; }
+
+    /// <summary>Native-editor compatibility rules identify a plugin by format and stable id.</summary>
+    [JsonPropertyName("kind")] public string? Kind { get; init; }
+    [JsonPropertyName("plugin")] public string? Plugin { get; init; }
+    /// <summary>True blocks the editor, false allows it, null follows the release default.</summary>
+    [JsonPropertyName("blocked")] public bool? Blocked { get; init; }
+}
+
+public sealed record NativeEditorRulesMessage(
+    [property: JsonPropertyName("rules")] IReadOnlyList<NativeEditorRuleState> Rules,
+    [property: JsonPropertyName("error")] string? Error)
+{
+    [JsonPropertyName("type")] public string Type => "nativeEditorRules";
+}
+
+public sealed record NativeEditorRulesChangedMessage
+{
+    [JsonPropertyName("type")] public string Type => "nativeEditorRulesChanged";
 }
 
 /// <summary>Reply to "getPluginSetup": where plugins go and what bridges Windows ones.</summary>

--- a/src/OpenXLR.Daemon/WebSocketHub.cs
+++ b/src/OpenXLR.Daemon/WebSocketHub.cs
@@ -199,7 +199,24 @@ public sealed class WebSocketHub
                 IReadOnlyList<OpenXLR.Core.Mixing.PluginInfo> plugins =
                     await Task.Run(() => OpenXLR.Core.Mixing.ClientCatalog.ForClient(
                         OpenXLR.Core.Mixing.PluginCatalog.Plugins, _mixer.InsertPlugins()));
-                await reply(new PluginsMessage(plugins));
+                await reply(new PluginsMessage(plugins.Select(p => p with
+                {
+                    NativeUiBlocked = _mixer.EditorPolicy.IsBlocked(p.Kind, p.Plugin),
+                }).ToArray()));
+                break;
+            case "getNativeEditorRules":
+                await reply(new NativeEditorRulesMessage(_mixer.EditorPolicy.Rules, _mixer.EditorPolicy.Error));
+                break;
+            case "setNativeEditorRule":
+                error = CommandValidation.CheckEditorRule(cmd);
+                if (error is not null) break;
+                error = _mixer.EditorPolicy.Set(cmd.Kind!, cmd.Plugin!, cmd.Name, cmd.Blocked);
+                if (error is null)
+                {
+                    Broadcast(new NativeEditorRulesChangedMessage());
+                    Broadcast(Snapshot());
+                }
+                await reply(new NativeEditorRulesMessage(_mixer.EditorPolicy.Rules, error ?? _mixer.EditorPolicy.Error));
                 break;
             case "getPluginDiagnostics":
                 await reply(new PluginDiagnosticsMessage(await Task.Run(() => new OpenXLR.Core.Mixing.PluginInstaller().Diagnostics())));

--- a/src/OpenXLR.Tests/DaemonClientTests.cs
+++ b/src/OpenXLR.Tests/DaemonClientTests.cs
@@ -235,6 +235,36 @@ public sealed class DaemonClientTests
         Assert.Equal(2, requests);
     }
 
+    [Fact]
+    public async Task EditorRuleOverridesAndDefaultResetHaveDistinctWireValues()
+    {
+        await using var server = await SocketTestServer.Start(async (socket, stop) =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                var command = await SocketTestServer.Receive(socket, stop);
+                if (command["cmd"]!.GetValue<string>() == "auth") continue;
+                Assert.Equal("setNativeEditorRule", command["cmd"]!.GetValue<string>());
+                bool blocked = command["blocked"]?.GetValue<bool>() ?? true;
+                await SocketTestServer.Send(socket, new { type = "nativeEditorRulesChanged" }, stop);
+                await SocketTestServer.Send(socket, new { type = "nativeEditorRules", rules = new[] { new { blocked } } }, stop);
+                await SocketTestServer.Send(socket, new { type = "commandResult", requestId = command["requestId"]!.GetValue<string>() }, stop);
+            }
+        });
+        await using var client = new DaemonClient(server.Url);
+        int changed = 0;
+        client.NativeEditorRulesChanged += () => changed++;
+        var connected = Completion();
+        client.ConnectionChanged += up => { if (up) connected.TrySetResult(); };
+        client.Start();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var allow = await client.SetNativeEditorRuleAsync("clap", "example", "Example", false, TimeSpan.FromSeconds(5));
+        Assert.False(allow!["rules"]![0]!["blocked"]!.GetValue<bool>());
+        var reset = await client.SetNativeEditorRuleAsync("clap", "example", "Example", null, TimeSpan.FromSeconds(5));
+        Assert.True(reset!["rules"]![0]!["blocked"]!.GetValue<bool>());
+        Assert.Equal(2, changed);
+    }
+
     private static TaskCompletionSource Completion()
         => new(TaskCreationOptions.RunContinuationsAsynchronously);
 }

--- a/src/OpenXLR.Tests/HttpApiTests.cs
+++ b/src/OpenXLR.Tests/HttpApiTests.cs
@@ -43,6 +43,8 @@ public sealed class HttpApiTests
         builder.Services.AddSingleton<DeviceManager>();
         builder.Services.AddSingleton<MixerService>();
         builder.Services.AddSingleton<WebSocketHub>();
+        string policyDirectory = Path.Combine(Path.GetTempPath(), "openxlr-editor-policy-api-" + Guid.NewGuid());
+        builder.Services.AddSingleton(new OpenXLR.Core.Mixing.NativeEditorPolicy(Path.Combine(policyDirectory, "rules.json")));
         await using var app = builder.Build();
         app.UseWebSockets();
         // The endpoints read the daemon's live token per request; publish one
@@ -105,6 +107,18 @@ public sealed class HttpApiTests
                 Assert.Equal(HttpStatusCode.BadRequest, folder.StatusCode);
                 Assert.Contains("absolute path", await folder.Content.ReadAsStringAsync());
             }
+            const string deEsser = "ABCDEF019182FAEB4D616E75466C7665";
+            foreach (bool? blocked in new bool?[] { false, null })
+            {
+                using var rule = await http.PostAsync("/api/v1/commands", new StringContent(
+                    System.Text.Json.JsonSerializer.Serialize(new { cmd = "setNativeEditorRule", kind = "vst3", plugin = deEsser, name = "Elgato De-Esser", blocked }),
+                    Encoding.UTF8, "application/json"));
+                Assert.Equal(HttpStatusCode.OK, rule.StatusCode);
+                using var policy = System.Text.Json.JsonDocument.Parse(await rule.Content.ReadAsStringAsync());
+                var rules = policy.RootElement.GetProperty("messages")[0];
+                Assert.Equal("nativeEditorRules", rules.GetProperty("type").GetString());
+                Assert.Equal(blocked ?? true, rules.GetProperty("rules")[0].GetProperty("blocked").GetBoolean());
+            }
             using var pluginDiagnostics = await http.PostAsync("/api/v1/commands",
                 new StringContent("{\"cmd\":\"getPluginDiagnostics\"}", Encoding.UTF8, "application/json"));
             Assert.Equal(HttpStatusCode.OK, pluginDiagnostics.StatusCode);
@@ -114,6 +128,10 @@ public sealed class HttpApiTests
             Assert.True(discovery.GetProperty("discovery").TryGetProperty("searchPaths", out _));
             Assert.True(discovery.GetProperty("discovery").TryGetProperty("scans", out _));
         }
-        finally { await app.StopAsync(); }
+        finally
+        {
+            await app.StopAsync();
+            if (Directory.Exists(policyDirectory)) Directory.Delete(policyDirectory, recursive: true);
+        }
     }
 }

--- a/src/OpenXLR.Tests/NativeEditorCompatibilityTests.cs
+++ b/src/OpenXLR.Tests/NativeEditorCompatibilityTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json.Nodes;
+using OpenXLR.Core.Mixing;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+public sealed class NativeEditorCompatibilityTests
+{
+    private const string DeEsser = "ABCDEF019182FAEB4D616E75466C7665";
+
+    [Fact]
+    public void BlockingTheEditorKeepsNativeProcessingAndGeneratedControlsAvailable()
+    {
+        var owner = new InsertsViewModel(new DaemonClient(), "mix:monitor", 2);
+        owner.PluginChoices.Add(new(DeEsser, "Elgato De-Esser", "Dynamics", new JsonArray(), true, true, "vst3", true));
+        owner.Apply(JsonNode.Parse($$"""
+            [{"insert":{"id":"de","kind":"vst3","plugin":"{{DeEsser}}","nativeHost":true,"bypass":false},
+              "nativeHostRunning":true,"nativeUiBlocked":true,"nativeUiBlockReason":"Use OpenXLR controls."}]
+            """));
+        var insert = Assert.Single(owner.Items);
+        Assert.True(insert.NativeHost);
+        Assert.True(insert.NativeHostRunning);
+        Assert.True(insert.NativeHostInstalled);
+        Assert.True(insert.NativeEditorSupported);
+        Assert.True(insert.IsActive);
+        Assert.True(insert.CanTurnNativeHostOn);
+        Assert.False(insert.NativeEditorAvailable);
+        Assert.True(insert.NativeUiBlocked);
+        Assert.Equal("Use OpenXLR controls.", insert.NativeUiBlockReason);
+        Assert.Equal("Open this plugin's controls", insert.ControlsHint);
+
+        owner.PluginChoices.Clear();
+        owner.PluginChoices.Add(new(DeEsser, "Elgato De-Esser", "Dynamics", new JsonArray(), true, true, "vst3"));
+        insert.ApplyFromDaemon(JsonNode.Parse("""{"nativeHost":true,"bypass":false}""")!, null, true);
+        Assert.False(insert.NativeUiBlocked);
+        Assert.True(insert.NativeEditorAvailable);
+        Assert.Equal("Open this plugin's own editor", insert.ControlsHint);
+    }
+
+    [Fact]
+    public void StatePolicyWorksBeforeTheCatalogueArrives()
+    {
+        var owner = new InsertsViewModel(new DaemonClient(), "mix:monitor", 2);
+        var insert = new InsertViewModel(owner, "de", DeEsser, "De-Esser", "vst3");
+        insert.ApplyFromDaemon(JsonNode.Parse("""{"nativeHost":true,"bypass":false}""")!, null, true, true, "Known editor issue.");
+        Assert.True(insert.NativeUiBlocked);
+        Assert.False(insert.NativeEditorAvailable);
+        Assert.True(insert.NativeHostRunning);
+        Assert.False(insert.HasError);
+    }
+
+    [Fact]
+    public void DaemonEditorGateRunsBeforeOpeningAHostAndLeavesTheChainUntouched()
+    {
+        var mixer = new Mixer();
+        mixer.SetInserts("mix:monitor", [new() { Id = "de", Kind = "vst3", Plugin = DeEsser, NativeHost = true }]);
+        var error = Assert.Throws<InvalidOperationException>(() => mixer.ShowInsertUi("mix:monitor", "de", _ => "Use OpenXLR controls."));
+        Assert.Contains("Native editor disabled", error.Message);
+        Assert.Equal(new[] { ("vst3", DeEsser) }, mixer.InsertPlugins());
+    }
+
+    [Fact]
+    public void EditorPolicyMetadataDoesNotChangeHostFeatureSupport()
+    {
+        var plugin = new PluginInfo("vst3", DeEsser, "De-Esser", "Dynamics", 2, 2, "in", "out", [], [], [], [])
+        { HasNativeUi = true, NativeUiBlocked = true };
+        Assert.True(plugin.Supported);
+        Assert.True(plugin.NativeEditorSupported);
+        Assert.Equal((plugin with { NativeUiBlocked = false }).NativeEditorAvailable, plugin.NativeEditorAvailable);
+    }
+}

--- a/src/OpenXLR.Tests/NativeEditorPolicyTests.cs
+++ b/src/OpenXLR.Tests/NativeEditorPolicyTests.cs
@@ -1,0 +1,374 @@
+using System.Text.Json;
+using OpenXLR.Core;
+using OpenXLR.Core.Mixing;
+
+namespace OpenXLR.Tests;
+
+/// <summary>
+/// The list of plugins whose own editor stays closed, and the user's choices
+/// over it. Every test works on its own file in a temporary directory, so
+/// nothing here reads or writes the real configuration.
+/// </summary>
+public sealed class NativeEditorPolicyTests
+{
+    private const string DeEsser = "ABCDEF019182FAEB4D616E75466C7665";
+
+    private static readonly IReadOnlyList<NativeEditorRule> Sample =
+    [
+        new("vst3", DeEsser, "Elgato De-Esser", "Its editor freezes under Wine."),
+        new("clap", "com.example.wobble", "Wobble", "Its editor crashes the host."),
+    ];
+
+    [Fact]
+    public void TheReleaseListBlocksTheDeEsserEditorAndNothingElse()
+    {
+        Run(directory =>
+        {
+            var policy = new NativeEditorPolicy(Path.Combine(directory, "native-editors.json"));
+            Assert.Null(policy.Error);
+            Assert.True(policy.IsBlocked("vst3", DeEsser));
+            string? reason = policy.BlockReason("vst3", DeEsser);
+            Assert.NotNull(reason);
+            Assert.Contains("Wine", reason);
+
+            // The only shipped entry, blocked by default and untouched.
+            NativeEditorRuleState rule = Assert.Single(policy.Rules);
+            Assert.Equal("vst3", rule.Kind);
+            Assert.Equal(DeEsser, rule.Plugin);
+            Assert.Equal("Elgato De-Esser", rule.Name);
+            Assert.True(rule.DefaultBlocked);
+            Assert.False(rule.Override.HasValue);
+            Assert.True(rule.Blocked);
+
+            // Every other plugin keeps its own editor.
+            Assert.False(policy.IsBlocked("vst3", "0123456789ABCDEF0123456789ABCDEF"));
+            Assert.False(policy.IsBlocked("clap", "com.example.other"));
+            Assert.Null(policy.BlockReason("clap", "com.example.other"));
+        });
+    }
+
+    [Fact]
+    public void ARuleIsKeptByKindAndPluginIdNotByNameOrSpelling()
+    {
+        Run(directory =>
+        {
+            var policy = new NativeEditorPolicy(Path.Combine(directory, "native-editors.json"));
+
+            // The same class id however the host spelt it.
+            Assert.True(policy.IsBlocked("vst3", DeEsser.ToLowerInvariant()));
+            Assert.True(policy.IsBlocked("VST3", " abcdef01-9182-faeb-4d61-6e75466c7665 "));
+            Assert.True(policy.IsBlocked("vst3", "{ABCDEF019182FAEB4D616E75466C7665}"));
+
+            // The id belongs to one kind only, and the display name decides nothing.
+            Assert.False(policy.IsBlocked("clap", DeEsser));
+            Assert.False(policy.IsBlocked("lv2", DeEsser));
+            Assert.False(policy.IsBlocked("vst3", "Elgato De-Esser"));
+        });
+    }
+
+    [Fact]
+    public void AllowingAndResettingOneRuleSurvivesAndLeavesTheListAlone()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            var policy = new NativeEditorPolicy(path, Sample);
+
+            Assert.Null(policy.Set("vst3", DeEsser.ToLowerInvariant(), null, false));
+            Assert.False(policy.IsBlocked("vst3", DeEsser));
+            Assert.Null(policy.BlockReason("vst3", DeEsser));
+            Assert.True(policy.IsBlocked("clap", "com.example.wobble"));
+
+            // The choice is on disk, and only the choice.
+            var reopened = new NativeEditorPolicy(path, Sample);
+            Assert.Null(reopened.Error);
+            Assert.False(reopened.IsBlocked("vst3", DeEsser));
+            NativeEditorRuleState allowed = reopened.Rules.Single(r => r.Plugin == DeEsser);
+            Assert.True(allowed.DefaultBlocked);
+            Assert.False(allowed.Override);
+            Assert.False(allowed.Blocked);
+            Assert.Equal(2, reopened.Rules.Count);
+            Assert.Single(Stored(path));
+
+            // Dropping the choice follows the release list again and empties the file.
+            Assert.Null(reopened.Set("vst3", DeEsser, null, null));
+            Assert.True(reopened.IsBlocked("vst3", DeEsser));
+            Assert.Empty(Stored(path));
+            Assert.False(new NativeEditorPolicy(path, Sample).Rules.Single(r => r.Plugin == DeEsser).Override.HasValue);
+        });
+    }
+
+    [Fact]
+    public void APluginTheReleaseDoesNotKnowCanBeBlockedByHand()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            var policy = new NativeEditorPolicy(path, Sample);
+            Assert.Null(policy.Set("lv2", "urn:example:comp", "Example Compressor", true));
+            Assert.True(policy.IsBlocked("lv2", "urn:example:comp"));
+            Assert.Equal(NativeEditorPolicy.ChosenReason, policy.BlockReason("lv2", "urn:example:comp"));
+
+            NativeEditorRuleState added = new NativeEditorPolicy(path, Sample).Rules.Single(r => r.Kind == "lv2");
+            Assert.Equal("urn:example:comp", added.Plugin);
+            Assert.Equal("Example Compressor", added.Name);
+            Assert.False(added.DefaultBlocked);
+            Assert.True(added.Override);
+            Assert.True(added.Blocked);
+        });
+    }
+
+    [Fact]
+    public void ChoicesOutliveEntriesTheReleaseListAddsOrDrops()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            var before = new NativeEditorPolicy(path, Sample);
+            Assert.Null(before.Set("vst3", DeEsser, null, false));                    // allow a shipped entry
+            Assert.Null(before.Set("clap", "com.example.wobble", "Wobble", true));    // agree with another
+            Assert.Null(before.Set("lv2", "urn:example:comp", "Example", true));      // add one of their own
+
+            // A later release drops the CLAP case and adds a new VST3 one.
+            const string added = "00112233445566778899AABBCCDDEEFF";
+            IReadOnlyList<NativeEditorRule> next =
+            [
+                new("vst3", DeEsser, "Elgato De-Esser", "Its editor freezes under Wine."),
+                new("vst3", added, "Newly Known", "Its editor does not repaint."),
+            ];
+            var after = new NativeEditorPolicy(path, next);
+            Assert.Null(after.Error);
+
+            Assert.False(after.IsBlocked("vst3", DeEsser));              // the user's choice survived
+            Assert.True(after.IsBlocked("vst3", added));                 // the new case applies at once
+            Assert.True(after.IsBlocked("lv2", "urn:example:comp"));     // the hand-made entry survived
+            Assert.True(after.IsBlocked("clap", "com.example.wobble"));  // the dropped case is now the user's own
+
+            NativeEditorRuleState dropped = after.Rules.Single(r => r.Kind == "clap");
+            Assert.False(dropped.DefaultBlocked);
+            Assert.True(dropped.Override);
+            Assert.Equal("Wobble", dropped.Name);   // the name captured when the choice was made
+
+            // And a release that knows nothing leaves every choice readable.
+            var bare = new NativeEditorPolicy(path, []);
+            Assert.Equal(3, bare.Rules.Count);
+            Assert.False(bare.IsBlocked("vst3", DeEsser));
+            Assert.All(bare.Rules, r => Assert.False(r.DefaultBlocked));
+        });
+    }
+
+    [Fact]
+    public void AFailedSaveChangesNeitherTheFileNorTheRunningPolicy()
+    {
+        Run(directory =>
+        {
+            // A directory in the file's place: the atomic rename cannot land.
+            string path = Path.Combine(directory, "native-editors.json");
+            var policy = new NativeEditorPolicy(path, Sample);
+            Assert.Null(policy.Error);
+            Directory.CreateDirectory(path);
+
+            string? failure = policy.Set("vst3", DeEsser, null, false);
+            Assert.NotNull(failure);
+            Assert.Contains(path, failure);
+            Assert.True(policy.IsBlocked("vst3", DeEsser));
+            Assert.False(policy.Rules.Single(r => r.Plugin == DeEsser).Override.HasValue);
+            Directory.Delete(path);
+            Assert.Null(policy.Set("vst3", DeEsser, null, false));
+            Assert.False(policy.IsBlocked("vst3", DeEsser));
+        });
+    }
+
+    [Fact]
+    public void UntouchedDefaultsDisappearWhenAReleaseRemovesThem()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            var before = new NativeEditorPolicy(path, Sample);
+            Assert.True(before.IsBlocked("vst3", DeEsser));
+            Assert.False(File.Exists(path));
+            var after = new NativeEditorPolicy(path, []);
+            Assert.False(after.IsBlocked("vst3", DeEsser));
+            Assert.Empty(after.Rules);
+        });
+    }
+
+    [Theory]
+    [InlineData("{\"version\":1,\"overrides\":[null]}")]
+    [InlineData("{\"version\":1,\"overrides\":[{\"kind\":\"clap\",\"plugin\":\"example\"}]}")]
+    [InlineData("{\"version\":1}")]
+    public void IncompleteChoicesCannotSilentlyAllowAnEditor(string contents)
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            File.WriteAllText(path, contents);
+            var policy = new NativeEditorPolicy(path);
+            Assert.NotNull(policy.Error);
+            Assert.True(policy.IsBlocked("vst3", DeEsser));
+            Assert.NotNull(policy.Set("vst3", DeEsser, null, false));
+            Assert.Equal(contents, File.ReadAllText(path));
+        });
+    }
+
+    [Fact]
+    public void ADamagedFileIsReportedAndNeverQuietlyReplaced()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            const string damaged = "{ \"version\": 1, \"overrides\": [ this is not json";
+            File.WriteAllText(path, damaged);
+
+            var policy = new NativeEditorPolicy(path, Sample);
+            string? error = policy.Error;
+            Assert.NotNull(error);
+            Assert.Contains(path, error);
+
+            // The release list still protects the user while the file is broken.
+            Assert.True(policy.IsBlocked("vst3", DeEsser));
+            Assert.Equal(2, policy.Rules.Count);
+            Assert.All(policy.Rules, r => Assert.False(r.Override.HasValue));
+
+            // A change is refused with the same reason, and the file is left alone.
+            Assert.Equal(error, policy.Set("vst3", DeEsser, null, false));
+            Assert.True(policy.IsBlocked("vst3", DeEsser));
+            Assert.Equal(damaged, File.ReadAllText(path));
+        });
+    }
+
+    [Fact]
+    public void AFileFromAnotherFormatOrWithABadEntryIsRefusedTheSameWay()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            string future = "{\"version\":99,\"overrides\":[{\"kind\":\"vst3\",\"plugin\":\"" + DeEsser + "\",\"blocked\":false}]}";
+            File.WriteAllText(path, future);
+            var policy = new NativeEditorPolicy(path, Sample);
+            string? error = policy.Error;
+            Assert.NotNull(error);
+            Assert.Contains("99", error);
+            Assert.True(policy.IsBlocked("vst3", DeEsser));   // the unreadable choice is not guessed at
+            Assert.NotNull(policy.Set("vst3", DeEsser, null, false));
+            Assert.Equal(future, File.ReadAllText(path));
+
+            string nonsense = "{\"version\":1,\"overrides\":[{\"kind\":\"vst2\",\"plugin\":\"x\",\"blocked\":true}]}";
+            File.WriteAllText(path, nonsense);
+            var second = new NativeEditorPolicy(path, Sample);
+            Assert.NotNull(second.Error);
+            Assert.NotNull(second.Set("clap", "com.example.wobble", null, false));
+            Assert.Equal(nonsense, File.ReadAllText(path));
+        });
+    }
+
+    [Fact]
+    public void BadInputIsRejectedWithoutTouchingTheFile()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            var policy = new NativeEditorPolicy(path, Sample);
+
+            Assert.NotNull(policy.Set("vst2", DeEsser, null, true));                       // unknown kind
+            Assert.NotNull(policy.Set("", DeEsser, null, true));
+            Assert.NotNull(policy.Set("vst3", "not-a-class-id", null, true));              // bad class id
+            Assert.NotNull(policy.Set("vst3", DeEsser + "00", null, true));
+            Assert.NotNull(policy.Set("clap", "", null, true));                            // empty id
+            Assert.NotNull(policy.Set("clap", new string('x', 600), null, true));          // unbounded id
+            Assert.NotNull(policy.Set("clap", "com.example\u0007bell", null, true));       // control character
+            Assert.NotNull(policy.Set("clap", "com example", null, true));                 // spaces in an id
+            Assert.NotNull(policy.Set("clap", "com.example.wobble", new string('n', 400), true));
+            Assert.NotNull(policy.Set("clap", "com.example.wobble", "Wob\u0007ble", true));
+
+            Assert.False(File.Exists(path));
+            Assert.Equal(2, policy.Rules.Count);
+            Assert.All(policy.Rules, r => Assert.False(r.Override.HasValue));
+        });
+    }
+
+    [Fact]
+    public void ChoicesMadeAtOnceFromSeveralThreadsAllSurvive()
+    {
+        Run(directory =>
+        {
+            string path = Path.Combine(directory, "native-editors.json");
+            var policy = new NativeEditorPolicy(path, Sample);
+            string[] plugins = [.. Enumerable.Range(0, 24).Select(i => $"com.example.plugin{i}")];
+
+            var stop = new ManualResetEventSlim(false);
+            var reader = new Thread(() =>
+            {
+                while (!stop.IsSet)
+                {
+                    policy.IsBlocked("vst3", DeEsser);
+                    _ = policy.Rules.Count;
+                }
+            });
+            reader.Start();
+
+            Parallel.ForEach(plugins, plugin => Assert.Null(policy.Set("clap", plugin, "Plugin", true)));
+            stop.Set();
+            Assert.True(reader.Join(TimeSpan.FromSeconds(5)));
+
+            foreach (string plugin in plugins) Assert.True(policy.IsBlocked("clap", plugin));
+            var reopened = new NativeEditorPolicy(path, Sample);
+            Assert.Null(reopened.Error);
+            foreach (string plugin in plugins) Assert.True(reopened.IsBlocked("clap", plugin));
+            Assert.Equal(plugins.Length, Stored(path).Count);
+        });
+    }
+
+    [Fact]
+    public void ABlockedEditorAlwaysSaysWhyAndAnAllowedOneSaysNothing()
+    {
+        Run(directory =>
+        {
+            const string blank = "00112233445566778899AABBCCDDEEFF";
+            IReadOnlyList<NativeEditorRule> defaults =
+            [
+                new("vst3", DeEsser, "Elgato De-Esser", "Its editor freezes under Wine."),
+                new("vst3", blank, "Unstated", "   "),   // a rule that forgot to say why
+            ];
+            string path = Path.Combine(directory, "native-editors.json");
+            var policy = new NativeEditorPolicy(path, defaults);
+
+            Assert.Equal(NativeEditorPolicy.UnstatedReason, policy.BlockReason("vst3", blank));
+            Assert.Null(policy.Set("clap", "com.example.wobble", "Wobble", true));
+            Assert.Equal(NativeEditorPolicy.ChosenReason, policy.BlockReason("clap", "com.example.wobble"));
+            Assert.Null(policy.Set("vst3", DeEsser, null, false));
+            Assert.Null(policy.BlockReason("vst3", DeEsser));            // allowed, so nothing to say
+            Assert.Null(policy.BlockReason("lv2", "urn:example:none"));  // never named, so nothing to say
+            Assert.Null(policy.BlockReason("vst2", DeEsser));            // not even a kind we know
+
+            // A reason is given exactly when the editor stays closed.
+            foreach (NativeEditorRuleState rule in policy.Rules)
+            {
+                string? reason = policy.BlockReason(rule.Kind, rule.Plugin);
+                Assert.Equal(rule.Blocked, policy.IsBlocked(rule.Kind, rule.Plugin));
+                if (rule.Blocked) Assert.False(string.IsNullOrWhiteSpace(reason));
+                else Assert.Null(reason);
+            }
+        });
+    }
+
+    [Fact]
+    public void TheFileLivesUnderTheConfigurationDirectory()
+        => Assert.Equal(OpenXlrPaths.ConfigFile("native-editors.json"), NativeEditorPolicy.DefaultPath);
+
+    /// <summary>The choices the file holds, which are never a copy of the release list.</summary>
+    private static List<JsonElement> Stored(string path)
+    {
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+        Assert.Equal(1, document.RootElement.GetProperty("version").GetInt32());
+        return [.. document.RootElement.GetProperty("overrides").EnumerateArray().Select(e => e.Clone())];
+    }
+
+    private static void Run(Action<string> test)
+    {
+        string directory = Directory.CreateTempSubdirectory("native-editor-policy-").FullName;
+        try { test(directory); }
+        finally { Directory.Delete(directory, recursive: true); }
+    }
+}

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -199,6 +199,16 @@ public sealed class WindowLayoutTests
                     AssertNoOverlap(((Grid)slider.Parent!).Children.Where(c => c.IsVisible).ToArray());
                     Capture(controls, "plugin-" + width);
                 }
+                Assert.False(controls.FindControl<Button>("ManageNativeEditors")!.IsVisible);
+                insert.ApplyFromDaemon(JsonNode.Parse("""{"nativeHost":true}""")!, null, true, true, "This editor is blocked by its compatibility rule.");
+                Layout(controls, 420, 560);
+                var manageEditors = controls.FindControl<Button>("ManageNativeEditors")!;
+                Assert.True(manageEditors.IsVisible);
+                var actionRows = controls.FindControl<WrapPanel>("PluginActions")!;
+                Assert.Equal("Bypass", ((Avalonia.Controls.Primitives.ToggleButton)actionRows.Children[actionRows.Children.IndexOf(manageEditors) - 1]).Content);
+                foreach (var button in actionRows.Children.Where(c => c.IsVisible)) AssertInside(button, controls);
+                Capture(controls, "plugin-compatibility-420");
+
                 insert.ApplyFromDaemon(JsonNode.Parse("{\"nativeHost\":true}")!,
                     "The plugin could not start. " + new string('x', 160), false);
                 Layout(controls, 420, controls.MinHeight);
@@ -262,6 +272,39 @@ public sealed class WindowLayoutTests
                 Assert.False(UiSettings.Load().MinimizeToTray);
                 Assert.False(vm.MinimizeToTray);
                 Capture(options, "options-startup");
+
+                var focusedRules = new NativeEditorRulesWindow(new DaemonClient(), "vst3", "ABCDEF019182FAEB4D616E75466C7665");
+                windows.Add(focusedRules);
+                focusedRules.ApplyRules(JsonNode.Parse("""
+                    {"rules":[{"kind":"vst3","plugin":"ABCDEF019182FAEB4D616E75466C7665","name":"Elgato De-Esser","reason":"Known issue","defaultBlocked":true,"blocked":true}]}
+                    """));
+                Assert.Equal("Elgato De-Esser", ((NativeEditorRuleRow)focusedRules.FindControl<ListBox>("RuleList")!.SelectedItem!).Name);
+
+                var editorRules = new NativeEditorRulesWindow();
+                windows.Add(editorRules);
+                editorRules.Show();
+                editorRules.ApplyRules(JsonNode.Parse("""
+                    {"rules":[
+                      {"kind":"vst3","plugin":"ABCDEF019182FAEB4D616E75466C7665","name":"Elgato De-Esser","reason":"Its native editor freezes under Wine.","defaultBlocked":true,"blocked":true},
+                      {"kind":"clap","plugin":"example.effect","name":"Example effect","reason":"You allowed this native editor.","defaultBlocked":false,"override":false,"blocked":false}
+                    ]}
+                    """));
+                foreach (double width in new[] { 480d, 780 })
+                {
+                    Layout(editorRules, width, 590);
+                    var rules = editorRules.FindControl<ListBox>("RuleList")!;
+                    rules.SelectedIndex = 0;
+                    Assert.True(editorRules.FindControl<Button>("AllowSelected")!.IsEnabled);
+                    Assert.False(editorRules.FindControl<Button>("DefaultSelected")!.IsEnabled);
+                    rules.SelectedIndex = 1;
+                    Assert.True(editorRules.FindControl<Button>("BlockSelected")!.IsEnabled);
+                    Assert.True(editorRules.FindControl<Button>("DefaultSelected")!.IsEnabled);
+                    rules.SelectedIndex = 0;
+                    Layout(editorRules, width, 590);
+                    foreach (var button in editorRules.GetVisualDescendants().OfType<Button>().Where(b => b.IsVisible))
+                        AssertInside(button, editorRules);
+                    Capture(editorRules, "native-editor-rules-" + width);
+                }
 
                 optionsVm.ApplyPluginSetup(JsonNode.Parse("""
                     {"yabridge":"5.1.1","wine":true,"bridgeProvider":"system",

--- a/src/OpenXLR.Tests/XdgConfigCollection.cs
+++ b/src/OpenXLR.Tests/XdgConfigCollection.cs
@@ -1,0 +1,6 @@
+namespace OpenXLR.Tests;
+
+// PATH and XDG changes affect every test in the process, not just this collection.
+// Keep these tests away from parallel helpers that inherit that environment.
+[CollectionDefinition("xdg-config", DisableParallelization = true)]
+public sealed class XdgConfigCollection;

--- a/src/OpenXLR.UI/DaemonClient.cs
+++ b/src/OpenXLR.UI/DaemonClient.cs
@@ -65,6 +65,16 @@ public sealed class DaemonClient : IAsyncDisposable
     public Task<JsonNode?> RequestPluginDiagnosticsAsync(TimeSpan timeout)
         => QueryAsync("pluginDiagnostics", "getPluginDiagnostics", timeout);
 
+    public Task<JsonNode?> RequestNativeEditorRulesAsync(TimeSpan timeout)
+        => PluginOperationAsync("getNativeEditorRules", timeout, replyType: "nativeEditorRules");
+
+    public Task<JsonNode?> SetNativeEditorRuleAsync(string kind, string plugin, string name, bool? blocked, TimeSpan timeout)
+    {
+        var fields = new Dictionary<string, object> { ["kind"] = kind, ["plugin"] = plugin, ["name"] = name };
+        if (blocked is bool value) fields["blocked"] = value;
+        return PluginOperationAsync("setNativeEditorRule", timeout, fields, "nativeEditorRules");
+    }
+
     /// <summary>Where plugins go and what bridges Windows ones (a "pluginSetup" message); null on timeout.</summary>
     public Task<JsonNode?> RequestPluginSetupAsync(TimeSpan timeout)
         => QueryAsync("pluginSetup", "getPluginSetup", timeout);
@@ -174,6 +184,7 @@ public sealed class DaemonClient : IAsyncDisposable
 
     /// <summary>Raised when an error message arrives from the daemon.</summary>
     public event Action<string>? ErrorReceived;
+    public event Action? NativeEditorRulesChanged;
 
     /// <summary>Raised on every meter frame (id to peak, 0..1 and above when clipping).</summary>
     public event Action<JsonNode>? MetersReceived;
@@ -273,7 +284,8 @@ public sealed class DaemonClient : IAsyncDisposable
             else if (type == "state") { LastStateJson = text; StateReceived?.Invoke(node); }
             else if (type == "diagnostics") StoreReply(type, node);
             else if (type == "plugins") StoreReply(type, node["plugins"]);
-            else if (type is "pluginSetup" or "pluginInstall" or "pluginDiagnostics" or "windowsPluginFiles") StoreReply(type, node);
+            else if (type == "nativeEditorRulesChanged") NativeEditorRulesChanged?.Invoke();
+            else if (type is "pluginSetup" or "pluginInstall" or "pluginDiagnostics" or "windowsPluginFiles" or "nativeEditorRules") StoreReply(type, node);
             else if (type == "commandResult" && node["requestId"]?.GetValue<string>() is string requestId)
             {
                 CompleteQuery(requestId);

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml
@@ -61,6 +61,8 @@
         <Button Content="Defaults" Padding="12,4" Margin="0,0,6,6" Click="OnDefaults"
                 ToolTip.Tip="Put every control back to the plugin's own defaults"/>
         <ToggleButton Content="Bypass" IsChecked="{Binding Bypass, Mode=TwoWay}" Padding="12,4" Margin="0,0,6,6"/>
+        <Button Name="ManageNativeEditors" Content="Native editors" Padding="12,4" Margin="0,0,6,6" Click="OnNativeEditorRules"
+                IsVisible="{Binding NativeUiBlocked}" ToolTip.Tip="Manage this plugin's native editor compatibility rule"/>
         <ToggleButton Content="Native host" IsChecked="{Binding NativeHost, Mode=TwoWay}" Padding="12,4" Margin="0,0,6,6"
                       IsVisible="{Binding CanChooseNativeHost}"
                       ToolTip.Tip="Run this insert in its own process, which is what lets its own editor open. Switching rebuilds the chain and interrupts audio for a moment."/>
@@ -73,6 +75,8 @@
          of floating over the value readouts -->
     <ScrollViewer VerticalScrollBarVisibility="Auto" AllowAutoHide="False">
       <StackPanel>
+      <TextBlock Text="{Binding NativeUiBlockReason}" Foreground="#8b93a7" FontSize="11" TextWrapping="Wrap"
+                 Margin="0,0,0,8" IsVisible="{Binding NativeUiBlocked}"/>
       <TextBlock Text="{Binding Error}" Foreground="#e0a05a" FontSize="11" TextWrapping="Wrap"
                  Margin="0,0,0,8" IsVisible="{Binding HasError}"/>
       <ItemsControl ItemsSource="{Binding Groups}" Margin="0,0,10,0">

--- a/src/OpenXLR.UI/InsertControlsWindow.axaml.cs
+++ b/src/OpenXLR.UI/InsertControlsWindow.axaml.cs
@@ -22,6 +22,12 @@ public partial class InsertControlsWindow : Window
         if (DataContext is InsertViewModel insert) await insert.Owner.ShowNativeEditorAsync(insert);
     }
 
+    private async void OnNativeEditorRules(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is InsertViewModel insert)
+            await new NativeEditorRulesWindow(insert.Owner.Client, insert.Kind, insert.Plugin).ShowDialog(this);
+    }
+
     private const string EditorManual =
         "https://github.com/emaspa/openxlr/blob/main/docs/manual.md#plugin-editors";
 

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -10,7 +10,7 @@ namespace OpenXLR.UI;
 
 /// <summary>A plugin the picker offers (mono in / mono out only for the mic path).</summary>
 public sealed record PluginChoice(string Uri, string Name, string Category, JsonNode Params,
-    bool NativeEditorAvailable = false, bool NativeEditorSupported = false, string Kind = "lv2")
+    bool NativeEditorAvailable = false, bool NativeEditorSupported = false, string Kind = "lv2", bool NativeUiBlocked = false)
 {
     /// <summary>The format, as the picker shows it: two plugins can share a name and differ in nothing else.</summary>
     public string Format => Kind.ToUpperInvariant();
@@ -121,8 +121,10 @@ public sealed class InsertsViewModel : ViewModelBase
                     p["params"] ?? new JsonArray(),
                     p["nativeEditorAvailable"]?.GetValue<bool>() == true,
                     p["nativeEditorSupported"]?.GetValue<bool>() == true,
-                    p["kind"]?.GetValue<string>() ?? "lv2"));
+                    p["kind"]?.GetValue<string>() ?? "lv2",
+                    p["nativeUiBlocked"]?.GetValue<bool>() == true));
             }
+            foreach (InsertViewModel insert in Items) insert.RefreshNativeFlags();
             string width = _channels == 1 ? "mono" : "stereo";
             Note = PluginChoices.Count == 0
                 ? $"No {width} plugins found. Install some, or add one with the buttons below"
@@ -169,7 +171,9 @@ public sealed class InsertsViewModel : ViewModelBase
                     vm = new InsertViewModel(this, id, ins["plugin"]!.GetValue<string>(), ins["label"]?.GetValue<string>() ?? id,
                         ins["kind"]?.GetValue<string>() ?? "lv2");
                 vm.ApplyFromDaemon(ins, entry?["error"]?.GetValue<string>(),
-                    entry?["nativeHostRunning"]?.GetValue<bool>() == true);
+                    entry?["nativeHostRunning"]?.GetValue<bool>() == true,
+                    entry?["nativeUiBlocked"]?.GetValue<bool>() == true,
+                    entry?["nativeUiBlockReason"]?.GetValue<string>());
                 next.Add(vm);
             }
             if (!next.SequenceEqual(Items))
@@ -276,7 +280,14 @@ public sealed class InsertViewModel : ViewModelBase
     /// <summary>The helper is here too, so turning the host on can work.</summary>
     public bool NativeHostInstalled => _owner.PluginChoices.Any(p => p.Uri == Plugin && p.NativeEditorAvailable);
 
-    public bool NativeEditorAvailable => NativeHostInstalled && NativeHost && !Bypass && !HasError && NativeHostRunning;
+    private bool _nativeUiBlocked;
+    private string? _nativeUiBlockReason;
+    public bool NativeUiBlocked => _nativeUiBlocked || _owner.PluginChoices.Any(p => p.Kind == Kind && p.Uri == Plugin && p.NativeUiBlocked);
+    public string? NativeUiBlockReason => NativeUiBlocked
+        ? _nativeUiBlockReason ?? "This native editor is disabled in Options. Use the OpenXLR controls."
+        : null;
+
+    public bool NativeEditorAvailable => !NativeUiBlocked && NativeHostInstalled && NativeHost && !Bypass && !HasError && NativeHostRunning;
 
     /// <summary>
     /// The switch can be turned on only where the helper is installed. It
@@ -290,8 +301,12 @@ public sealed class InsertViewModel : ViewModelBase
         : "Open this plugin's controls";
 
     /// <summary>Everything the row and the controls window derive from the host state.</summary>
+    internal void RefreshNativeFlags() => RaiseNativeFlags();
+
     private void RaiseNativeFlags()
     {
+        Raise(nameof(NativeUiBlocked));
+        Raise(nameof(NativeUiBlockReason));
         Raise(nameof(NativeEditorSupported));
         Raise(nameof(NativeHostInstalled));
         Raise(nameof(NativeEditorAvailable));
@@ -413,8 +428,11 @@ public sealed class InsertViewModel : ViewModelBase
                 Groups.Add(new InsertParamGroup(g, true, l));
     }
 
-    public void ApplyFromDaemon(JsonNode ins, string? error, bool nativeHostRunning)
+    public void ApplyFromDaemon(JsonNode ins, string? error, bool nativeHostRunning,
+        bool nativeUiBlocked = false, string? nativeUiBlockReason = null)
     {
+        _nativeUiBlocked = nativeUiBlocked;
+        _nativeUiBlockReason = nativeUiBlockReason;
         _bypass = ins["bypass"]?.GetValue<bool>() ?? false;
         _nativeHost = ins["nativeHost"]?.GetValue<bool>() ?? false;
         Raise(nameof(NativeHost));

--- a/src/OpenXLR.UI/NativeEditorRulesWindow.axaml
+++ b/src/OpenXLR.UI/NativeEditorRulesWindow.axaml
@@ -1,0 +1,53 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:OpenXLR.UI"
+        x:Class="OpenXLR.UI.NativeEditorRulesWindow"
+        Title="Native editor compatibility" Width="780" Height="590" MinWidth="480" MinHeight="400"
+        WindowStartupLocation="CenterOwner" Background="#16181d">
+  <Grid Margin="18" RowDefinitions="Auto,12,*,12,Auto,10,Auto,12,Auto">
+    <StackPanel Spacing="6">
+      <TextBlock Text="Native editor compatibility" FontSize="17" FontWeight="SemiBold"/>
+      <TextBlock Text="Use OpenXLR controls for plugins whose own editor freezes or misbehaves. Audio processing is unchanged."
+                 FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+      <TextBlock Text="Release defaults can change as compatibility improves. Your overrides take priority until you choose Use release default."
+                 FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+    </StackPanel>
+    <Border Grid.Row="2" Background="#1d2027" CornerRadius="8" Padding="8">
+      <Grid>
+        <ListBox Name="RuleList" SelectionChanged="OnRuleSelected" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:NativeEditorRuleRow">
+              <StackPanel Spacing="3" Margin="0,5,12,5">
+                <TextBlock Text="{Binding Label}" TextWrapping="Wrap" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding Summary}" FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+              </StackPanel>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+        <TextBlock Name="EmptyRules" Text="No native editors are blocked." Margin="8" Foreground="#8b93a7" IsHitTestVisible="False"/>
+      </Grid>
+    </Border>
+    <WrapPanel Grid.Row="4">
+      <Button Name="BlockSelected" Content="Use OpenXLR controls" Click="OnBlockSelected" Padding="12,5" Margin="0,0,8,4" IsEnabled="False"/>
+      <Button Name="AllowSelected" Content="Allow native editor" Click="OnAllowSelected" Padding="12,5" Margin="0,0,8,4" IsEnabled="False"/>
+      <Button Name="DefaultSelected" Content="Use release default" Click="OnDefaultSelected" Padding="12,5" Margin="0,0,0,4" IsEnabled="False"/>
+    </WrapPanel>
+    <TextBlock Grid.Row="6" Name="RuleDetail" FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap" MaxHeight="72"/>
+    <StackPanel Grid.Row="8" Spacing="8">
+      <Grid ColumnDefinitions="*,8,Auto">
+        <AutoCompleteBox Name="PluginPicker" PlaceholderText="Find an installed plugin…" MinimumPrefixLength="0"
+                         FilterMode="Contains" SelectionChanged="OnPluginSelected"/>
+        <Button Grid.Column="2" Name="AddRule" Content="Use OpenXLR controls" Click="OnAddRule" Padding="12,5" IsEnabled="False"/>
+      </Grid>
+      <TextBlock Text="Changes apply the next time an editor is opened. Existing editor windows are not closed."
+                 FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
+      <Grid ColumnDefinitions="*,12,Auto,8,Auto">
+        <ScrollViewer MaxHeight="80" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+          <TextBlock Name="Status" FontSize="12" Foreground="#e0a05a" TextWrapping="Wrap" Margin="0,0,12,0"/>
+        </ScrollViewer>
+        <Button Grid.Column="2" Content="Refresh" Padding="12,6" Click="OnRefresh"/>
+        <Button Grid.Column="4" Content="Close" Padding="18,6" Click="OnClose"/>
+      </Grid>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/OpenXLR.UI/NativeEditorRulesWindow.axaml.cs
+++ b/src/OpenXLR.UI/NativeEditorRulesWindow.axaml.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+
+namespace OpenXLR.UI;
+
+public sealed record NativeEditorRuleRow(string Kind, string Plugin, string Name, string Reason,
+    bool DefaultBlocked, bool? Override, bool Blocked)
+{
+    public string Label => $"{Name} ({Kind.ToUpperInvariant()})";
+    public string Summary => (Blocked ? "OpenXLR controls" : "Native editor allowed")
+        + (Override is null ? " · Release default" : " · Your override");
+}
+
+public sealed record NativeEditorPluginChoice(string Kind, string Plugin, string Name)
+{
+    public override string ToString() => $"{Name} ({Kind.ToUpperInvariant()})";
+}
+
+public partial class NativeEditorRulesWindow : Window
+{
+    private readonly ObservableCollection<NativeEditorRuleRow> _rules = [];
+    private readonly ObservableCollection<NativeEditorPluginChoice> _plugins = [];
+    private readonly DaemonClient? _client;
+    private readonly (string Kind, string Plugin)? _initialSelection;
+    private bool _busy, _closed, _hasError;
+    private NativeEditorRuleRow? Selected => RuleList.SelectedItem as NativeEditorRuleRow;
+
+    public NativeEditorRulesWindow()
+    {
+        InitializeComponent();
+        RuleList.ItemsSource = _rules;
+        PluginPicker.ItemsSource = _plugins;
+        Opened += (_, _) =>
+        {
+            var screen = Screens.ScreenFromWindow(this);
+            if (screen is null) return;
+            double height = screen.WorkingArea.Height / screen.Scaling - 60;
+            if (height > 300) { MinHeight = Math.Min(MinHeight, height); MaxHeight = height; }
+        };
+    }
+
+    public NativeEditorRulesWindow(DaemonClient client, string? kind = null, string? plugin = null) : this()
+    {
+        _client = client;
+        if (kind is not null && plugin is not null) _initialSelection = (kind, plugin);
+        Opened += async (_, _) => await LoadAsync();
+        client.NativeEditorRulesChanged += OnRulesChanged;
+        Closed += (_, _) => { _closed = true; client.NativeEditorRulesChanged -= OnRulesChanged; };
+    }
+
+    private void OnRulesChanged() => Dispatcher.UIThread.Post(async () =>
+    {
+        if (!_closed && !_busy) await LoadAsync();
+    });
+
+    private async Task LoadAsync()
+    {
+        if (_client is null) return;
+        _busy = true;
+        UpdateButtons();
+        try
+        {
+            ApplyRules(await _client.RequestNativeEditorRulesAsync(TimeSpan.FromSeconds(20)));
+            JsonNode? catalogue = await _client.RequestPluginsAsync(TimeSpan.FromSeconds(20));
+            _plugins.Clear();
+            foreach (JsonNode p in (catalogue as JsonArray ?? []).OfType<JsonNode>()
+                .Where(p => p["nativeEditorSupported"]?.GetValue<bool>() == true || p["nativeEditorAvailable"]?.GetValue<bool>() == true)
+                .OrderBy(p => p["name"]?.GetValue<string>(), StringComparer.OrdinalIgnoreCase))
+                _plugins.Add(new(p["kind"]?.GetValue<string>() ?? "lv2", p["plugin"]!.GetValue<string>(),
+                    p["name"]?.GetValue<string>() ?? p["plugin"]!.GetValue<string>()));
+            if (catalogue is null && !_hasError) Status.Text = "The plugin list is unavailable. Existing rules can still be edited.";
+        }
+        catch (Exception ex) { _hasError = true; Status.Text = ex.Message; }
+        finally { _busy = false; UpdateButtons(); }
+    }
+
+    internal void ApplyRules(JsonNode? reply)
+    {
+        var selected = Selected;
+        _rules.Clear();
+        _hasError = reply is null || reply["error"]?.GetValue<string>() is { Length: > 0 };
+        Status.Text = reply is null ? "The daemon did not return editor rules. Update or restart it if needed."
+            : reply["error"]?.GetValue<string>() ?? "";
+        foreach (JsonNode row in (reply?["rules"] as JsonArray ?? []).OfType<JsonNode>())
+            _rules.Add(new(row["kind"]!.GetValue<string>(), row["plugin"]!.GetValue<string>(),
+                row["name"]!.GetValue<string>(), row["reason"]?.GetValue<string>() ?? "",
+                row["defaultBlocked"]!.GetValue<bool>(), row["override"]?.GetValue<bool>(), row["blocked"]!.GetValue<bool>()));
+        string? kind = selected?.Kind ?? _initialSelection?.Kind;
+        string? plugin = selected?.Plugin ?? _initialSelection?.Plugin;
+        RuleList.SelectedItem = _rules.FirstOrDefault(r => r.Kind == kind && r.Plugin == plugin);
+        EmptyRules.IsVisible = _rules.Count == 0;
+        UpdateButtons();
+    }
+
+    private void UpdateButtons()
+    {
+        bool ready = !_busy && !_hasError;
+        RuleList.IsEnabled = PluginPicker.IsEnabled = ready;
+        BlockSelected.IsEnabled = ready && Selected is { Blocked: false };
+        AllowSelected.IsEnabled = ready && Selected is { Blocked: true };
+        DefaultSelected.IsEnabled = ready && Selected?.Override is not null;
+        AddRule.IsEnabled = ready && PluginPicker.SelectedItem is NativeEditorPluginChoice choice
+            && !_rules.Any(r => r.Kind == choice.Kind && r.Plugin == choice.Plugin && r.Blocked);
+        RuleDetail.Text = Selected is { } rule
+            ? rule.Reason + "\n" + rule.Kind.ToUpperInvariant() + " · " + rule.Plugin
+                + "\nRelease default: " + (rule.DefaultBlocked ? "OpenXLR controls" : "native editor allowed")
+            : "Select a rule to change it, or find a plugin below to add one.";
+    }
+
+    private void OnRuleSelected(object? sender, SelectionChangedEventArgs e) => UpdateButtons();
+    private void OnPluginSelected(object? sender, SelectionChangedEventArgs e) => UpdateButtons();
+
+    private async Task SetRuleAsync(string kind, string plugin, string name, bool? blocked)
+    {
+        if (_client is null || _busy) return;
+        _busy = true;
+        UpdateButtons();
+        try
+        {
+            ApplyRules(await _client.SetNativeEditorRuleAsync(kind, plugin, name, blocked, TimeSpan.FromSeconds(20)));
+            RuleList.SelectedItem = _rules.FirstOrDefault(r => r.Kind == kind && r.Plugin == plugin);
+        }
+        catch (Exception ex) { Status.Text = ex.Message; }
+        finally { _busy = false; UpdateButtons(); }
+    }
+
+    private async void OnAddRule(object? sender, RoutedEventArgs e)
+    {
+        if (PluginPicker.SelectedItem is NativeEditorPluginChoice plugin)
+            await SetRuleAsync(plugin.Kind, plugin.Plugin, plugin.Name, true);
+    }
+
+    private async void OnBlockSelected(object? sender, RoutedEventArgs e)
+    {
+        if (Selected is { } rule) await SetRuleAsync(rule.Kind, rule.Plugin, rule.Name, true);
+    }
+
+    private async void OnAllowSelected(object? sender, RoutedEventArgs e)
+    {
+        if (Selected is not { } rule) return;
+        if (!await Dialogs.ConfirmAsync(this, "Allow this native editor?",
+            $"Allow {rule.Name} to open its own editor again? If the compatibility issue remains, its window may freeze or its plugin process may crash. Your choice will override release defaults.", "Allow editor")) return;
+        await SetRuleAsync(rule.Kind, rule.Plugin, rule.Name, false);
+    }
+
+    private async void OnDefaultSelected(object? sender, RoutedEventArgs e)
+    {
+        if (Selected is { } rule) await SetRuleAsync(rule.Kind, rule.Plugin, rule.Name, null);
+    }
+
+    private async void OnRefresh(object? sender, RoutedEventArgs e)
+    {
+        if (!_busy) await LoadAsync();
+    }
+
+    private void OnClose(object? sender, RoutedEventArgs e) => Close();
+}

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -147,8 +147,10 @@
           <Button Name="Rescan" Content="Rescan" Padding="14,5" Click="OnRescanPlugins"
                   ToolTip.Tip="Read the plugin directories again, for plugins installed by other means"/>
         </StackPanel>
-        <Button Name="ManageFolders" Content="Manage Windows plugins…" Padding="14,5" Margin="0,4,0,0"
-                HorizontalAlignment="Left" Click="OnManagePluginFolders"/>
+        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+          <Button Name="ManageFolders" Content="Manage Windows plugins…" Padding="14,5" Click="OnManagePluginFolders"/>
+          <Button Content="Native editors" Padding="14,5" Click="OnNativeEditorRules"/>
+        </StackPanel>
         <TextBlock Text="{Binding WindowsPlugins}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="0,4,0,0"/>
         <!-- A pair of versions that leaves a bridged plugin's own editor deaf
              to the mouse. Worth saying before the user spends an evening on it. -->

--- a/src/OpenXLR.UI/OptionsWindow.axaml.cs
+++ b/src/OpenXLR.UI/OptionsWindow.axaml.cs
@@ -53,6 +53,12 @@ public partial class OptionsWindow : Window
             await vm.Client.SyncWindowsPluginsAsync(TimeSpan.FromMinutes(4)), "the sync"), "Bridging Windows plugins…", vm);
     }
 
+    private async void OnNativeEditorRules(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is OptionsViewModel vm)
+            await new NativeEditorRulesWindow(vm.Client).ShowDialog(this);
+    }
+
     private async void OnManagePluginFolders(object? sender, RoutedEventArgs e)
     {
         if (DataContext is OptionsViewModel vm)

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -58,6 +58,7 @@ public sealed class MainViewModel : ViewModelBase
             else { Inserts.EnsurePluginsLoaded(); Inserts2.EnsurePluginsLoaded(); }
         });
         _client.ErrorReceived += msg => Dispatcher.UIThread.Post(() => Status = msg);
+        _client.NativeEditorRulesChanged += () => Dispatcher.UIThread.Post(() => InsertsViewModel.ReloadAll?.Invoke());
         _client.MetersReceived += levels => Dispatcher.UIThread.Post(() => ApplyMeters(levels));
         InsertsViewModel.ReloadAll = () =>
         {


### PR DESCRIPTION
## Changes

- Add a curated native-editor compatibility policy, initially blocking the Elgato De-Esser VST3 editor.
- Keep audio processing, native hosting, parameters and bypass choices unchanged. Blocked cogs open OpenXLR controls, and the daemon refuses direct native-editor requests.
- Edit the list from Options or the Native editors shortcut beside Bypass in a blocked controls window, with the current plugin selected.
- Store only explicit user overrides. Untouched plugins follow future release defaults; user allow/block choices survive until reset to the release default.
- Save atomically, preserve policy on failed writes, reject damaged configuration without overwriting it, and update editor availability live without rescanning plugins.
- Isolate environment-mutating tests from parallel helper processes.

## Verification

- Native-enabled Release build passed with 0 warnings and 0 errors.
- Policy, persistence, API, notification and editor-only availability tests passed. The combined local suite passed 510 tests; the two button-label tests belong to the separate cleanup commit.
- Xvfb layout checks passed for narrow/wide windows and the shortcut's placement and plugin preselection.
- Live API returned the curated De-Esser block and refused its native editor; mixer and window settings were preserved.
- Local deployment verified. No Wine patch or runtime override was installed.

No version bump or release changes. Button-label cleanup is separate.
