### PR TITLE
CI: update the CodeQL action to 4.38.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,10 +26,10 @@ jobs:
             build-mode: none
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      - uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      - uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Bumps `github/codeql-action/init` and `github/codeql-action/analyze` together from 4.37.9 to 4.38.0.

Dependabot opened these as two pull requests, #99 for init and #101 for analyze. Each one leaves the workflow on two different versions of the action, and the analyze step then fails with "Loaded a configuration file for version '4.38.0', but running version '4.37.9'" (and the reverse on the other pull request), so neither can pass on its own. This carries both steps to the same pinned commit, which is the one Dependabot proposed in each.

Closes #99. Closes #101.