### PR TITLE
Window: remove ellipses from button labels

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -146,7 +146,7 @@ Chains and exposed parameter values are saved with the mixer and profiles.
 Opaque plugin state, loaded sample files and plugin preset data are not
 persisted by OpenXLR. A plugin may save its own preferences separately.
 
-"Install file…" and "Install folder…" accept extracted Linux plugins or
+"Install file" and "Install folder" accept extracted Linux plugins or
 Windows plugin folders. Linux bundles are copied into `~/.lv2`, `~/.clap`
 or `~/.vst3`. Windows installers must run in Wine first; OpenXLR bridges
 the installed plugins and rescans automatically. Options offers a rescan,

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -194,8 +194,8 @@ scroll horizontally and vertically. Resizing the window manually turns off autom
 ### 3.3 Put an application on a different channel
 
 The APPLICATIONS card lists every app that is currently registered with
-PipeWire as an audio client; a green light means it is playing. Manage… sits
-beside the APPLICATIONS heading, like Edit layout… beside SUBMIXER. The app
+PipeWire as an audio client; a green light means it is playing. Manage sits
+beside the APPLICATIONS heading, like Edit layout beside SUBMIXER. The app
 controls wrap onto further rows when the window is narrower.
 
 An app's playback streams and audio client share the same identity even
@@ -211,7 +211,7 @@ alias, the existing normalized assignment takes precedence.
    so you can see there which OpenXLR channel an app is playing into;
    the hardware inputs (XLR 1, XLR 2, Aux In) are deliberately not
    listed, nothing should play into a microphone's channel.
-2. To pre-assign an app that has not played yet, open Manage…, pick it
+2. To pre-assign an app that has not played yet, open Manage, pick it
    from the installed-application list, choose a channel and press Add.
    The identity is guessed from its launcher; if the app reports a
    different name on first play it shows up as a new entry.
@@ -246,8 +246,8 @@ channel, with its level and lock in the INPUTS card.
 <a name="plugins"></a>
 ### 3.5 Add a plugin to the signal path
 
-1. Under XLR 1, XLR 2 or a mix, press "Inserts…". The chain window opens
-   with that chain's plugins and an "Add plugin…" button. The picker lists
+1. Under XLR 1, XLR 2 or a mix, press "Inserts". The chain window opens
+   with that chain's plugins and an "Add plugin" button. The picker lists
    compatible installed LV2, CLAP and VST3 effects (mono for an input,
    stereo for a mix), searchable by name, category or format. Host
    feature requirements can exclude a plugin; install a compatible set
@@ -299,7 +299,7 @@ to reload it.
 on Arch, `lsp-plugins-lv2` and `x42-plugins` cover the microphone path
 well. Choose LV2, CLAP or VST3 packages available for your distribution;
 the picker offers only plugins compatible with the selected slot.
-For a plugin you downloaded, press "Install file…" or "Install folder…" in the picker or in Options and pick it; OpenXLR puts it where
+For a plugin you downloaded, press "Install file" or "Install folder" in the picker or in Options and pick it; OpenXLR puts it where
 it looks and the picker lists it a moment later. A file is a `.clap` or a
 single-file `.vst3`; a folder is a `.vst3` or `.lv2` bundle, or a folder
 holding several of them, such as an extracted download. Linux plugins are
@@ -403,7 +403,7 @@ yabridge has seen that folder before:
 |---|---|
 | Bridge Wine's plugins | The first Windows plugin, and any later one installed somewhere new. The button names what it found and disappears once that folder is bridged |
 | Sync Windows plugins | Every plugin after that, when the installer wrote into a folder already bridged. This is the usual case |
-| Install folder… | An installer that wrote outside Wine's usual folders. Press Ctrl+H in the dialog to see `~/.wine`, which is hidden |
+| Install folder | An installer that wrote outside Wine's usual folders. Press Ctrl+H in the dialog to see `~/.wine`, which is hidden |
 | Rescan | Plugins that arrived by other means, such as a package from your distribution. Nothing to press after a bridge or a sync, since both read the catalogues again |
 
 Bridging and syncing end the same way: yabridge wraps each Windows plugin
@@ -415,11 +415,11 @@ has to be restarted.
 
 <a name="plugin-folders"></a>
 **Managing Windows plugin folders.** Open Options, PLUGINS, then "Manage Windows
-plugins…" to see the folders registered with the selected yabridge provider.
+plugins" to see the folders registered with the selected yabridge provider.
 
-- "Add folder…" registers a folder holding Windows VST3 or CLAP plugins,
+- "Add folder" registers a folder holding Windows VST3 or CLAP plugins,
   syncs it and refreshes the catalogue. The original files stay in that
-  folder. Use "Install file…" or "Install folder…" for native Linux plugins.
+  folder. Use "Install file" or "Install folder" for native Linux plugins.
 - Select a folder and press "Remove from list" to unregister it. A
   confirmation explains what will be removed. OpenXLR cleans up only that
   folder's generated VST3 and CLAP wrappers; original plugin files and
@@ -441,17 +441,17 @@ disabled or in use by an insert chain.
   its generated wrappers. Its files stay in place and the row remains listed.
   "Enable in OpenXLR" restores it. A separately installed copy can still
   appear in the picker; disabling one source does not ban a plugin name.
-- "Delete file…" permanently deletes a standalone file or bundle after a
+- "Delete file" permanently deletes a standalone file or bundle after a
   confirmation. Other files in the same folder are kept. It is unavailable
   for Wine-installed or linked sources, which may depend on an installer,
   registry entries or shared resources.
-- "Wine uninstaller…" opens the installed-apps list in the selected plugin's
+- "Wine uninstaller" opens the installed-apps list in the selected plugin's
   Wine prefix. Choose the plugin's installer entry there. Close other Wine
   applications and remove affected inserts first: one installer entry may
   remove several effects from the same package. OpenXLR waits without killing
   the uninstaller on a timeout, then syncs and rescans when it closes.
 
-When a row says "In use", choose "Remove from all chains…" and confirm to
+When a row says "In use", choose "Remove from all chains" and confirm to
 remove every occurrence from the current input and mix chains, including
 bypassed inserts. Other plugins keep their order and settings. This requires
 a running mixer and can briefly interrupt affected audio paths. The current
@@ -484,11 +484,11 @@ than asking you to go and find it. Once a folder is bridged, yabridge keeps
 it on its own list, so a second plugin installed into it needs only the
 sync, and the Bridge button has nothing left to offer.
 
-Picking one Windows `.vst3` or `.clap` file with "Install file…" installs
+Picking one Windows `.vst3` or `.clap` file with "Install file" installs
 only that plugin. OpenXLR copies it into its own folder under
 `~/.local/share/openxlr/windows-plugins`, grouped by format and plugin name,
 and registers that folder with yabridge. A single Windows `.vst3` bundle
-picked with "Install folder…" is copied whole, including its resources.
+picked with "Install folder" is copied whole, including its resources.
 The original download is kept and can be deleted afterwards. Other plugins
 beside the selected one, including other downloads, are not registered.
 Selecting the same plugin name again updates its managed copy.
@@ -496,12 +496,12 @@ Selecting the same plugin name again updates its managed copy.
 A plugin already installed inside a Wine prefix is linked from its managed
 folder instead of being copied or moved. It keeps its original location,
 Wine prefix and neighbouring files. Selecting an ordinary folder or using
-"Add folder…" in the folder manager still registers that folder in place.
+"Add folder" in the folder manager still registers that folder in place.
 VST2 `.dll` files are left out because OpenXLR cannot load VST2.
 
 Older folder registrations are not silently removed. If an earlier
 single-file import registered Downloads, remove that entry with "Manage Windows
-plugins…" and import the plugins you want individually. Remove affected
+plugins" and import the plugins you want individually. Remove affected
 inserts first if the manager asks you to. Removing a folder refreshes the
 catalogue and the open plugin pickers.
 
@@ -801,7 +801,7 @@ the release page matches the daemon of that release.
 <a name="layout"></a>
 ### 3.11 Edit the mixer layout
 
-The default channels and mixes are a starting point. Edit layout… in the
+The default channels and mixes are a starting point. Edit layout in the
 SUBMIXER card opens the layout editor: application channels on the left,
 mixes on the right, each with move up and down, Rename and Delete, and a
 box at the bottom to add one. The hardware inputs, Monitor A, Monitor B

--- a/src/OpenXLR.Tests/ButtonLabelTests.cs
+++ b/src/OpenXLR.Tests/ButtonLabelTests.cs
@@ -1,0 +1,40 @@
+using System.Xml.Linq;
+using OpenXLR.UI;
+
+namespace OpenXLR.Tests;
+
+public sealed class ButtonLabelTests
+{
+    [Fact]
+    public void ButtonLabelsDoNotContainEllipses()
+    {
+        DirectoryInfo? root = new(AppContext.BaseDirectory);
+        while (root is not null && !Directory.Exists(Path.Combine(root.FullName, "src", "OpenXLR.UI"))) root = root.Parent;
+        Assert.NotNull(root);
+        string ui = Path.Combine(root.FullName, "src", "OpenXLR.UI");
+        foreach (string path in Directory.EnumerateFiles(ui, "*.axaml"))
+        {
+            var document = XDocument.Load(path);
+            foreach (var button in document.Descendants().Where(e => e.Name.LocalName.EndsWith("Button", StringComparison.Ordinal)))
+            {
+                if (button.Attribute("Content")?.Value is string content)
+                    AssertPlain(content, Path.GetFileName(path));
+                foreach (var text in button.Descendants().Where(e => e.Name.LocalName == "TextBlock"))
+                    if (text.Attribute("Text")?.Value is string label) AssertPlain(label, Path.GetFileName(path));
+            }
+        }
+    }
+
+    [Fact]
+    public void DynamicInsertButtonLabelsHaveNoEllipsis()
+    {
+        var inserts = new InsertsViewModel(new DaemonClient(), "xlr1");
+        Assert.Equal("Inserts", inserts.ButtonText);
+        inserts.Items.Add(new InsertViewModel(inserts, "test", "test-plugin", "Test"));
+        Assert.Equal("Inserts (1)", inserts.ButtonText);
+    }
+
+    private static void AssertPlain(string text, string file)
+        => Assert.True(!text.Contains('…') && !text.Contains("...", StringComparison.Ordinal),
+            $"{file}: button label '{text}' contains an ellipsis.");
+}

--- a/src/OpenXLR.Tests/WindowLayoutTests.cs
+++ b/src/OpenXLR.Tests/WindowLayoutTests.cs
@@ -153,7 +153,7 @@ public sealed class WindowLayoutTests
                     double manageCenter = manageApps.TranslatePoint(default, main)!.Value.Y + manageApps.Bounds.Height / 2;
                     Assert.InRange(Math.Abs(headingCenter - manageCenter), 0, 1);
                     Assert.True(manageApps.TranslatePoint(default, main)!.Value.X > heading.TranslatePoint(default, main)!.Value.X + heading.Bounds.Width);
-                    var editLayout = main.GetVisualDescendants().OfType<Button>().Single(b => b.Content as string == "Edit layout…");
+                    var editLayout = main.GetVisualDescendants().OfType<Button>().Single(b => b.Content as string == "Edit layout");
                     Assert.Equal(editLayout.Padding, manageApps.Padding);
                     Assert.Equal(editLayout.FontSize, manageApps.FontSize);
                     Assert.Equal(editLayout.MinHeight, manageApps.MinHeight);

--- a/src/OpenXLR.UI/InsertsViewModel.cs
+++ b/src/OpenXLR.UI/InsertsViewModel.cs
@@ -71,7 +71,7 @@ public sealed class InsertsViewModel : ViewModelBase
     };
 
     /// <summary>Label for a compact button that opens the chain window.</summary>
-    public string ButtonText => Items.Count == 0 ? "Inserts…" : $"Inserts ({Items.Count})…";
+    public string ButtonText => Items.Count == 0 ? "Inserts" : $"Inserts ({Items.Count})";
 
     private PluginChoice? _selectedPlugin;
     public PluginChoice? SelectedPlugin

--- a/src/OpenXLR.UI/MainWindow.axaml
+++ b/src/OpenXLR.UI/MainWindow.axaml
@@ -531,7 +531,7 @@
         <Expander.Header>
           <StackPanel Orientation="Horizontal" Spacing="10">
             <TextBlock Text="APPLICATIONS" Classes="h" VerticalAlignment="Center"/>
-            <Button Name="ManageApps" Content="Manage…" Padding="8,1" FontSize="11" MinHeight="0" VerticalAlignment="Center"
+            <Button Name="ManageApps" Content="Manage" Padding="8,1" FontSize="11" MinHeight="0" VerticalAlignment="Center"
                     IsEnabled="{Binding HasApps}" Click="OnManageApps"/>
           </StackPanel>
         </Expander.Header>
@@ -563,7 +563,7 @@
         <Expander.Header>
           <StackPanel Orientation="Horizontal" Spacing="10">
             <TextBlock Text="SUBMIXER" Classes="h" VerticalAlignment="Center"/>
-            <Button Content="Edit layout…" Padding="8,1" FontSize="11" MinHeight="0" VerticalAlignment="Center"
+            <Button Content="Edit layout" Padding="8,1" FontSize="11" MinHeight="0" VerticalAlignment="Center"
                     IsVisible="{Binding HasMixer}" IsEnabled="{Binding CanEditLayout}" Click="OnEditLayout"
                     ToolTip.Tip="Add, rename, reorder and remove application channels and virtual microphones while audio plays"/>
           </StackPanel>
@@ -601,7 +601,7 @@
                     </Border>
                   </StackPanel>
                   <Slider Minimum="0" Maximum="1" Value="{Binding Volume, Mode=TwoWay}"/>
-                  <ToggleButton Content="Mute mix" Classes="mute" IsChecked="{Binding Muted, Mode=TwoWay}"/>
+                  <ToggleButton Content="Mute" Classes="mute" IsChecked="{Binding Muted, Mode=TwoWay}"/>
                   <Button Content="{Binding Inserts.ButtonText}" HorizontalAlignment="Stretch"
                           HorizontalContentAlignment="Center" Padding="8,4" FontSize="12" Click="OnMixInserts"
                           ToolTip.Tip="Stereo plugins processing this mix before it reaches its outputs"/>

--- a/src/OpenXLR.UI/MixInsertsWindow.axaml
+++ b/src/OpenXLR.UI/MixInsertsWindow.axaml
@@ -22,7 +22,7 @@
                    TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Title}"/>
         <TextBlock Text="{Binding ChainHint}" Classes="h" FontSize="11" TextWrapping="Wrap"/>
       </StackPanel>
-      <Button Grid.Column="1" Content="Add plugin…" Padding="12,4" VerticalAlignment="Top" Click="OnAddInsert"/>
+      <Button Grid.Column="1" Content="Add plugin" Padding="12,4" VerticalAlignment="Top" Click="OnAddInsert"/>
     </Grid>
     <Button DockPanel.Dock="Bottom" Content="Close" HorizontalAlignment="Right" Padding="18,6" Margin="0,10,0,0" Click="OnClose"/>
     <TextBlock DockPanel.Dock="Top" Text="No inserts yet." Classes="h" IsVisible="{Binding !HasItems}"/>

--- a/src/OpenXLR.UI/OptionsWindow.axaml
+++ b/src/OpenXLR.UI/OptionsWindow.axaml
@@ -142,13 +142,13 @@
         <TextBlock Text="Pick a plugin you downloaded and OpenXLR puts it in place: a .clap or .vst3 file, a .vst3 or .lv2 folder, or a folder holding plugins."
                    FontSize="11" Foreground="#6b7285" TextWrapping="Wrap"/>
         <StackPanel Orientation="Horizontal" Spacing="8">
-          <Button Name="InstallFile" Content="Install file…" Padding="14,5" Click="OnInstallPluginFile"/>
-          <Button Name="InstallFolder" Content="Install folder…" Padding="14,5" Click="OnInstallPluginFolder"/>
+          <Button Name="InstallFile" Content="Install file" Padding="14,5" Click="OnInstallPluginFile"/>
+          <Button Name="InstallFolder" Content="Install folder" Padding="14,5" Click="OnInstallPluginFolder"/>
           <Button Name="Rescan" Content="Rescan" Padding="14,5" Click="OnRescanPlugins"
                   ToolTip.Tip="Read the plugin directories again, for plugins installed by other means"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
-          <Button Name="ManageFolders" Content="Manage Windows plugins…" Padding="14,5" Click="OnManagePluginFolders"/>
+          <Button Name="ManageFolders" Content="Manage Windows plugins" Padding="14,5" Click="OnManagePluginFolders"/>
           <Button Content="Native editors" Padding="14,5" Click="OnNativeEditorRules"/>
         </StackPanel>
         <TextBlock Text="{Binding WindowsPlugins}" FontSize="11" Foreground="#8b93a7" TextWrapping="Wrap" Margin="0,4,0,0"/>

--- a/src/OpenXLR.UI/PluginFoldersWindow.axaml
+++ b/src/OpenXLR.UI/PluginFoldersWindow.axaml
@@ -31,7 +31,7 @@
           </Grid>
         </Border>
         <WrapPanel Orientation="Horizontal">
-          <Button Name="AddFolder" Content="Add folder…" Padding="14,5" Margin="0,0,8,4" Click="OnAddFolder"/>
+          <Button Name="AddFolder" Content="Add folder" Padding="14,5" Margin="0,0,8,4" Click="OnAddFolder"/>
           <Button Name="RemoveFolder" Content="Remove from list" Padding="14,5" Margin="0,0,8,4" Click="OnRemoveFolder" IsEnabled="False"/>
           <Button Name="RescanFolders" Content="Rescan" Padding="14,5" Margin="0,0,0,4" Click="OnRescan"/>
         </WrapPanel>
@@ -54,11 +54,11 @@
           </Grid>
         </Border>
         <WrapPanel Orientation="Horizontal">
-          <Button Name="RemoveUses" Content="Remove from all chains…" Padding="14,5" Margin="0,0,8,4"
+          <Button Name="RemoveUses" Content="Remove from all chains" Padding="14,5" Margin="0,0,8,4"
                   Click="OnRemoveUses" IsVisible="False"/>
           <Button Name="TogglePlugin" Content="Disable in OpenXLR" Padding="14,5" Margin="0,0,8,4" Click="OnTogglePlugin" IsEnabled="False"/>
-          <Button Name="DeletePlugin" Content="Delete file…" Padding="14,5" Margin="0,0,8,4" Click="OnDeletePlugin" IsEnabled="False"/>
-          <Button Name="WineUninstaller" Content="Wine uninstaller…" Padding="14,5" Margin="0,0,0,4" Click="OnWineUninstaller" IsVisible="False"/>
+          <Button Name="DeletePlugin" Content="Delete file" Padding="14,5" Margin="0,0,8,4" Click="OnDeletePlugin" IsEnabled="False"/>
+          <Button Name="WineUninstaller" Content="Wine uninstaller" Padding="14,5" Margin="0,0,0,4" Click="OnWineUninstaller" IsVisible="False"/>
         </WrapPanel>
         <TextBlock Name="PluginDetail" Text="Select a plugin to manage it." FontSize="12" Foreground="#8b93a7" TextWrapping="Wrap"/>
         <TextBlock Text="Disabling keeps the files. Delete file permanently removes a standalone plugin. Wine-installed plugins use their uninstaller. Changes refresh the plugin catalogue."

--- a/src/OpenXLR.UI/PluginPickerWindow.axaml
+++ b/src/OpenXLR.UI/PluginPickerWindow.axaml
@@ -34,9 +34,9 @@
       <TextBlock Name="InstallStatus" Classes="h" FontSize="11" TextWrapping="Wrap"
                  IsVisible="{Binding #InstallStatus.Text, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
       <Grid ColumnDefinitions="Auto,6,Auto,*,Auto,8,Auto">
-        <Button Name="InstallFile" Content="Install file…" Padding="12,6" Click="OnInstallFile"
+        <Button Name="InstallFile" Content="Install file" Padding="12,6" Click="OnInstallFile"
                 ToolTip.Tip="Install a .clap or .vst3 file, or a Windows plugin through yabridge"/>
-        <Button Grid.Column="2" Name="InstallFolder" Content="Install folder…" Padding="12,6" Click="OnInstallFolder"
+        <Button Grid.Column="2" Name="InstallFolder" Content="Install folder" Padding="12,6" Click="OnInstallFolder"
                 ToolTip.Tip="Install a .vst3 or .lv2 bundle, or every plugin in a folder"/>
         <Button Grid.Column="4" Name="AddButton" Content="Add" Padding="18,6" IsEnabled="False" Click="OnAdd"/>
         <Button Grid.Column="6" Content="Cancel" Padding="18,6" Click="OnCancel"/>

--- a/src/OpenXLR.UI/ViewModels.cs
+++ b/src/OpenXLR.UI/ViewModels.cs
@@ -461,7 +461,7 @@ public sealed class MainViewModel : ViewModelBase
     /// <summary>Running audio-capable apps (the main card shows these).</summary>
     public ObservableCollection<AppStreamViewModel> ActiveApps { get; } = [];
 
-    /// <summary>True when the registry holds anything (enables Manage…).</summary>
+    /// <summary>True when the registry holds anything (enables Manage).</summary>
     public bool HasApps => Apps.Count > 0;
 
     /// <summary>Pre-register an installed app with a channel (Manage dialog).</summary>


### PR DESCRIPTION
## Changes

- Shorten the mix-master mute button label to **Mute**.
- Remove ellipses from button labels across the UI, including dynamic Inserts labels.
- Update the manual and feature documentation to match.
- Keep progress messages, placeholder prompts and text-truncation indicators unchanged.
- Add regression checks for literal XAML button labels and dynamic insert labels.

## Verification

- Native-enabled Release build passed with 0 warnings and 0 errors.
- Combined .NET suite: 510 passed, 3 opt-in desktop tests skipped.
- Separate Xvfb layout checks passed; inspected the generated controls and confirmed the new labels fit.
- Local UI relaunched and verified without restarting audio.

No version bump or release changes. Editor compatibility policy is a separate PR.
